### PR TITLE
Add a service spawning methods to World

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -18,7 +18,7 @@
 use crate::{StreamPack, AddOperation, OperateService, Provider, ProvideOnce};
 
 use bevy::{
-    prelude::{Entity, App, Commands, Component, Deref, DerefMut},
+    prelude::{Entity, App, Commands, Component, Deref, DerefMut, World},
     ecs::schedule::ScheduleLabel,
     utils::{intern::Interned, define_label},
 };
@@ -310,6 +310,27 @@ impl<'w, 's> SpawnServicesExt<'w, 's> for Commands<'w, 's> {
         <B::Service as IntoService<M2>>::Streams: StreamPack,
     {
         builder.into_service_builder().spawn_service(self)
+    }
+}
+
+impl<'w, 's> SpawnServicesExt<'w, 's> for World {
+    fn spawn_service<'a, M1, M2, B: IntoServiceBuilder<M1, Also=(), Configure=()>>(
+        &'a mut self,
+        builder: B,
+    ) -> Service<
+            <B::Service as IntoService<M2>>::Request,
+            <B::Service as IntoService<M2>>::Response,
+            <B::Service as IntoService<M2>>::Streams,
+        >
+    where
+        B::Service: IntoService<M2>,
+        B::Deliver: DeliveryChoice,
+        B::With: WithEntityCommands,
+        <B::Service as IntoService<M2>>::Request: 'static + Send + Sync,
+        <B::Service as IntoService<M2>>::Response: 'static + Send + Sync,
+        <B::Service as IntoService<M2>>::Streams: StreamPack,
+    {
+        builder.into_service_builder().spawn_service_world(self)
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -19,7 +19,10 @@ use crate::{StreamPack, AddOperation, OperateService, Provider, ProvideOnce};
 
 use bevy::{
     prelude::{Entity, App, Commands, Component, Deref, DerefMut, World},
-    ecs::schedule::ScheduleLabel,
+    ecs::{
+        schedule::ScheduleLabel,
+        system::CommandQueue,
+    },
     utils::{intern::Interned, define_label},
 };
 
@@ -330,7 +333,11 @@ impl<'w, 's> SpawnServicesExt<'w, 's> for World {
         <B::Service as IntoService<M2>>::Response: 'static + Send + Sync,
         <B::Service as IntoService<M2>>::Streams: StreamPack,
     {
-        builder.into_service_builder().spawn_service_world(self)
+        let mut command_queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut command_queue, self);
+        let provider = commands.spawn_service(builder);
+        command_queue.apply(self);
+        provider
     }
 }
 

--- a/src/service/service_builder.rs
+++ b/src/service/service_builder.rs
@@ -18,10 +18,10 @@
 use crate::{Service, IntoService, IntoContinuousService, Delivery, stream::*};
 
 use bevy::{
-    prelude::App,
+    prelude::{App, World},
     ecs::{
         world::EntityWorldMut,
-        system::{Commands, EntityCommands},
+        system::{Commands, CommandQueue, EntityCommands},
         schedule::{ScheduleLabel, SystemConfigs},
     }
 };
@@ -191,6 +191,19 @@ where
         self.deliver.apply_entity_commands::<Srv::Request>(&mut entity_cmds);
         self.with.apply(&mut entity_cmds);
         provider
+    }
+
+    pub(crate) fn spawn_service_world<M>(self, world: &mut World) -> Service<Srv::Request, Srv::Response, Srv::Streams>
+    where
+        Srv: IntoService<M>,
+        With: WithEntityCommands,
+        Srv::Request: 'static + Send + Sync,
+        Srv::Response: 'static + Send + Sync,
+        Srv::Streams: StreamPack,
+    {
+        let mut command_queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut command_queue, &world);
+        self.spawn_service(&mut commands)
     }
 }
 

--- a/src/service/service_builder.rs
+++ b/src/service/service_builder.rs
@@ -203,7 +203,9 @@ where
     {
         let mut command_queue = CommandQueue::default();
         let mut commands = Commands::new(&mut command_queue, &world);
-        self.spawn_service(&mut commands)
+        let provider = self.spawn_service(&mut commands);
+        command_queue.apply(world);
+        provider
     }
 }
 

--- a/src/service/service_builder.rs
+++ b/src/service/service_builder.rs
@@ -18,10 +18,10 @@
 use crate::{Service, IntoService, IntoContinuousService, Delivery, stream::*};
 
 use bevy::{
-    prelude::{App, World},
+    prelude::App,
     ecs::{
         world::EntityWorldMut,
-        system::{Commands, CommandQueue, EntityCommands},
+        system::{Commands, EntityCommands},
         schedule::{ScheduleLabel, SystemConfigs},
     }
 };
@@ -190,21 +190,6 @@ where
         entity_cmds.insert(<Srv::Streams as StreamPack>::StreamAvailableBundle::default());
         self.deliver.apply_entity_commands::<Srv::Request>(&mut entity_cmds);
         self.with.apply(&mut entity_cmds);
-        provider
-    }
-
-    pub(crate) fn spawn_service_world<M>(self, world: &mut World) -> Service<Srv::Request, Srv::Response, Srv::Streams>
-    where
-        Srv: IntoService<M>,
-        With: WithEntityCommands,
-        Srv::Request: 'static + Send + Sync,
-        Srv::Response: 'static + Send + Sync,
-        Srv::Streams: StreamPack,
-    {
-        let mut command_queue = CommandQueue::default();
-        let mut commands = Commands::new(&mut command_queue, &world);
-        let provider = self.spawn_service(&mut commands);
-        command_queue.apply(world);
         provider
     }
 }


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Workflows can be spawned from `World` but services couldn't because of a missing implementation.

### Implementation description

Added an implementation to spawn services from `World`, useful when `&mut World` access is available (i.e. when initializing resources)