### PR TITLE
Buffer access pattern

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -162,10 +162,10 @@ impl<T: Clone> Copy for CloneFromBuffer<T> {}
 /// This key can unlock access to the contents of a buffer by passing it into
 /// [`BufferAccess`] or [`BufferAccessMut`].
 ///
-/// To obtain a `BufferKey`, use [`Chain::with_access`][1], or [`select`][2].
+/// To obtain a `BufferKey`, use [`Chain::with_access`][1], or [`listen`][2].
 ///
 /// [1]: crate::Chain::with_access
-/// [2]: crate::Bufferable::select
+/// [2]: crate::Bufferable::listen
 pub struct BufferKey<T> {
     buffer: Entity,
     session: Entity,

--- a/src/buffer/buffer_access_lifecycle.rs
+++ b/src/buffer/buffer_access_lifecycle.rs
@@ -17,33 +17,57 @@
 
 use bevy::prelude::{Entity, World};
 
-use crate::{OperationRoster, ChannelItem};
-
 use crossbeam::channel::Sender as CbSender;
 
+use std::sync::Arc;
+
+use crate::{OperationRoster, ChannelItem, Disposal, emit_disposal};
+
+/// This is used as a field inside of [`crate::BufferKey`] which keeps track of
+/// when a key that was sent out into the world gets fully dropped from use. We
+/// could implement the [`Drop`] trait for [`crate::BufferKey`] itself, but then
+/// we would be needlessly doing a reachability check every time the key gets
+/// cloned.
+#[derive(Clone)]
 pub(crate) struct BufferAccessLifecycle {
     scope: Entity,
+    accessor: Entity,
     session: Entity,
+    buffer: Entity,
     sender: CbSender<ChannelItem>,
+    /// This tracker is an additional layer of indirection that allows the
+    /// buffer accessor node that created the key to keep track of whether this
+    /// lifecycle is still active.
+    pub(crate) tracker: Arc<()>,
 }
 
 impl BufferAccessLifecycle {
     pub(crate) fn new(
         scope: Entity,
+        buffer: Entity,
         session: Entity,
+        accessor: Entity,
         sender: CbSender<ChannelItem>,
+        tracker: Arc<()>,
     ) -> Self {
-        Self { scope, session, sender }
+        Self { scope, accessor, session, buffer, sender, tracker }
+    }
+
+    pub(crate) fn is_in_use(&self) -> bool {
+        Arc::strong_count(&self.tracker) > 1
     }
 }
 
 impl Drop for BufferAccessLifecycle {
     fn drop(&mut self) {
         let scope = self.scope;
+        let accessor = self.accessor;
         let session = self.session;
+        let buffer = self.buffer;
         if let Err(err) = self.sender.send(
-            Box::new(move |_: &mut World, roster: &mut OperationRoster| {
-                roster.disposed(scope, session);
+            Box::new(move |world: &mut World, roster: &mut OperationRoster| {
+                let disposal = Disposal::buffer_key(accessor, buffer);
+                emit_disposal(accessor, session, disposal, world, roster);
             })
         ) {
             eprintln!(

--- a/src/buffer/buffer_access_lifecycle.rs
+++ b/src/buffer/buffer_access_lifecycle.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::prelude::{Entity, World};
+
+use crate::{OperationRoster, ChannelItem};
+
+use crossbeam::channel::Sender as CbSender;
+
+pub(crate) struct BufferAccessLifecycle {
+    scope: Entity,
+    session: Entity,
+    channel: CbSender<ChannelItem>,
+}
+
+impl Drop for BufferAccessLifecycle {
+    fn drop(&mut self) {
+        let scope = self.scope;
+        let session = self.session;
+        if let Err(err) = self.channel.send(
+            Box::new(move |_: &mut World, roster: &mut OperationRoster| {
+                roster.disposed(scope, session);
+            })
+        ) {
+            eprintln!(
+                "Failed to send disposal notice for dropped buffer key in \
+                scope [{:?}] for session [{:?}]: {}",
+                scope,
+                session,
+                err,
+            );
+        }
+    }
+}

--- a/src/buffer/buffer_access_lifecycle.rs
+++ b/src/buffer/buffer_access_lifecycle.rs
@@ -24,14 +24,24 @@ use crossbeam::channel::Sender as CbSender;
 pub(crate) struct BufferAccessLifecycle {
     scope: Entity,
     session: Entity,
-    channel: CbSender<ChannelItem>,
+    sender: CbSender<ChannelItem>,
+}
+
+impl BufferAccessLifecycle {
+    pub(crate) fn new(
+        scope: Entity,
+        session: Entity,
+        sender: CbSender<ChannelItem>,
+    ) -> Self {
+        Self { scope, session, sender }
+    }
 }
 
 impl Drop for BufferAccessLifecycle {
     fn drop(&mut self) {
         let scope = self.scope;
         let session = self.session;
-        if let Err(err) = self.channel.send(
+        if let Err(err) = self.sender.send(
             Box::new(move |_: &mut World, roster: &mut OperationRoster| {
                 roster.disposed(scope, session);
             })

--- a/src/buffer/buffer_key_builder.rs
+++ b/src/buffer/buffer_key_builder.rs
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::prelude::Entity;
+
+use std::sync::Arc;
+
+use crate::{ChannelSender, BufferKey, BufferAccessLifecycle};
+
+pub struct BufferKeyBuilder {
+    scope: Entity,
+    session: Entity,
+    accessor: Entity,
+    lifecycle: Option<(ChannelSender, Arc<()>)>,
+}
+
+impl BufferKeyBuilder {
+    pub(crate) fn build<T>(&self, buffer: Entity) -> BufferKey<T> {
+        BufferKey {
+            buffer: buffer,
+            session: self.session,
+            accessor: self.accessor,
+            lifecycle: self.lifecycle.as_ref().map(|(sender, tracker)|
+                Arc::new(BufferAccessLifecycle::new(
+                    self.scope, buffer, self.session, self.accessor,
+                    sender.clone(), tracker.clone(),
+                ))
+            ),
+            _ignore: Default::default(),
+        }
+    }
+
+    pub(crate) fn with_tracking(
+        scope: Entity,
+        session: Entity,
+        accessor: Entity,
+        sender: ChannelSender,
+        tracker: Arc<()>,
+    ) -> Self {
+        Self {
+            scope,
+            session,
+            accessor,
+            lifecycle: Some((sender, tracker)),
+        }
+    }
+
+    pub(crate) fn without_tracking(
+        scope: Entity,
+        session: Entity,
+        accessor: Entity,
+    ) -> Self {
+        Self {
+            scope,
+            session,
+            accessor,
+            lifecycle: None,
+        }
+    }
+}

--- a/src/buffer/buffer_storage.rs
+++ b/src/buffer/buffer_storage.rs
@@ -1,0 +1,255 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::prelude::{Entity, Component};
+
+use smallvec::{SmallVec, Drain};
+
+use std::collections::HashMap;
+
+use std::{
+    slice::{Iter, IterMut},
+    iter::Rev,
+    ops::RangeBounds,
+};
+
+use crate::{BufferSettings, RetentionPolicy};
+
+
+#[derive(Component)]
+pub(crate) struct BufferStorage<T> {
+    /// Settings that determine how this buffer will behave.
+    settings: BufferSettings,
+    /// Map from session ID to a queue of data that has arrived for it. This
+    /// is used by nodes that feed into joiner nodes to store input so that it's
+    /// readily available when needed.
+    ///
+    /// The main reason we use this as a reverse queue instead of a forward queue
+    /// is because SmallVec doesn't have a version of pop that we can use on the
+    /// front. We should reconsider whether this is really a sensible choice.
+    reverse_queues: HashMap<Entity, SmallVec<[T; 16]>>,
+}
+
+impl<T> BufferStorage<T> {
+    pub(crate) fn push(&mut self, session: Entity, value: T) -> Option<T> {
+        let reverse_queue = self.reverse_queues.entry(session).or_default();
+        let replaced = match self.settings.retention() {
+            RetentionPolicy::KeepFirst(n) => {
+                if reverse_queue.len() >= n {
+                    // We're at the limit for inputs in this queue so just send
+                    // this back
+                    return Some(value)
+                }
+
+                None
+            }
+            RetentionPolicy::KeepLast(n) => {
+                if n > 0 && reverse_queue.len() >= n {
+                    reverse_queue.pop()
+                } else if n == 0 {
+                    // This can never store any number of entries
+                    return Some(value);
+                } else {
+                    None
+                }
+            }
+            RetentionPolicy::KeepAll => {
+                None
+            }
+        };
+
+        reverse_queue.insert(0, value);
+        return replaced;
+    }
+
+    pub(crate) fn push_as_oldest(&mut self, session: Entity, value: T) -> Option<T> {
+        let reverse_queue = self.reverse_queues.entry(session).or_default();
+        let replaced = match self.settings.retention() {
+            RetentionPolicy::KeepFirst(n) => {
+                if n > 0 && reverse_queue.len() >= n {
+                    Some(reverse_queue.remove(0))
+                } else {
+                    None
+                }
+            }
+            RetentionPolicy::KeepLast(n) => {
+                if reverse_queue.len() >= n {
+                    return Some(value);
+                }
+
+                None
+            }
+            RetentionPolicy::KeepAll => {
+                None
+            }
+        };
+
+        reverse_queue.push(value);
+        return replaced;
+    }
+
+    pub(crate) fn pull(&mut self, session: Entity) -> Option<T> {
+        self.reverse_queues.entry(session).or_default().pop()
+    }
+
+    pub(crate) fn pull_newest(&mut self, session: Entity) -> Option<T> {
+        let reverse_queue = self.reverse_queues.entry(session).or_default();
+        if reverse_queue.is_empty() {
+            return None;
+        }
+
+        Some(reverse_queue.remove(0))
+    }
+
+    pub(crate) fn consume(&mut self, session: Entity) -> SmallVec<[T; 16]> {
+        let reverse_queue = self.reverse_queues.entry(session).or_default();
+        let mut result = SmallVec::new();
+        std::mem::swap(reverse_queue, &mut result);
+        result.reverse();
+        result
+    }
+
+    pub(crate) fn clear_session(&mut self, session: Entity) {
+        self.reverse_queues.remove(&session);
+    }
+
+    pub(crate) fn count(&self, session: Entity) -> usize {
+        self.reverse_queues.get(&session).map(|q| q.len()).unwrap_or(0)
+    }
+
+    pub(crate) fn iter<'b>(&'b self, session: Entity) -> IterBufferView<'b, T>
+    where
+        T: 'static + Send + Sync,
+    {
+        IterBufferView {
+            iter: self.reverse_queues.get(&session).map(|q| q.iter().rev())
+        }
+    }
+
+    pub(crate) fn iter_mut<'b>(&'b mut self, session: Entity) -> IterBufferMut<'b, T>
+    where
+        T: 'static + Send + Sync,
+    {
+        IterBufferMut {
+            iter: self.reverse_queues.get_mut(&session).map(|q| q.iter_mut().rev())
+        }
+    }
+
+    pub(crate) fn drain<'b, R>(&'b mut self, session: Entity, range: R) -> DrainBuffer<'b, T>
+    where
+        T: 'static + Send + Sync,
+        R: RangeBounds<usize>,
+    {
+        DrainBuffer {
+            drain: self.reverse_queues.get_mut(&session).map(|q| q.drain(range).rev())
+        }
+    }
+
+    pub(crate) fn clone_oldest(&self, session: Entity) -> Option<T>
+    where
+        T: Clone,
+    {
+        self.reverse_queues.get(&session).map(|q| q.last().cloned()).flatten()
+    }
+
+    pub(crate) fn clone_newest(&self, session: Entity) -> Option<T>
+    where
+        T: Clone,
+    {
+        self.reverse_queues.get(&session).map(|q| q.first().cloned()).flatten()
+    }
+
+    pub(crate) fn active_sessions(&self) -> SmallVec<[Entity; 16]> {
+        self.reverse_queues
+            .iter()
+            .map(|(e, _)| *e)
+            .collect()
+    }
+
+    pub(crate) fn new(settings: BufferSettings) -> Self {
+        Self {
+            settings,
+            reverse_queues: Default::default(),
+        }
+    }
+}
+
+pub struct IterBufferView<'b, T>
+where
+    T: 'static + Send + Sync,
+{
+    iter: Option<Rev<Iter<'b, T>>>,
+}
+
+impl<'b, T> Iterator for IterBufferView<'b, T>
+where
+    T: 'static + Send + Sync
+{
+    type Item = &'b T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(iter) = &mut self.iter {
+            iter.next()
+        } else {
+            None
+        }
+    }
+}
+
+pub struct IterBufferMut<'b, T>
+where
+    T: 'static + Send + Sync,
+{
+    iter: Option<Rev<IterMut<'b, T>>>,
+}
+
+impl<'b, T> Iterator for IterBufferMut<'b, T>
+where
+    T: 'static + Send + Sync,
+{
+    type Item = &'b mut T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(iter) = &mut self.iter {
+            iter.next()
+        } else {
+            None
+        }
+    }
+}
+
+pub struct DrainBuffer<'b, T>
+where
+    T: 'static + Send + Sync,
+{
+    drain: Option<Rev<Drain<'b, [T; 16]>>>,
+}
+
+impl<'b, T> Iterator for DrainBuffer<'b, T>
+where
+    T: 'static + Send + Sync,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(drain) = &mut self.drain {
+            drain.next()
+        } else {
+            None
+        }
+    }
+}

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -59,8 +59,13 @@ pub trait Bufferable {
         Output::new(scope, target).chain(builder)
     }
 
-    /// Create an operation that will output buffer keys each time any one of
-    /// the buffers is modified.
+    /// Create an operation that will output buffer access keys each time any
+    /// one of the buffers is modified. This can be used to create a node in a
+    /// workflow that wakes up every time one or more buffers change, and then
+    /// operates on those buffers.
+    ///
+    /// For an operation that simply joins the contents of two or more outputs
+    /// or buffers, use [`join`](Self::join) instead.
     fn listen<'w, 's, 'a, 'b>(
         self,
         builder: &'b mut Builder<'w, 's, 'a>,

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -22,6 +22,8 @@ use crate::{
     UnusedTarget, AddOperation, Chain,
 };
 
+pub type BufferKeys<B> = <<B as Bufferable>::BufferType as Buffered>::Key;
+
 pub trait Bufferable {
     type BufferType: Buffered;
 

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -20,7 +20,7 @@ use smallvec::SmallVec;
 
 use crate::{
     Buffer, CloneFromBuffer, Output, Builder, BufferSettings, Buffered, Join,
-    UnusedTarget, AddOperation, Chain, Listen,
+    UnusedTarget, AddOperation, Chain, Listen, Scope, ScopeSettings,
 };
 
 pub type BufferKeys<B> = <<B as Bufferable>::BufferType as Buffered>::Key;
@@ -90,6 +90,21 @@ pub trait Bufferable {
         ));
 
         Output::new(scope, target).chain(builder)
+    }
+
+    /// Alternative way to call [`Builder::on_cancel`]
+    fn on_cancel<'w, 's, 'a, Settings>(
+        self,
+        builder: &mut Builder<'w, 's, 'a>,
+        build: impl FnOnce(Scope<BufferKeys<Self>, (), ()>, &mut Builder) -> Settings,
+    )
+    where
+        Self: Sized,
+        Self::BufferType: 'static + Send + Sync,
+        BufferKeys<Self>: 'static + Send + Sync,
+        Settings: Into<ScopeSettings>,
+    {
+        builder.on_cancel(self, build)
     }
 }
 

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 pub type BufferKeys<B> = <<B as Bufferable>::BufferType as Buffered>::Key;
+pub type BufferItem<B> = <<B as Bufferable>::BufferType as Buffered>::Item;
 
 pub trait Bufferable {
     type BufferType: Buffered;
@@ -41,11 +42,11 @@ pub trait Bufferable {
     fn join<'w, 's, 'a, 'b>(
         self,
         builder: &'b mut Builder<'w, 's, 'a>,
-    ) -> Chain<'w, 's, 'a, 'b, <Self::BufferType as Buffered>::Item>
+    ) -> Chain<'w, 's, 'a, 'b, BufferItem<Self>>
     where
         Self: Sized,
         Self::BufferType: 'static + Send + Sync,
-        <Self::BufferType as Buffered>::Item: 'static + Send + Sync,
+        BufferItem<Self>: 'static + Send + Sync,
     {
         let scope = builder.scope();
         let buffers = self.as_buffer(builder);

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -20,8 +20,8 @@ use bevy::prelude::{Entity, World};
 use smallvec::SmallVec;
 
 use crate::{
-    Buffer, CloneFromBuffer, OperationError, OrBroken, InspectInput, ManageInput,
-    OperationResult, ForkTargetStorage,
+    Buffer, CloneFromBuffer, OperationError, OrBroken, InspectBuffer,
+    ManageBuffer, OperationResult, ForkTargetStorage,
 };
 
 pub trait Buffered: Clone {
@@ -99,7 +99,8 @@ impl<T: 'static + Send + Sync + Clone> Buffered for CloneFromBuffer<T> {
         world: &mut World,
     ) -> Result<Self::Item, OperationError> {
         world.get_entity(self.source).or_broken()?
-            .clone_from_buffer(session)
+            .try_clone_from_buffer(session)
+            .and_then(|r| r.or_broken())
     }
 
     fn listen(

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -60,6 +60,7 @@ pub trait Buffered: Clone {
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError>;
 
@@ -130,9 +131,10 @@ impl<T: 'static + Send + Sync> Buffered for Buffer<T> {
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError> {
-        Ok(BufferKey::new(scope, self.source, session, sender.clone()))
+        Ok(BufferKey::new(scope, self.source, session, accessor, sender.clone()))
     }
 
     fn ensure_active_session(
@@ -213,9 +215,10 @@ impl<T: 'static + Send + Sync + Clone> Buffered for CloneFromBuffer<T> {
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError> {
-        Ok(BufferKey::new(scope, self.source, session, sender.clone()))
+        Ok(BufferKey::new(scope, self.source, session, accessor, sender.clone()))
     }
 
     fn ensure_active_session(
@@ -297,10 +300,11 @@ where
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError> {
-        let t0 = self.0.create_key(scope, session, sender)?;
-        let t1 = self.1.create_key(scope, session, sender)?;
+        let t0 = self.0.create_key(scope, session, accessor, sender)?;
+        let t1 = self.1.create_key(scope, session, accessor, sender)?;
         Ok((t0, t1))
     }
 
@@ -391,11 +395,12 @@ where
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError> {
-        let t0 = self.0.create_key(scope, session, sender)?;
-        let t1 = self.1.create_key(scope, session, sender)?;
-        let t2 = self.2.create_key(scope, session, sender)?;
+        let t0 = self.0.create_key(scope, session, accessor, sender)?;
+        let t1 = self.1.create_key(scope, session, accessor, sender)?;
+        let t2 = self.2.create_key(scope, session, accessor, sender)?;
         Ok((t0, t1, t2))
     }
 
@@ -484,11 +489,12 @@ impl<T: Buffered, const N: usize> Buffered for [T; N] {
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError> {
         let mut keys = SmallVec::new();
         for buffer in self {
-            keys.push(buffer.create_key(scope, session, sender)?);
+            keys.push(buffer.create_key(scope, session, accessor, sender)?);
         }
         Ok(keys)
     }
@@ -581,11 +587,12 @@ impl<T: Buffered, const N: usize> Buffered for SmallVec<[T; N]> {
         &self,
         scope: Entity,
         session: Entity,
+        accessor: Entity,
         sender: &ChannelSender,
     ) -> Result<Self::Key, OperationError> {
         let mut keys = SmallVec::new();
         for buffer in self {
-            keys.push(buffer.create_key(scope, session, sender)?);
+            keys.push(buffer.create_key(scope, session, accessor, sender)?);
         }
         Ok(keys)
     }

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -20,8 +20,8 @@ use bevy::prelude::{Entity, World};
 use smallvec::SmallVec;
 
 use crate::{
-    Buffer, CloneFromBuffer, OperationError, OrBroken, InspectBuffer,
-    ManageBuffer, OperationResult, ForkTargetStorage,
+    Buffer, CloneFromBuffer, OperationError, OrBroken, InspectBuffer, ChannelSender,
+    ManageBuffer, OperationResult, ForkTargetStorage, BufferKey, BufferAccessors,
 };
 
 pub trait Buffered: Clone {
@@ -45,6 +45,22 @@ pub trait Buffered: Clone {
     ) -> OperationResult;
 
     fn as_input(&self) -> SmallVec<[Entity; 8]>;
+
+    type Key: Clone;
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult;
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError>;
+
+    fn is_key_in_use(key: &Self::Key) -> bool;
 }
 
 impl<T: 'static + Send + Sync> Buffered for Buffer<T> {
@@ -79,6 +95,35 @@ impl<T: 'static + Send + Sync> Buffered for Buffer<T> {
 
     fn as_input(&self) -> SmallVec<[Entity; 8]> {
         SmallVec::from_iter([self.source])
+    }
+
+    type Key = BufferKey<T>;
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult {
+        let mut accessors = world
+            .get_mut::<BufferAccessors>(self.source)
+            .or_broken()?;
+
+        accessors.0.push(accessor);
+        accessors.0.sort();
+        accessors.0.dedup();
+        Ok(())
+    }
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError> {
+        Ok(BufferKey::new(scope, self.source, session, sender.clone()))
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        key.is_in_use()
     }
 }
 
@@ -119,6 +164,35 @@ impl<T: 'static + Send + Sync + Clone> Buffered for CloneFromBuffer<T> {
 
     fn as_input(&self) -> SmallVec<[Entity; 8]> {
         SmallVec::from_iter([self.source])
+    }
+
+    type Key = BufferKey<T>;
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult {
+        let mut accessors = world
+            .get_mut::<BufferAccessors>(self.source)
+            .or_broken()?;
+
+        accessors.0.push(accessor);
+        accessors.0.sort();
+        accessors.0.dedup();
+        Ok(())
+    }
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError> {
+        Ok(BufferKey::new(scope, self.source, session, sender.clone()))
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        key.is_in_use()
     }
 }
 
@@ -164,6 +238,33 @@ where
         inputs.extend(self.0.as_input());
         inputs.extend(self.1.as_input());
         inputs
+    }
+
+    type Key = (T0::Key, T1::Key);
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult {
+        self.0.access(accessor, world)?;
+        self.1.access(accessor, world)?;
+        Ok(())
+    }
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError> {
+        let t0 = self.0.create_key(scope, session, sender)?;
+        let t1 = self.1.create_key(scope, session, sender)?;
+        Ok((t0, t1))
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        T0::is_key_in_use(&key.0)
+        || T1::is_key_in_use(&key.1)
     }
 }
 
@@ -215,6 +316,36 @@ where
         inputs.extend(self.2.as_input());
         inputs
     }
+
+    type Key = (T0::Key, T1::Key, T2::Key);
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult {
+        self.0.access(accessor, world)?;
+        self.1.access(accessor, world)?;
+        self.2.access(accessor, world)?;
+        Ok(())
+    }
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError> {
+        let t0 = self.0.create_key(scope, session, sender)?;
+        let t1 = self.1.create_key(scope, session, sender)?;
+        let t2 = self.2.create_key(scope, session, sender)?;
+        Ok((t0, t1, t2))
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        T0::is_key_in_use(&key.0)
+        || T1::is_key_in_use(&key.1)
+        || T2::is_key_in_use(&key.2)
+    }
 }
 
 impl<T: Buffered, const N: usize> Buffered for [T; N] {
@@ -261,6 +392,41 @@ impl<T: Buffered, const N: usize> Buffered for [T; N] {
     fn as_input(&self) -> SmallVec<[Entity; 8]> {
         self.iter().flat_map(|buffer| buffer.as_input()).collect()
     }
+
+    type Key = SmallVec<[T::Key; N]>;
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult {
+        for buffer in self {
+            buffer.access(accessor, world)?;
+        }
+        Ok(())
+    }
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError> {
+        let mut keys = SmallVec::new();
+        for buffer in self {
+            keys.push(buffer.create_key(scope, session, sender)?);
+        }
+        Ok(keys)
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        for k in key {
+            if T::is_key_in_use(k) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }
 
 impl<T: Buffered, const N: usize> Buffered for SmallVec<[T; N]> {
@@ -304,5 +470,40 @@ impl<T: Buffered, const N: usize> Buffered for SmallVec<[T; N]> {
 
     fn as_input(&self) -> SmallVec<[Entity; 8]> {
         self.iter().flat_map(|buffer| buffer.as_input()).collect()
+    }
+
+    type Key = SmallVec<[T::Key; N]>;
+    fn access(
+        &self,
+        accessor: Entity,
+        world: &mut World,
+    ) -> OperationResult {
+        for buffer in self {
+            buffer.access(accessor, world)?;
+        }
+        Ok(())
+    }
+
+    fn create_key(
+        &self,
+        scope: Entity,
+        session: Entity,
+        sender: &ChannelSender,
+    ) -> Result<Self::Key, OperationError> {
+        let mut keys = SmallVec::new();
+        for buffer in self {
+            keys.push(buffer.create_key(scope, session, sender)?);
+        }
+        Ok(keys)
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        for k in key {
+            if T::is_key_in_use(k) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/buffer/manage_buffer.rs
+++ b/src/buffer/manage_buffer.rs
@@ -54,7 +54,7 @@ impl<'w> InspectBuffer for EntityRef<'w> {
         session: Entity,
     ) -> Result<Option<T>, OperationError> {
         let buffer = self.get::<BufferStorage<T>>().or_broken()?;
-        Ok(buffer.clone_oldest(session))
+        Ok(buffer.oldest(session).cloned())
     }
 
     fn buffered_sessions<T: 'static + Send + Sync>(

--- a/src/buffer/manage_buffer.rs
+++ b/src/buffer/manage_buffer.rs
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::{
+    prelude::Entity,
+    ecs::world::{EntityMut, EntityRef},
+};
+
+use smallvec::SmallVec;
+
+use crate::{OperationError, OrBroken, OperationResult, BufferStorage};
+
+pub trait InspectBuffer {
+    fn buffered_count<T: 'static + Send + Sync>(
+        &self,
+        session: Entity,
+    ) -> Result<usize, OperationError>;
+
+    fn try_clone_from_buffer<T: 'static + Send + Sync + Clone>(
+        &self,
+        session: Entity,
+    ) -> Result<Option<T>, OperationError>;
+
+    fn buffered_sessions<T: 'static + Send + Sync>(
+        &self,
+    ) -> Result<SmallVec<[Entity; 16]>, OperationError>;
+}
+
+impl<'w> InspectBuffer for EntityRef<'w> {
+    fn buffered_count<T: 'static + Send + Sync>(
+        &self,
+        session: Entity,
+    ) -> Result<usize, OperationError> {
+        let buffer = self.get::<BufferStorage<T>>().or_broken()?;
+        Ok(buffer.count(session))
+    }
+
+    fn try_clone_from_buffer<T: 'static + Send + Sync + Clone>(
+        &self,
+        session: Entity,
+    ) -> Result<Option<T>, OperationError> {
+        let buffer = self.get::<BufferStorage<T>>().or_broken()?;
+        Ok(buffer.clone_oldest(session))
+    }
+
+    fn buffered_sessions<T: 'static + Send + Sync>(
+        &self,
+    ) -> Result<SmallVec<[Entity; 16]>, OperationError> {
+        let sessions = self.get::<BufferStorage<T>>().or_broken()?
+            .active_sessions();
+
+        Ok(sessions)
+    }
+}
+
+pub trait ManageBuffer {
+    fn pull_from_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> Result<T, OperationError> {
+        self.try_pull_from_buffer(session).and_then(|r| r.or_broken())
+    }
+
+    fn try_pull_from_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> Result<Option<T>, OperationError>;
+
+    fn consume_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> Result<SmallVec<[T; 16]>, OperationError>;
+
+    fn clear_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> OperationResult;
+}
+
+impl<'w> ManageBuffer for EntityMut<'w> {
+    fn try_pull_from_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> Result<Option<T>, OperationError> {
+        let mut buffer = self.get_mut::<BufferStorage<T>>().or_broken()?;
+        Ok(buffer.pull(session))
+    }
+
+    fn consume_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> Result<SmallVec<[T; 16]>, OperationError> {
+        let mut buffer = self.get_mut::<BufferStorage<T>>().or_broken()?;
+        Ok(buffer.consume(session))
+    }
+
+    fn clear_buffer<T: 'static + Send + Sync>(
+        &mut self,
+        session: Entity,
+    ) -> OperationResult {
+        self.get_mut::<BufferStorage<T>>().or_broken()?
+            .clear_session(session);
+        Ok(())
+    }
+
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -327,6 +327,27 @@ mod tests {
     use crate::{*, testing::*};
 
     #[test]
+    fn test_disconnected_workflow() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|_: Scope<(), ()>, _| {
+            // Do nothing. Totally empty workflow.
+        });
+
+        let mut promise = context.command(|commands|
+            commands
+            .request((), workflow)
+            .take_response()
+        );
+
+        context.run_with_conditions(&mut promise, 1);
+        assert!(promise.take().cancellation().is_some_and(
+            |c| matches!(*c.cause, CancellationCause::Unreachable(_))
+        ));
+        assert!(context.no_unhandled_errors());
+    }
+
+    #[test]
     fn test_fork_clone() {
         let mut context = TestingContext::minimal_plugins();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,7 +22,7 @@ use std::future::Future;
 use crate::{
     Provider, UnusedTarget, StreamPack, Node, InputSlot, Output, StreamTargetMap,
     Buffer, BufferSettings, AddOperation, OperateBuffer, Scope, OperateScope,
-    ScopeSettings, BeginCancel, ScopeEndpoints, IntoBlockingMap, IntoAsyncMap,
+    ScopeSettings, BeginCleanupWorkflow, ScopeEndpoints, IntoBlockingMap, IntoAsyncMap,
     AsMap, ProvideOnce, ScopeSettingsStorage, Bufferable, BufferKeys, BufferItem,
     Chain,
 };
@@ -219,27 +219,105 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         buffers.listen(self)
     }
 
-    /// It is possible for a scope to be cancelled before it terminates. Even a
-    /// scope which is marked as uninterruptible will still experience a
+    /// This method allows you to define a cleanup workflow that branches off of
+    /// this scope that will activate during the scope's cleanup phase. The
+    /// input to the cleanup workflow will be a key to access to one or more
+    /// buffers from the parent scope.
+    ///
+    /// Each different cleanup workflow that you define using this function will
+    /// be given its own unique session ID when it gets run. You can define any
+    /// number of cleanup workflows.
+    ///
+    /// The parent scope will only finish its cleanup phase after all cleanup
+    /// workflows for the scope have finished, either by terminating or by being
+    /// cancelled themselves.
+    ///
+    /// Cleanup workflows that you define with this function will always be run
+    /// no matter how the scope finished. If you want a cleanup workflow that
+    /// only runs when the scope is cancelled, use [`Self::on_cancel`]. If you
+    /// want a cleanup workflow that only runs when the scope terminates
+    /// successfully, then use [`Self::on_terminate`]. For easier runtime
+    /// flexibility you can also use [`Self::on_cleanup_if`].
+    pub fn on_cleanup<B, Settings>(
+        &mut self,
+        from_buffers: B,
+        build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
+    )
+    where
+        B: Bufferable,
+        B::BufferType: 'static + Send + Sync,
+        BufferKeys<B>: 'static + Send + Sync,
+        Settings: Into<ScopeSettings>,
+    {
+        self.on_cleanup_if(
+            CleanupWorkflowConditions::always_if(true, true),
+            from_buffers,
+            build,
+        )
+    }
+
+    /// Define a cleanup workflow that only gets run if the scope was cancelled.
+    ///
+    /// When the scope gets dropped before it terminates (i.e. the parent scope
+    /// finished while this scope was active, and this scope is interruptible)
+    /// that also counts as cancelled.
+    ///
+    /// A scope which is set to be uninterruptible will still experience a
     /// cancellation if its terminal node becomes unreachable.
     ///
-    /// This method allows you to define a workflow that branches off of this
-    /// scope that will active if and only if the scope gets cancelled. The
-    /// workflow will be activated once for each item in the buffer, and each
-    /// activation will have its own session.
-    ///
-    /// If you only want this cancellation workflow to activate once per
-    /// cancelled session, then you should use a buffer that has a limit of one
-    /// item.
-    ///
-    /// The cancelled scope will only finish its cleanup after all cancellation
-    /// workflows for the cancelled scope have finished, either by terminating
-    /// or by being cancelled themselves.
-    //
-    // TODO(@mxgrey): Consider offering a setting to choose between whether each
-    // buffer item gets its own session or whether they share a session.
+    /// If you want a cleanup workflow that only runs when the scope terminates
+    /// successfully then use [`Self::on_terminate`]. If you want a cleanup
+    /// workflow that always runs when the scope is finished, then use
+    /// [`Self::on_cleanup`].
     pub fn on_cancel<B, Settings>(
         &mut self,
+        from_buffers: B,
+        build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
+    )
+    where
+        B: Bufferable,
+        B::BufferType: 'static + Send + Sync,
+        BufferKeys<B>: 'static + Send + Sync,
+        Settings: Into<ScopeSettings>,
+    {
+        self.on_cleanup_if(
+            CleanupWorkflowConditions::always_if(false, true),
+            from_buffers,
+            build,
+        )
+    }
+
+    /// Define a cleanup workflow that only gets run if the scope was successfully
+    /// terminated. That means an input reached its terminal node, and now the
+    /// scope is cleaning up.
+    ///
+    /// If you want a cleanup workflow that only runs when the scope is cancelled
+    /// then use [`Self::on_cancel`]. If you want a cleanup workflow that always
+    /// runs when then scope is finished, then use [`Self::on_cleanup`].
+    pub fn on_terminate<B, Settings>(
+        &mut self,
+        from_buffers: B,
+        build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
+    )
+    where
+        B: Bufferable,
+        B::BufferType: 'static + Send + Sync,
+        BufferKeys<B>: 'static + Send + Sync,
+        Settings: Into<ScopeSettings>,
+    {
+        self.on_cleanup_if(
+            CleanupWorkflowConditions::always_if(true, false),
+            from_buffers,
+            build,
+        )
+    }
+
+    /// Define a sub-workflow that will be run when this workflow is being cleaned
+    /// up if the conditions are met. A workflow enters the cleanup stage when
+    /// its terminal node is reached or if it gets cancelled.
+    pub fn on_cleanup_if<B, Settings>(
+        &mut self,
+        conditions: CleanupWorkflowConditions,
         from_buffers: B,
         build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
     )
@@ -261,7 +339,10 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         self.commands.add(AddOperation::new(
             None,
             begin_cancel,
-            BeginCancel::<B::BufferType>::new(self.scope, buffers, cancelling_scope_id),
+            BeginCleanupWorkflow::<B::BufferType>::new(
+                self.scope, buffers, cancelling_scope_id,
+                conditions.run_on_terminate, conditions.run_on_cancel,
+            ),
         ));
     }
 
