### PR TITLE
Add derive macro for DeliveryLabel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_impulse"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["Grey <mxgrey@intrinsic.ai>"]
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ keywords = ["reactive", "workflow", "behavior", "agent", "bevy"]
 categories = ["science::robotics", "asynchronous", "concurrency", "game-development"]
 
 [dependencies]
-bevy_impulse_derive = { path = "macros", version = "0.0.1" }
+bevy_impulse_derive = { path = "macros", version = "0.0.2" }
 bevy_ecs = "0.12"
 bevy_utils = "0.12"
 bevy_hierarchy = "0.12"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_impulse_derive"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["Grey <mxgrey@intrinsic.ai>"]
 license = "Apache-2.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -24,11 +24,36 @@ pub fn simple_stream_macro(item: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(item).unwrap();
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
-    // let bevy_impulse_path: Path =
 
     quote! {
-        impl #impl_generics Stream for #struct_name #type_generics #where_clause {
+        impl #impl_generics ::bevy_impulse::Stream for #struct_name #type_generics #where_clause {
             type Container = ::bevy_impulse::DefaultStreamContainer<Self>;
+        }
+    }
+    .into()
+}
+
+#[proc_macro_derive(DeliveryLabel)]
+pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(item).unwrap();
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::bevy_impulse::DeliveryLabel for #struct_name #type_generics #where_clause {
+            fn dyn_clone(&self) -> Box<dyn DeliveryLabel> {
+                ::std::boxed::Box::new(::std::clone::Clone::clone(self))
+            }
+
+            fn as_dyn_eq(&self) -> &dyn ::bevy_impulse::utils::DynEq {
+                self
+            }
+
+            fn dyn_hash(&self, mut state: &mut dyn ::std::hash::Hasher) {
+                let ty_id = ::std::any::TypeId::of::<Self>();
+                ::std::hash::Hash::hash(&ty_id, &mut state);
+                ::std::hash::Hash::hash(self, &mut state);
+            }
         }
     }
     .into()

--- a/src/impulse.rs
+++ b/src/impulse.rs
@@ -683,7 +683,12 @@ mod tests {
         verify_ensured([true, true, false, false], service, label.clone(), context);
         verify_ensured([false, false, true, true], service, label.clone(), context);
         verify_ensured([true, false, false, true], service, label.clone(), context);
-        verify_ensured([false, false, false, false], service, label.clone(), context);
+        verify_ensured(
+            [false, false, false, false],
+            service,
+            label.clone(),
+            context,
+        );
         verify_ensured([true, true, true, true], service, label.clone(), context);
     }
 
@@ -713,7 +718,10 @@ mod tests {
 
         let mut preempter = context.command(|commands| {
             commands
-                .request(Arc::clone(&counter), service.instruct(label.clone().preempt()))
+                .request(
+                    Arc::clone(&counter),
+                    service.instruct(label.clone().preempt()),
+                )
                 .take_response()
         });
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -26,6 +26,7 @@ use bevy_ecs::{
     prelude::{Commands, Component, Entity, Event, World},
     schedule::ScheduleLabel,
 };
+pub use bevy_impulse_derive::DeliveryLabel;
 use bevy_utils::{define_label, intern::Interned};
 use std::{any::TypeId, collections::HashSet};
 use thiserror::Error as ThisError;
@@ -195,6 +196,11 @@ define_label!(
     DeliveryLabel,
     DELIVERY_LABEL_INTERNER
 );
+
+pub mod utils {
+    /// Used by the procedural macro for DeliveryLabel
+    pub use bevy_utils::label::DynEq;
+}
 
 /// When using a service, you can bundle in delivery instructions that affect
 /// how multiple requests to the same service may interact with each other.


### PR DESCRIPTION
This PR adds the ability for downstream users to `#[derive(DeliveryLabel, ...)]` on their custom structs.

Unfortunately this derive macro cannot be used inside of `bevy_impulse` itself because I still have not figured out the dark ritual to make that work.