### PR TITLE
Migrate to Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Grey <mxgrey@intrinsic.ai>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11"
+bevy = "0.12"
 arrayvec = "*"
 itertools = "*"
 smallvec = "*"

--- a/src/buffer/manage_buffer.rs
+++ b/src/buffer/manage_buffer.rs
@@ -17,7 +17,7 @@
 
 use bevy::{
     prelude::Entity,
-    ecs::world::{EntityMut, EntityRef},
+    ecs::world::{EntityWorldMut, EntityRef},
 };
 
 use smallvec::SmallVec;
@@ -91,7 +91,7 @@ pub trait ManageBuffer {
     ) -> OperationResult;
 }
 
-impl<'w> ManageBuffer for EntityMut<'w> {
+impl<'w> ManageBuffer for EntityWorldMut<'w> {
     fn try_pull_from_buffer<T: 'static + Send + Sync>(
         &mut self,
         session: Entity,

--- a/src/cancel.rs
+++ b/src/cancel.rs
@@ -17,7 +17,7 @@
 
 use bevy::{
     prelude::{Entity, Component, Bundle, World},
-    ecs::world::EntityMut,
+    ecs::world::EntityWorldMut,
 };
 
 use backtrace::Backtrace;
@@ -244,7 +244,7 @@ pub trait ManageCancellation {
     );
 }
 
-impl<'w> ManageCancellation for EntityMut<'w> {
+impl<'w> ManageCancellation for EntityWorldMut<'w> {
     fn emit_cancel(
         &mut self,
         session: Entity,
@@ -307,7 +307,7 @@ pub fn try_emit_broken(
 }
 
 fn try_emit_cancel(
-    source_mut: &mut EntityMut,
+    source_mut: &mut EntityWorldMut,
     session: Option<Entity>,
     cancellation: Cancellation,
     roster: &mut OperationRoster,

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -17,7 +17,7 @@
 
 use bevy::{
     prelude::{Entity, Component, World},
-    ecs::world::{EntityMut, EntityRef},
+    ecs::world::{EntityWorldMut, EntityRef},
 };
 
 use backtrace::Backtrace;
@@ -317,7 +317,7 @@ pub trait InspectDisposals {
     fn get_disposals(&self, session: Entity) -> Option<&Vec<Disposal>>;
 }
 
-impl<'w> ManageDisposal for EntityMut<'w> {
+impl<'w> ManageDisposal for EntityWorldMut<'w> {
     fn emit_disposal(
         &mut self,
         session: Entity,
@@ -360,7 +360,7 @@ impl<'w> ManageDisposal for EntityMut<'w> {
     }
 }
 
-impl<'w> InspectDisposals for EntityMut<'w> {
+impl<'w> InspectDisposals for EntityWorldMut<'w> {
     fn get_disposals(&self, session: Entity) -> Option<&Vec<Disposal>> {
         if let Some(storage) = self.get::<DisposalStorage>() {
             return storage.disposals.get(&session);

--- a/src/input.rs
+++ b/src/input.rs
@@ -18,7 +18,7 @@
 use bevy::{
     prelude::{Entity, Component, Bundle},
     ecs::{
-        world::{EntityMut, EntityRef, World},
+        world::{EntityWorldMut, EntityRef, World},
         system::Command,
     },
 };
@@ -135,7 +135,7 @@ pub trait InspectInput {
     ) -> Result<bool, OperationError>;
 }
 
-impl<'w> ManageInput for EntityMut<'w> {
+impl<'w> ManageInput for EntityWorldMut<'w> {
     fn give_input<T: 'static + Send + Sync>(
         &mut self,
         session: Entity,
@@ -234,7 +234,7 @@ impl<'w> ManageInput for EntityMut<'w> {
     }
 }
 
-impl<'a> InspectInput for EntityMut<'a> {
+impl<'a> InspectInput for EntityWorldMut<'a> {
     fn has_input<T: 'static + Send + Sync>(
         &self,
         session: Entity,

--- a/src/service.rs
+++ b/src/service.rs
@@ -384,7 +384,7 @@ pub trait AddContinuousServicesExt {
     where
         B::Service: IntoContinuousService<M2>,
         B::Deliver: DeliveryChoice,
-        B::With: WithEntityMut,
+        B::With: WithEntityWorldMut,
         B::Also: AlsoAdd<
             <B::Service as IntoContinuousService<M2>>::Request,
             <B::Service as IntoContinuousService<M2>>::Response,
@@ -432,7 +432,7 @@ impl AddContinuousServicesExt for App {
     where
         B::Service: IntoContinuousService<M2>,
         B::Deliver: DeliveryChoice,
-        B::With: WithEntityMut,
+        B::With: WithEntityWorldMut,
         B::Also: AlsoAdd<
             <B::Service as IntoContinuousService<M2>>::Request,
             <B::Service as IntoContinuousService<M2>>::Response,

--- a/src/service.rs
+++ b/src/service.rs
@@ -347,7 +347,7 @@ pub trait AddServicesExt {
     where
         B::Service: IntoService<M2>,
         B::Deliver: DeliveryChoice,
-        B::With: WithEntityMut,
+        B::With: WithEntityWorldMut,
         B::Also: AlsoAdd<
             <B::Service as IntoService<M2>>::Request,
             <B::Service as IntoService<M2>>::Response,

--- a/src/service/async_srv.rs
+++ b/src/service/async_srv.rs
@@ -31,7 +31,7 @@ use bevy::{
     prelude::{Component, In, World, Entity},
     tasks::AsyncComputeTaskPool,
     ecs::{
-        world::EntityMut,
+        world::EntityWorldMut,
         system::{IntoSystem, BoxedSystem, EntityCommands},
     }
 };
@@ -66,7 +66,7 @@ where
         ));
     }
 
-    fn insert_service_mut<'w>(self, entity_mut: &mut EntityMut<'w>) {
+    fn insert_service_mut<'w>(self, entity_mut: &mut EntityWorldMut<'w>) {
         entity_mut.insert((
             UninitAsyncServiceStorage(Box::new(IntoSystem::into_system(self))),
             ServiceBundle::<AsyncServiceStorage<Request, Streams, Task>>::new(),
@@ -332,7 +332,7 @@ where
         peel_async.pipe(self.0).insert_service_commands(entity_commands)
     }
 
-    fn insert_service_mut<'w>(self, entity_mut: &mut EntityMut<'w>) {
+    fn insert_service_mut<'w>(self, entity_mut: &mut EntityWorldMut<'w>) {
         peel_async.pipe(self.0).insert_service_mut(entity_mut)
     }
 }

--- a/src/service/blocking.rs
+++ b/src/service/blocking.rs
@@ -18,7 +18,7 @@
 use bevy::{
     prelude::{Component, In},
     ecs::{
-        world::EntityMut,
+        world::EntityWorldMut,
         system::{IntoSystem, BoxedSystem, EntityCommands},
     }
 };
@@ -61,7 +61,7 @@ where
         ));
     }
 
-    fn insert_service_mut<'w>(self, entity_mut: &mut EntityMut<'w>) {
+    fn insert_service_mut<'w>(self, entity_mut: &mut EntityWorldMut<'w>) {
         entity_mut.insert((
             UninitBlockingServiceStorage(Box::new(IntoSystem::into_system(self))),
             ServiceBundle::<BlockingServiceStorage<Request, Response, Streams>>::new(),
@@ -181,7 +181,7 @@ where
         peel_blocking.pipe(self.0).insert_service_commands(entity_commands)
     }
 
-    fn insert_service_mut<'w>(self, entity_mut: &mut EntityMut<'w>) {
+    fn insert_service_mut<'w>(self, entity_mut: &mut EntityWorldMut<'w>) {
         peel_blocking.pipe(self.0).insert_service_mut(entity_mut)
     }
 }

--- a/src/service/continuous.rs
+++ b/src/service/continuous.rs
@@ -19,7 +19,7 @@ use bevy::{
     prelude::{Component, Entity, Local, Query, Commands, World, BuildWorldChildren},
     ecs::{
         system::{SystemParam, Command, IntoSystem},
-        world::EntityMut,
+        world::EntityWorldMut,
         schedule::{SystemConfigs, IntoSystemConfigs}
     }
 };
@@ -678,7 +678,7 @@ where
     type Response = Response;
     type Streams = Streams;
 
-    fn into_system_config<'w>(self, entity_mut: &mut EntityMut<'w>) -> SystemConfigs {
+    fn into_system_config<'w>(self, entity_mut: &mut EntityWorldMut<'w>) -> SystemConfigs {
         let provider = entity_mut.insert((
             ContinuousQueueStorage::<Request>::new(),
             ServiceBundle::<ContinuousServiceImpl<Request, Response, Streams>>::new(),

--- a/src/service/service_builder.rs
+++ b/src/service/service_builder.rs
@@ -20,7 +20,7 @@ use crate::{Service, IntoService, IntoContinuousService, Delivery, stream::*};
 use bevy::{
     prelude::App,
     ecs::{
-        world::EntityMut,
+        world::EntityWorldMut,
         system::{Commands, EntityCommands},
         schedule::{ScheduleLabel, SystemConfigs},
     }
@@ -120,7 +120,7 @@ impl<Srv, Deliver, With, Also> ServiceBuilder<Srv, Deliver, With, Also, ()> {
     where
         Srv: IntoService<M>,
         Deliver: DeliveryChoice,
-        With: WithEntityMut,
+        With: WithEntityWorldMut,
         Also: AlsoAdd<Srv::Request, Srv::Response, Srv::Streams>,
         Srv::Request: 'static + Send + Sync,
         Srv::Response: 'static + Send + Sync,
@@ -148,7 +148,7 @@ where
     where
         Srv: IntoContinuousService<M>,
         Deliver: DeliveryChoice,
-        With: WithEntityMut,
+        With: WithEntityWorldMut,
         Also: AlsoAdd<Srv::Request, Srv::Response, Srv::Streams>,
         Configure: ConfigureContinuousService,
         Srv::Request: 'static + Send + Sync,
@@ -271,7 +271,7 @@ pub struct SerialChosen;
 
 impl DeliveryChoice for SerialChosen {
     fn apply_entity_mut<'w, Request: 'static + Send + Sync>(
-        self, entity_mut: &mut EntityMut<'w>
+        self, entity_mut: &mut EntityWorldMut<'w>
     ) {
         entity_mut.insert(Delivery::<Request>::serial());
     }
@@ -290,7 +290,7 @@ pub struct ParallelChosen;
 
 impl DeliveryChoice for ParallelChosen {
     fn apply_entity_mut<'w, Request: 'static + Send + Sync>(
-        self, entity_mut: &mut EntityMut<'w>
+        self, entity_mut: &mut EntityWorldMut<'w>
     ) {
         entity_mut.insert(Delivery::<Request>::parallel());
     }
@@ -316,7 +316,7 @@ impl DeliveryChoice for BlockingChosen {
     }
 
     fn apply_entity_mut<'w, Request: 'static + Send + Sync>(
-        self, _: &mut EntityMut<'w>
+        self, _: &mut EntityWorldMut<'w>
     ) {
         // Do nothing
     }
@@ -329,20 +329,20 @@ impl DeliveryChoice for () {
         ParallelChosen.apply_entity_commands::<Request>(entity_commands)
     }
     fn apply_entity_mut<'w, Request: 'static + Send + Sync>(
-        self, entity_mut: &mut EntityMut<'w>
+        self, entity_mut: &mut EntityWorldMut<'w>
     ) {
         ParallelChosen.apply_entity_mut::<Request>(entity_mut)
     }
 }
 
-impl<T: FnOnce(EntityMut)> WithEntityMut for T {
-    fn apply<'w>(self, entity_mut: EntityMut<'w>) {
+impl<T: FnOnce(EntityWorldMut)> WithEntityWorldMut for T {
+    fn apply<'w>(self, entity_mut: EntityWorldMut<'w>) {
         self(entity_mut);
     }
 }
 
-impl WithEntityMut for () {
-    fn apply<'w>(self, _: EntityMut<'w>) {
+impl WithEntityWorldMut for () {
+    fn apply<'w>(self, _: EntityWorldMut<'w>) {
         // Do nothing
     }
 }

--- a/src/service/traits.rs
+++ b/src/service/traits.rs
@@ -23,7 +23,7 @@ use crate::{
 use bevy::{
     prelude::App,
     ecs::{
-        world::EntityMut,
+        world::EntityWorldMut,
         system::EntityCommands,
         schedule::SystemConfigs,
     },
@@ -42,7 +42,7 @@ pub trait IntoService<M> {
     type Streams;
     type DefaultDeliver: Default;
 
-    fn insert_service_mut<'w>(self, entity_mut: &mut EntityMut<'w>);
+    fn insert_service_mut<'w>(self, entity_mut: &mut EntityWorldMut<'w>);
     fn insert_service_commands<'w, 's, 'a>(self, entity_commands: &mut EntityCommands<'w, 's, 'a>);
 }
 
@@ -51,7 +51,7 @@ pub trait IntoContinuousService<M> {
     type Response;
     type Streams;
 
-    fn into_system_config<'w>(self, entity_mut: &mut EntityMut<'w>) -> SystemConfigs;
+    fn into_system_config<'w>(self, entity_mut: &mut EntityWorldMut<'w>) -> SystemConfigs;
 }
 
 /// This trait allows service systems to be converted into a builder that
@@ -92,17 +92,17 @@ pub trait ChooseAsyncServiceDelivery<M> {
 /// This trait is used to set the delivery mode of a service.
 pub trait DeliveryChoice {
     fn apply_entity_mut<'w, Request: 'static + Send + Sync>(
-        self, entity_mut: &mut EntityMut<'w>,
+        self, entity_mut: &mut EntityWorldMut<'w>,
     );
     fn apply_entity_commands<'w, 's, 'a, Request: 'static + Send + Sync>(
         self, entity_commands: &mut EntityCommands<'w, 's, 'a>,
     );
 }
 
-/// This trait is used to accept anything that can be executed on an EntityMut,
+/// This trait is used to accept anything that can be executed on an EntityWorldMut,
 /// used when adding a service with the App interface.
-pub trait WithEntityMut {
-    fn apply<'w>(self, entity_mut: EntityMut<'w>);
+pub trait WithEntityWorldMut {
+    fn apply<'w>(self, entity_mut: EntityWorldMut<'w>);
 }
 
 /// This trait is used to accept anything that can be executed on an

--- a/src/workflow/internal.rs
+++ b/src/workflow/internal.rs
@@ -17,7 +17,7 @@
 
 use bevy::ecs::{
     system::EntityCommands,
-    world::EntityMut,
+    world::EntityWorldMut,
 };
 
 use crate::{DeliveryChoice, DeliverySettings, Delivery};
@@ -37,7 +37,7 @@ impl DeliveryChoice for DeliverySettings {
     }
 
     fn apply_entity_mut<'w, Request: 'static + Send + Sync>(
-        self, entity_mut: &mut EntityMut<'w>,
+        self, entity_mut: &mut EntityWorldMut<'w>,
     ) {
         match self {
             Self::Serial => {


### PR DESCRIPTION
## New feature implementation

### Implemented feature

[rmf_site](https://github.com/open-rmf/rmf_site/blob/main/Cargo.toml) is currently on Bevy 0.12, so to use this library we would need to be at least at that version.

### Implementation description

The bulk of the changes is `EntityMut` -> `EntityWorldMut`.
The only other change is in labels implementation, the test code shows a trait implementation example with a TODO that it would be a lot easier for users to derive it, but that would require refactoring this library to have a separate proc_macro crate.

Still pending #9 to have the crate actually usable but thought I wouldn't make the PR here too complex