@@ -322,6 +403,23 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
             output: Output::new(self.scope, exit_scope),
             streams: stream_out,
         }
+    }
+}
+
+/// This struct is used to describe when a cleanup workflow should run. Currently
+/// this is only two simple booleans, but in the future it could potentially
+/// contain systems that make decisions at runtime, so for now we encapsulate
+/// the idea of cleanup conditions in this struct so we enhance the capabilities
+/// later without breaking API.
+#[derive(Clone)]
+pub struct CleanupWorkflowConditions {
+    run_on_terminate: bool,
+    run_on_cancel: bool,
+}
+
+impl CleanupWorkflowConditions {
+    pub fn always_if(run_on_terminate: bool, run_on_cancel: bool) -> Self {
+        CleanupWorkflowConditions { run_on_terminate, run_on_cancel }
     }
 }
 
@@ -528,12 +626,11 @@ mod tests {
     use crossbeam::channel::unbounded;
 
     #[test]
-    fn test_on_cancel() {
-        let (sender, receiver) = unbounded();
-
+    fn test_on_cleanup() {
         let mut context = TestingContext::minimal_plugins();
-        let workflow = context.spawn_io_workflow(|scope, builder| {
 
+        let (sender, receiver) = unbounded();
+        let workflow = context.spawn_io_workflow(|scope, builder| {
             let input = scope.input.fork_clone(builder);
 
             let buffer = builder.create_buffer(BufferSettings::default());
@@ -555,7 +652,7 @@ mod tests {
                     .consume_buffer::<8>()
                     .map_block(move |values| {
                         for value in values {
-                            sender.send(value).ok();
+                            sender.send(value).unwrap();
                         }
                     })
                     .connect(scope.terminate);
@@ -571,6 +668,95 @@ mod tests {
         let channel_output = receiver.try_recv().unwrap();
         assert_eq!(channel_output, 5);
         assert!(receiver.try_recv().is_err());
+        assert!(context.no_unhandled_errors());
+        assert!(context.confirm_buffers_empty().is_ok());
+
+        let (cancel_sender, cancel_receiver) = unbounded();
+        let (terminate_sender, terminate_receiver) = unbounded();
+        let (cleanup_sender, cleanup_receiver) = unbounded();
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let input = scope.input.fork_clone(builder);
+
+            let cancel_buffer = builder.create_buffer(BufferSettings::default());
+            let input_to_cancel = input.clone_output(builder);
+            builder.connect(input_to_cancel, cancel_buffer.input_slot());
+
+            let terminate_buffer = builder.create_buffer(BufferSettings::default());
+            let input_to_terminate = input.clone_output(builder);
+            builder.connect(input_to_terminate, terminate_buffer.input_slot());
+
+            let cleanup_buffer = builder.create_buffer(BufferSettings::default());
+            let input_to_cleanup = input.clone_output(builder);
+            builder.connect(input_to_cleanup, cleanup_buffer.input_slot());
+
+            let filter_node = builder.create_map_block(
+                |value: u64| if value >= 5 { Some(value) } else { None }
+            );
+            let input_to_filter_node = input.clone_output(builder);
+            builder.connect(input_to_filter_node, filter_node.input);
+            filter_node.output.chain(builder)
+                .cancel_on_none()
+                .connect(scope.terminate);
+
+            builder.on_cancel(cancel_buffer, |scope, builder| {
+                scope.input.chain(builder)
+                    .consume_buffer::<8>()
+                    .map_block(move |values| {
+                        for value in values {
+                            cancel_sender.send(value).unwrap();
+                        }
+                    })
+                    .connect(scope.terminate);
+            });
+
+            builder.on_terminate(terminate_buffer, |scope, builder| {
+                scope.input.chain(builder)
+                    .consume_buffer::<8>()
+                    .map_block(move |values| {
+                        for value in values {
+                            terminate_sender.send(value).unwrap();
+                        }
+                    })
+                    .connect(scope.terminate);
+            });
+
+            builder.on_cleanup(cleanup_buffer, |scope, builder| {
+                scope.input.chain(builder)
+                    .consume_buffer::<8>()
+                    .map_block(move |values| {
+                        for value in values {
+                            cleanup_sender.send(value).unwrap();
+                        }
+                    })
+                    .connect(scope.terminate);
+            });
+        });
+
+        let mut promise = context.command(|commands| {
+            commands.request(3, workflow).take_response()
+        });
+
+        context.run_with_conditions(&mut promise, 10);
+        assert!(promise.peek().is_cancelled());
+        assert_eq!(cancel_receiver.try_recv().unwrap(), 3);
+        assert!(cancel_receiver.try_recv().is_err());
+        assert_eq!(cleanup_receiver.try_recv().unwrap(), 3);
+        assert!(cleanup_receiver.try_recv().is_err());
+        assert!(terminate_receiver.try_recv().is_err());
+        assert!(context.no_unhandled_errors());
+        assert!(context.confirm_buffers_empty().is_ok());
+
+        let mut promise = context.command(|commands| {
+            commands.request(6, workflow).take_response()
+        });
+
+        context.run_with_conditions(&mut promise, 10);
+        assert!(promise.take().available().is_some_and(|v| v == 6));
+        assert_eq!(terminate_receiver.try_recv().unwrap(), 6);
+        assert!(terminate_receiver.try_recv().is_err());
+        assert_eq!(cleanup_receiver.try_recv().unwrap(), 6);
+        assert!(cleanup_receiver.try_recv().is_err());
+        assert!(cancel_receiver.try_recv().is_err());
         assert!(context.no_unhandled_errors());
         assert!(context.confirm_buffers_empty().is_ok());
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,7 +23,8 @@ use crate::{
     Provider, UnusedTarget, StreamPack, Node, InputSlot, Output, StreamTargetMap,
     Buffer, BufferSettings, AddOperation, OperateBuffer, Scope, OperateScope,
     ScopeSettings, BeginCancel, ScopeEndpoints, IntoBlockingMap, IntoAsyncMap,
-    AsMap, ProvideOnce, ScopeSettingsStorage,
+    AsMap, ProvideOnce, ScopeSettingsStorage, Bufferable, BufferKeys, BufferItem,
+    Chain,
 };
 
 pub(crate) mod connect;
@@ -192,6 +193,30 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         Settings: Into<ScopeSettings>,
     {
         self.create_scope::<Request, Response, (), Settings>(build)
+    }
+
+    /// Alternative way of calling [`Bufferable::join`]
+    pub fn join<'b, B: Bufferable>(
+        &'b mut self,
+        buffers: B,
+    ) -> Chain<'w, 's, 'a, 'b, BufferItem<B>>
+    where
+        B::BufferType: 'static + Send + Sync,
+        BufferItem<B>: 'static + Send + Sync,
+    {
+        buffers.join(self)
+    }
+
+    /// Alternative way of calling [`Bufferable::listen`].
+    pub fn listen<'b, B: Bufferable>(
+        &'b mut self,
+        buffers: B,
+    ) -> Chain<'w, 's, 'a, 'b, BufferKeys<B>>
+    where
+        B::BufferType: 'static + Send + Sync,
+        BufferKeys<B>: 'static + Send + Sync,
+    {
+        buffers.listen(self)
     }
 
     /// It is possible for a scope to be cancelled before it terminates. Even a

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -198,6 +198,7 @@ where
 
         if !self.initialized {
             self.system.initialize(&mut input.world);
+            self.initialized = true;
         }
 
         let streams = Streams::make_buffer(input.source, input.world);

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -94,7 +94,7 @@ pub enum CancellationCause {
     /// `bevy_impulse` itself, and you encouraged to open an issue with a minimal
     /// reproducible example.
     ///
-    /// The entity provided in [`BrokenLink`] is the link where the breakage was
+    /// The entity provided in [`Broken`] is the link where the breakage was
     /// detected.
     Broken(Broken),
 }
@@ -123,8 +123,7 @@ impl From<Broken> for CancellationCause {
     }
 }
 
-/// Passed into the [`OperationRoster`](crate::OperationRoster) to pass a cancel
-/// signal into the target.
+/// Passed into the [`OperationRoster`] to pass a cancel  signal into the target.
 #[derive(Debug, Clone)]
 pub struct Cancel {
     /// The entity that triggered the cancellation

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -147,8 +147,8 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// output of the map will be the Response of the returned Chain.
     ///
     /// This takes in a regular blocking function rather than an async function,
-    /// so while the function is executing, it will block all systems from
-    /// running, similar to how [`Commands`] are flushed.
+    /// so while the function is executing, it will block all systems and all
+    /// other workflows from running.
     #[must_use]
     pub fn map_block<U>(
         self,
@@ -426,6 +426,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     ///
     /// As the name suggests, a no-op will not actually do anything, but it adds
     /// a new link (entity) into the chain.
+    ///
     /// [1]: `<https://en.wikipedia.org/wiki/NOP_(code)>`
     #[must_use]
     pub fn noop(self) -> Chain<'w, 's, 'a, 'b, T> {
@@ -464,15 +465,10 @@ where
     E: 'static + Send + Sync,
 {
     /// Build a chain that activates if the response is an [`Err`]. If the
-    /// response is [`Ok`] then the branch built by this function will be disposed,
-    /// which means it gets dropped without triggering any cancellation behavior.
+    /// response is [`Ok`] then this branch will not be activated.
     ///
     /// This function returns a chain that will be activated if the result was
     /// [`Ok`] so you can continue building your response to the [`Ok`] case.
-    ///
-    /// You should make sure to [`detach`](Chain::detach) the chain inside your
-    /// builder or else it will be disposed during the first flush, even if an
-    /// [`Err`] value arrives.
     #[must_use]
     pub fn branch_for_err(
         self,
@@ -625,15 +621,10 @@ where
     T: 'static + Send + Sync,
 {
     /// Build a chain that activates if the response is [`None`]. If the response
-    /// is [`Some`] then the branch built by this function will be disposed,
-    /// which means it gets dropped without triggering any cancellation behavior.
+    /// is [`Some`] then the branch built by this function will not be activated.
     ///
     /// This function returns a chain that will be activated if the result was
     /// [`Some`] so you can continue building your response to the [`Some`] case.
-    ///
-    /// You should make sure to [`detach`](Chain::detach) the chain inside this
-    /// builder or else it will be disposed during the first flush, even if a
-    /// [`None`] value arrives.
     #[must_use]
     pub fn branch_for_none(
         self,

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -273,8 +273,14 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     }
 
     /// Combine the output with access to some buffers. The input must be one or
-    /// more buffers (for multiple buffers, combine them into a tuple or an
-    /// [`Iterator`]).
+    /// more buffers. For multiple buffers, combine them into a tuple or an
+    /// [`Iterator`]. Tuples of buffers can be nested inside each other.
+    ///
+    /// Other [outputs](Output) can also be passed in as buffers. Those outputs
+    /// will be transformed into a buffer with default buffer settings.
+    ///
+    /// To obtain a set of buffer keys each time a buffer is modified, use
+    /// [`listen`](crate::Bufferable::listen).
     pub fn with_access<B>(
         self,
         buffers: B,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -102,11 +102,13 @@ impl InnerChannel {
 }
 
 pub(crate) type ChannelItem = Box<dyn FnOnce(&mut World, &mut OperationRoster) + Send>;
+pub(crate) type ChannelSender = CbSender<ChannelItem>;
+pub(crate) type ChannelReceiver = CbReceiver<ChannelItem>;
 
 #[derive(Resource)]
 pub(crate) struct ChannelQueue {
-    pub(crate) sender: CbSender<ChannelItem>,
-    pub(crate) receiver: CbReceiver<ChannelItem>,
+    pub(crate) sender: ChannelSender,
+    pub(crate) receiver: ChannelReceiver,
 }
 
 impl ChannelQueue {

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -59,6 +59,13 @@ impl Disposal {
         DisposedBranch { branched_at_node, disposed_for_target, reason }.into()
     }
 
+    pub fn buffer_key(
+        accessor_node: Entity,
+        key_for_buffer: Entity,
+    ) -> Disposal {
+        DisposedBufferKey { accessor_node, key_for_buffer }.into()
+    }
+
     pub fn supplanted(
         supplanted_at_node: Entity,
         supplanted_by_node: Entity,
@@ -84,6 +91,9 @@ pub enum DisposalCause {
 
     /// A node disposed of one of its output branches.
     Branching(DisposedBranch),
+
+    /// A buffer key was disposed, so a buffer will no longer be able to update.
+    BufferKey(DisposedBufferKey),
 
     /// A [`Service`](crate::Service) provider needed by the chain was despawned
     /// or had a critical component removed. The entity provided in the variant
@@ -168,6 +178,19 @@ pub struct DisposedBranch {
 impl From<DisposedBranch> for DisposalCause {
     fn from(value: DisposedBranch) -> Self {
         Self::Branching(value)
+    }
+}
+
+/// A variant of [`DisposalCause`]
+#[derive(Debug)]
+pub struct DisposedBufferKey {
+    pub accessor_node: Entity,
+    pub key_for_buffer: Entity,
+}
+
+impl From<DisposedBufferKey> for DisposalCause {
+    fn from(value: DisposedBufferKey) -> Self {
+        Self::BufferKey(value)
     }
 }
 

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -17,10 +17,7 @@
 
 use bevy::{
     prelude::{Entity, Component, World},
-    ecs::{
-        system::Command,
-        world::{EntityMut, EntityRef},
-    }
+    ecs::world::{EntityMut, EntityRef},
 };
 
 use backtrace::Backtrace;
@@ -31,7 +28,7 @@ use std::collections::HashMap;
 
 use crate::{
     OperationRoster, operation::ScopeStorage, Cancellation, UnhandledErrors,
-    DisposalFailure, ImpulseMarker, DeferredRoster,
+    DisposalFailure, ImpulseMarker,
 };
 
 #[derive(Debug, Clone)]
@@ -339,22 +336,4 @@ pub fn emit_disposal(
 struct DisposalStorage {
     /// A map from a session to all the disposals that occurred for the session
     disposals: HashMap<Entity, Vec<Disposal>>,
-}
-
-pub(crate) struct DisposalCommand {
-    scope: Entity,
-    session: Entity,
-}
-
-impl DisposalCommand {
-    pub(crate) fn new(scope: Entity, session: Entity) -> Self {
-        Self { scope, session }
-    }
-}
-
-impl Command for DisposalCommand {
-    fn apply(self, world: &mut World) {
-        world.get_resource_or_insert_with(|| DeferredRoster::default()).0
-            .disposed(self.scope, self.session);
-    }
 }

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -49,7 +49,7 @@ pub struct FlushParameters {
     ///
     /// Use this limit to prevent the flush from blocking for too long in those
     /// scenarios. If the flush loops beyond this limit, anything remaining in
-    /// the roster will be moved into the [`DeferredRoster`] to be processed
+    /// the roster will be moved into a deferred roster which will be processed
     /// during the next flush.
     ///
     /// A value of `None` means the flush can loop indefinitely (this is the default).

--- a/src/impulse.rs
+++ b/src/impulse.rs
@@ -53,7 +53,7 @@ pub(crate) use store::*;
 mod taken;
 pub(crate) use taken::*;
 
-/// Impulses can be chained as a simple sequence of [providers](Provider).
+/// Impulses can be chained as a simple sequence of [providers](crate::Provider).
 pub struct Impulse<'w, 's, 'a, Response, Streams> {
     pub(crate) source: Entity,
     pub(crate) target: Entity,
@@ -272,7 +272,7 @@ where
     /// [`Self::detach`] before calling this.
     ///
     /// If the response is not a bundle then you can store it in an entity using
-    /// [`Self::store`] or [`Self::append`]. Alternatively you can transform it
+    /// [`Self::store`] or [`Self::push`]. Alternatively you can transform it
     /// into a bundle using [`Self::map_block`] or [`Self::map_async`].
     pub fn insert(self, target: Entity) {
         self.commands.add(AddImpulse::new(

--- a/src/input.rs
+++ b/src/input.rs
@@ -219,7 +219,7 @@ impl<'w> ManageInput for EntityMut<'w> {
                 // since then.
                 let mut buffer = self.get_mut::<BufferStorage<T>>().unwrap();
                 for data in reverse_remaining.into_iter().rev() {
-                    buffer.push(session, data);
+                    buffer.force_push(session, data);
                 }
             }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -242,7 +242,6 @@ impl<'a> InspectInput for EntityMut<'a> {
         let inputs = self.get::<InputStorage<T>>().or_broken()?;
         Ok(inputs.contains_session(session))
     }
-
 }
 
 impl<'a> InspectInput for EntityRef<'a> {

--- a/src/input.rs
+++ b/src/input.rs
@@ -32,8 +32,8 @@ use crate::{
     Cancel, Cancellation, CancellationCause, Broken, UnusedTarget,
 };
 
-/// Typical container for input data accompanied by its session information.
-/// This defines the elements of [`InputStorage`].
+/// This contains data that has been provided as input into an operation, along
+/// with an indication of what session the data belongs to.
 pub struct Input<T> {
     pub session: Entity,
     pub data: T,
@@ -91,9 +91,9 @@ pub trait ManageInput {
     ) -> Result<(), OperationError>;
 
     /// Same as [`Self::give_input`], but the wakeup for this node will be
-    /// deferred until after the [`ChannelQueue`](crate::ChannelQueue) is flushed.
-    /// This is used for async output to ensure that all async operations are
-    /// finished being processed before the final output gets processed.
+    /// deferred until after the async updates are flushed. This is used for
+    /// async task output to ensure that all async operations, such as streams,
+    /// are finished being processed before the final output gets processed.
     fn defer_input<T: 'static + Send + Sync>(
         &mut self,
         session: Entity,

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -58,6 +58,9 @@ pub(crate) use noop::*;
 mod operate_buffer;
 pub use operate_buffer::*;
 
+mod operate_buffer_access;
+pub use operate_buffer_access::*;
+
 mod operate_callback;
 pub(crate) use operate_callback::*;
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -52,6 +52,9 @@ pub(crate) use fork_unzip::*;
 mod join;
 pub(crate) use join::*;
 
+mod listen;
+pub(crate) use listen::*;
+
 mod noop;
 pub(crate) use noop::*;
 

--- a/src/operation/fork_clone.rs
+++ b/src/operation/fork_clone.rs
@@ -62,7 +62,7 @@ impl<T: 'static + Send + Sync + Clone> Operation for ForkClone<T> {
     ) -> OperationResult {
         let mut source_mut = world.get_entity_mut(source).or_broken()?;
         let Input { session, data: input } = source_mut.take_input::<T>()?;
-        let ForkTargetStorage(targets) = source_mut.take().or_broken()?;
+        let targets = source_mut.get::<ForkTargetStorage>().or_broken()?.0.clone();
 
         let mut send_value = |value: T, target: Entity| -> Result<(), OperationError> {
             world

--- a/src/operation/join.rs
+++ b/src/operation/join.rs
@@ -49,7 +49,7 @@ where
         world.get_entity_mut(self.target).or_broken()?
             .insert(SingleInputStorage::new(source));
 
-        self.buffers.listen(source, world)?;
+        self.buffers.add_listener(source, world)?;
 
         world.entity_mut(source).insert((
             FunnelInputStorage::from(self.buffers.as_input()),

--- a/src/operation/operate_buffer.rs
+++ b/src/operation/operate_buffer.rs
@@ -33,7 +33,7 @@ use crate::{
     OperationCleanup, OperationReachability, ReachabilityResult, OrBroken,
     ManageInput, ForkTargetStorage, SingleInputStorage, BufferSettings,
     UnhandledErrors, MiscellaneousFailure, InputBundle, OperationError,
-    Input, ManageBuffer, InspectBuffer, DeferredRoster, Broken,
+    Input, ManageBuffer, InspectBuffer, DeferredRoster, Broken, BufferAccessors,
 };
 
 #[derive(Bundle)]
@@ -60,6 +60,7 @@ where
             SingleInputStorage::empty(),
             InputBundle::<T>::new(),
             BufferBundle::new::<T>(),
+            BufferAccessors::default(),
         ));
 
         Ok(())

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -138,7 +138,7 @@ where
         Entry::Vacant(vacant) => {
             made_key = true;
             vacant.insert(
-                s.buffers.create_key(scope, session, &sender)?
+                s.buffers.create_key(scope, session, source, &sender)?
             ).clone()
         }
     };

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy::prelude::{Entity, Component, World};
+
+use std::collections::{
+    HashMap, hash_map::Entry,
+};
+
+use smallvec::SmallVec;
+
+use crate::{
+    Operation, OperationRequest, OperationReachability, OperationResult,
+    Buffered, OperationSetup, InputBundle, SingleTargetStorage, OrBroken,
+    SingleInputStorage, Input, ManageInput, ChannelQueue, ScopeStorage,
+    OperationCleanup, ReachabilityResult,
+};
+
+pub(crate) struct OperateBufferAccess<T, B>
+where
+    T: 'static + Send + Sync,
+    B: Buffered,
+{
+    buffers: B,
+    target: Entity,
+    _ignore: std::marker::PhantomData<(T, B)>,
+}
+
+impl<T, B> OperateBufferAccess<T, B>
+where
+    T: 'static + Send + Sync,
+    B: Buffered,
+{
+    pub(crate) fn new(buffers: B, target: Entity) -> Self {
+        Self { buffers, target, _ignore: Default::default() }
+    }
+}
+
+#[derive(Component)]
+pub struct BufferKeyUsage(fn(Entity, Entity, &World) -> ReachabilityResult);
+
+#[derive(Component)]
+struct BufferAccessStorage<B: Buffered> {
+    buffers: B,
+    keys: HashMap<Entity, B::Key>,
+}
+
+impl<B: Buffered> BufferAccessStorage<B> {
+    fn new(buffers: B) -> Self {
+        Self { buffers, keys: HashMap::new() }
+    }
+}
+
+impl<T, B> Operation for OperateBufferAccess<T, B>
+where
+    T: 'static + Send + Sync,
+    B: Buffered + 'static + Send + Sync,
+    B::Key: 'static + Send + Sync,
+{
+    fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
+        world.get_entity_mut(self.target).or_broken()?
+            .insert(SingleInputStorage::new(source));
+
+        self.buffers.access(source, world)?;
+        world.entity_mut(source).insert((
+            InputBundle::<T>::new(),
+            BufferAccessStorage::new(self.buffers),
+            SingleTargetStorage::new(self.target),
+            BufferKeyUsage(buffer_key_usage::<B>),
+        ));
+
+        Ok(())
+    }
+
+    fn execute(
+        OperationRequest { source, world, roster }: OperationRequest,
+    ) -> OperationResult {
+        let Input { session, data } = world.get_entity_mut(source).or_broken()?
+            .take_input::<T>()?;
+
+        let scope = world.get::<ScopeStorage>(source).or_broken()?.get();
+        let sender = world
+            .get_resource_or_insert_with(|| ChannelQueue::default())
+            .sender.clone();
+
+        let mut storage = world.get_mut::<BufferAccessStorage<B>>(source).or_broken()?;
+        let s = storage.as_mut();
+        let keys = match s.keys.entry(source) {
+            Entry::Occupied(occupied) => occupied.get().clone(),
+            Entry::Vacant(vacant) => {
+                vacant.insert(
+                    s.buffers.create_key(scope, session, &sender)?
+                ).clone()
+            }
+        };
+
+        let target = world.get::<SingleTargetStorage>(source).or_broken()?.get();
+        world.get_entity_mut(target).or_broken()?.give_input(
+            session, (data, keys), roster,
+        )
+    }
+
+    fn cleanup(mut clean: OperationCleanup) -> OperationResult {
+        clean.cleanup_inputs::<T>()?;
+        clean.world.get_mut::<BufferAccessStorage<B>>(clean.source).or_broken()?
+            .keys.remove(&clean.session);
+        clean.notify_cleaned()
+    }
+
+    fn is_reachable(mut r: OperationReachability) -> ReachabilityResult {
+        if r.has_input::<T>()? {
+            return Ok(true);
+        }
+
+
+        SingleInputStorage::is_reachable(&mut r)
+    }
+}
+
+fn buffer_key_usage<B>(
+    accessor: Entity,
+    session: Entity,
+    world: &World,
+) -> ReachabilityResult
+where
+    B: Buffered + 'static + Send + Sync,
+    B::Key: 'static + Send + Sync,
+{
+    let key = world.get::<BufferAccessStorage<B>>(accessor).or_broken()?
+        .keys.get(&session);
+    if let Some(key) = key {
+        if B::is_key_in_use(key) {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+/// Buffer access nodes are siblings nodes in a workflow which can access the
+/// buffer, potentially in a mutable way. Their outputs do not get fed to the
+/// buffer, so they are not considered input nodes, but they may modify the
+/// contents of the buffer, which includes pushing new data, so they affect
+/// the reachability of the buffer.
+#[derive(Component, Default)]
+pub(crate) struct BufferAccessors(pub(crate) SmallVec<[Entity; 8]>);
+
+impl BufferAccessors {
+    pub(crate) fn is_reachable(mut r: OperationReachability) -> ReachabilityResult {
+        let Some(accessors) = r.world.get::<Self>(r.source) else {
+            return Ok(false);
+        };
+
+        for accessor in &accessors.0 {
+            let usage = r.world.get::<BufferKeyUsage>(*accessor).or_broken()?.0;
+            if usage(*accessor, r.session, r.world)? {
+                return Ok(true);
+            }
+        }
+
+        for accessor in &accessors.0 {
+            if r.check_upstream(*accessor)? {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    }
+}

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -28,7 +28,7 @@ use crate::{
     Operation, OperationRequest, OperationReachability, OperationResult,
     Buffered, OperationSetup, InputBundle, SingleTargetStorage, OrBroken,
     SingleInputStorage, Input, ManageInput, ChannelQueue, ScopeStorage,
-    OperationCleanup, ReachabilityResult, OperationError,
+    OperationCleanup, ReachabilityResult, OperationError, BufferKeyBuilder,
 };
 
 pub(crate) struct OperateBufferAccess<T, B>
@@ -138,9 +138,10 @@ where
         Entry::Occupied(occupied) => B::deep_clone_key(occupied.get()),
         Entry::Vacant(vacant) => {
             made_key = true;
-            let new_key = vacant.insert(
-                s.buffers.create_key(scope, session, source, &sender, &Arc::new(()))?
+            let builder = BufferKeyBuilder::with_tracking(
+                scope, session, source, sender, Arc::new(()),
             );
+            let new_key = vacant.insert(s.buffers.create_key(&builder));
             B::deep_clone_key(new_key)
         }
     };

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -20,7 +20,7 @@ use crate::{
     OperationReachability, ReachabilityResult, OperationSetup, StreamPack,
     SingleInputStorage, SingleTargetStorage, OrBroken, OperationCleanup,
     Cancellation, Unreachability, InspectDisposals, execute_operation,
-    Cancellable, OperationRoster, ManageCancellation,
+    Cancellable, OperationRoster, ManageCancellation, ManageBuffer,
     OperationError, OperationCancel, Cancel, UnhandledErrors, check_reachability,
     Blocker, Stream, StreamTargetStorage, StreamRequest, AddOperation,
     ScopeSettings, StreamTargetMap, ClearBufferFn,

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -43,7 +43,7 @@ impl<T> Promise<T> {
     /// This will never block, but it might provide a state that is out of date.
     ///
     /// To borrow a view of the most current state at the cost of synchronizing
-    /// you can use [`peek`].
+    /// you can use [`Self::peek`].
     pub fn sneak_peek(&self) -> &PromiseState<T> {
         &self.state
     }
@@ -53,7 +53,7 @@ impl<T> Promise<T> {
     ///
     /// This requires a mutable reference to the promise because it may try to
     /// update the current state if needed. To peek at that last known state
-    /// without trying to synchronize you can use [`sneak_peek()`].
+    /// without trying to synchronize you can use [`Self::sneak_peek()`].
     pub fn peek(&mut self) -> &PromiseState<T> {
         self.update();
         &self.state
@@ -72,7 +72,7 @@ impl<T> Promise<T> {
     /// of the mutable methods.
     ///
     /// To both wait for a result and update the Promise's internal state once
-    /// it is available, use [`wait_mut`].
+    /// it is available, use [`Self::wait_mut`].
     pub fn wait(&self) -> &Self {
         if !self.state.is_pending() {
             // The result arrived and ownership has been transferred to this
@@ -136,9 +136,9 @@ impl<T> Promise<T> {
     }
 
     /// Update the internal state of the promise if it is still pending. This
-    /// will automatically be done by [`peek`] and [`take`] so there is no
-    /// need to call this explicitly unless you want a specific timing for when
-    /// to synchronize the internal state.
+    /// will automatically be done by [`Self::peek`] and [`Self::take`] so there
+    /// is no need to call this explicitly unless you want a specific timing for
+    /// when to synchronize the internal state.
     pub fn update(&mut self) {
         if self.state.is_pending() {
             match self.target.inner.lock() {

--- a/src/service.rs
+++ b/src/service.rs
@@ -54,7 +54,7 @@ pub(crate) use workflow::*;
 ///
 /// To use a provider, call [`bevy::prelude::Commands`]`.`[`request(provider, request)`][3].
 ///
-/// [1]: AddservicesExt::add_service
+/// [1]: crate::AddServicesExt::add_service
 /// [2]: SpawnServicesExt::spawn_service
 /// [3]: crate::RequestExt::request
 #[derive(Debug, PartialEq, Eq)]
@@ -111,7 +111,7 @@ define_label!(
     /// A strongly-typed class of labels used to tag delivery instructions that
     /// are related to each other.
     DeliveryLabel,
-    /// Strongly-typed identifier for a [`RequestLabel`].
+    /// Strongly-typed identifier for a [`DeliveryLabel`].
     DeliveryLabelId,
 );
 
@@ -154,7 +154,7 @@ pub struct DeliveryInstructions {
 impl DeliveryInstructions {
     /// Begin building a label for a request. You do not need to call this
     /// function explicitly. You can instead use `.preempt()` or `.ensure()`
-    /// directly on a `RequestLabel` instance.
+    /// directly on a [`DeliveryLabel`] instance.
     pub fn new(label: impl DeliveryLabel) -> Self {
         Self {
             label: label.as_label(),
@@ -227,7 +227,7 @@ impl<L: DeliveryLabel> From<L> for DeliveryInstructions {
 }
 
 /// Allow anything that can be converted into [`DeliveryInstructions`] to have
-/// access to the [`preempt`] and [`ensure`] methods.
+/// access to the [`Self::preempt`] and [`Self::ensure`] methods.
 pub trait AsDeliveryInstructions {
     /// Instruct the delivery to have [preemptive behavior][1].
     ///

--- a/src/service/builder.rs
+++ b/src/service/builder.rs
@@ -59,8 +59,8 @@ impl<Srv, With, Also> ServiceBuilder<Srv, (), With, Also> {
     }
 
     /// Allow the service to run in parallel. Requests that shared the same
-    /// RequestLabel will still be run in serial or interrupt each other
-    /// depending on settings.
+    /// [`DeliveryLabel`](crate::DeliveryLabel) will still be run in serial or
+    /// interrupt each other depending on settings.
     pub fn parallel(self) -> ServiceBuilder<Srv, ParallelChosen, With, Also> {
         ServiceBuilder {
             service: self.service,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -198,6 +198,12 @@ impl From<Duration> for FlushConditions {
     }
 }
 
+impl From<usize> for FlushConditions {
+    fn from(value: usize) -> Self {
+        Self::new().with_update_count(value)
+    }
+}
+
 impl FlushConditions {
     pub fn new() -> Self {
         FlushConditions::default()

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -154,10 +154,10 @@ pub enum DeliverySettings {
     Serial,
 
     /// The workflow can run any number of sessions at a time. If multiple
-    /// requests with the same [`RequestLabelId`][1] try to run at the same time,
+    /// requests with the same [`DeliveryLabelId`][1] try to run at the same time,
     /// those requests will follow the serial delivery behavior.
     ///
-    /// [1]: crate::RequestLabelId
+    /// [1]: crate::DeliveryLabelId
     #[default]
     Parallel,
 }


### PR DESCRIPTION
This PR introduces the ability for services to directly access the contents of a buffer using a `BufferKey` which can be passed around through a workflow as a value.

TODO:
- [x]  Reachability tests
- [x] Use buffer keys for on_cancel
- [x] Support on_terminate to help clear out buffers during regular termination 