### PR TITLE
Introduce Split operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ async-task = { version = "4.7.1", optional = true }
 # bevy_tasks::Task, so we're leaving it as a mandatory dependency for now.
 bevy_tasks = { version = "0.12", features = ["multi-threaded"] }
 
-arrayvec = "0.7"
 itertools = "0.13"
 smallvec = "1.13"
 tokio = { version = "1.39", features = ["sync"]}

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -207,28 +207,28 @@ impl<T: Bufferable, const N: usize> Bufferable for [T; N] {
 }
 
 pub trait IterBufferable {
-    type BufferType: Buffered;
+    type BufferElement: Buffered;
 
     /// Convert an iterable collection of bufferable workflow elements into
     /// buffers if they are not buffers already.
     fn into_buffer_vec<const N: usize>(
         self,
         builder: &mut Builder,
-    ) -> SmallVec<[Self::BufferType; N]>;
+    ) -> SmallVec<[Self::BufferElement; N]>;
 
     /// Join an iterable collection of bufferable workflow elements.
     ///
     /// Performance is best if you can choose an `N` which is equal to the
     /// number of buffers inside the iterable, but this will work even if `N`
     /// does not match the number.
-    fn join_vec<const N: usize>(
+    fn join_vec<'w, 's, 'a, 'b, const N: usize>(
         self,
-        builder: &mut Builder,
-    ) -> Output<SmallVec<[<Self::BufferType as Buffered>::Item; N]>>
+        builder: &'b mut Builder<'w, 's, 'a>,
+    ) -> Chain<'w, 's, 'a, 'b, SmallVec<[<Self::BufferElement as Buffered>::Item; N]>>
     where
         Self: Sized,
-        Self::BufferType: 'static + Send + Sync,
-        <Self::BufferType as Buffered>::Item: 'static + Send + Sync,
+        Self::BufferElement: 'static + Send + Sync,
+        <Self::BufferElement as Buffered>::Item: 'static + Send + Sync,
     {
         let buffers = self.into_buffer_vec::<N>(builder);
         let join = builder.commands.spawn(()).id();
@@ -239,6 +239,25 @@ pub trait IterBufferable {
             Join::new(buffers, target),
         ));
 
-        Output::new(builder.scope, target)
+        Output::new(builder.scope, target).chain(builder)
+    }
+}
+
+impl<T> IterBufferable for T
+where
+    T: IntoIterator,
+    T::Item: Bufferable,
+{
+    type BufferElement = <T::Item as Bufferable>::BufferType;
+
+    fn into_buffer_vec<const N: usize>(
+        self,
+        builder: &mut Builder,
+    ) -> SmallVec<[Self::BufferElement; N]> {
+        SmallVec::<[Self::BufferElement; N]>::from_iter(
+            self
+            .into_iter()
+            .map(|e| e.into_buffer(builder))
+        )
     }
 }

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -255,9 +255,7 @@ where
         builder: &mut Builder,
     ) -> SmallVec<[Self::BufferElement; N]> {
         SmallVec::<[Self::BufferElement; N]>::from_iter(
-            self
-            .into_iter()
-            .map(|e| e.into_buffer(builder))
+            self.into_iter().map(|e| e.into_buffer(builder)),
         )
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -26,10 +26,10 @@ use crate::{
     AddOperation, AsMap, BeginCleanupWorkflow, Buffer, BufferItem, BufferKeys, BufferSettings,
     Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
     GateRequest, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Node, OperateBuffer,
-    OperateBufferAccess, OperateDynamicGate, OperateScope, OperateStaticGate, Output, Provider,
-    RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage,
-    Sendish, Service, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
-    SplitOutputs, OperateSplit, Splittable,
+    OperateBufferAccess, OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output,
+    Provider, RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings,
+    ScopeSettingsStorage, Sendish, Service, SplitOutputs, Splittable, StreamPack, StreamTargetMap,
+    StreamsOfMap, Trim, TrimBranch, UnusedTarget,
 };
 
 pub(crate) mod connect;
@@ -354,7 +354,10 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
             OperateSplit::<T>::default(),
         ));
 
-        (InputSlot::new(self.scope, source), SplitOutputs::new(self.scope, source))
+        (
+            InputSlot::new(self.scope, source),
+            SplitOutputs::new(self.scope, source),
+        )
     }
 
     /// This method allows you to define a cleanup workflow that branches off of

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -625,6 +625,11 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// If the chain's response implements the [`Splittable`] trait, then this
     /// will insert a split and provide a container for its available outputs.
     /// To build connections to these outputs later, use [`SplitOutputs::build`].
+    ///
+    /// This is equivalent to
+    /// ```text
+    /// .split(|split| split.outputs())
+    /// ```
     pub fn split_outputs(self) -> SplitOutputs<T>
     where
         T: Splittable,
@@ -634,18 +639,28 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
 
     /// If the chain's response can be turned into an iterator with an appropriate
     /// item type, this will allow it to be split in a list-like way.
+    ///
+    /// This is equivalent to
+    /// ```text
+    /// .map_block(SplitAsList::new).split(build)
+    /// ```
     pub fn split_as_list<U>(self, build: impl FnOnce(SplitBuilder<SplitAsList<T>>) -> U) -> U
     where
         T: IntoIterator,
         T::Item: 'static + Send + Sync,
     {
-        self.map_block(|v| SplitAsList::new(v)).split(build)
+        self.map_block(SplitAsList::new).split(build)
     }
 
     /// If the chain's response can be turned into an iterator with an appropriate
     /// item type, this will insert a split and provide a container for its
     /// available outputs. To build connections to these outputs later, use
     /// [`SplitOutputs::build`].
+    ///
+    /// This is equivalent to
+    /// ```text
+    /// .split_as_list(|split| split.outputs())
+    /// ```
     pub fn split_as_list_outputs(self) -> SplitOutputs<SplitAsList<T>>
     where
         T: IntoIterator,
@@ -1006,14 +1021,24 @@ where
     /// If the chain's response type can be turned into an iterator that returns
     /// `(key, value)` pairs, then this will split it in a map-like way, whether
     /// or not it is a conventional map data structure.
+    ///
+    /// This is equivalent to
+    /// ```text
+    /// .map_block(SplitAsMap::new).split(build)
+    /// ```
     pub fn split_as_map<U>(self, build: impl FnOnce(SplitBuilder<SplitAsMap<K, V, T>>) -> U) -> U {
-        self.map_block(|v| SplitAsMap::new(v)).split(build)
+        self.map_block(SplitAsMap::new).split(build)
     }
 
     /// If the chain's response type can be turned into an iterator that returns
     /// `(key, value)` pairs, then this will split it in a map-like way and
     /// provide a container for its available outputs. To build connections to
     /// these outputs later, use [`SplitOutputs::build`].
+    ///
+    /// This is equivalent to
+    /// ```text
+    /// .split_as_map(|split| split.outputs())
+    /// ```
     pub fn split_as_map_outputs(self) -> SplitOutputs<SplitAsMap<K, V, T>> {
         self.split_as_map(|b| b.outputs())
     }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -27,9 +27,9 @@ use crate::{
     make_option_branching, make_result_branching, AddOperation, AsMap, Buffer, BufferKey,
     BufferKeys, Bufferable, Buffered, Builder, Collect, CreateCancelFilter, CreateDisposalFilter,
     ForkTargetStorage, Gate, GateRequest, InputSlot, IntoAsyncMap, IntoBlockingCallback,
-    IntoBlockingMap, Node, Noop, OperateBufferAccess, OperateDynamicGate, OperateStaticGate,
-    Output, ProvideOnce, Provider, Scope, ScopeSettings, Sendish, Service, Spread, StreamOf,
-    StreamPack, StreamTargetMap, Trim, TrimBranch, UnusedTarget, OperateSplit,
+    IntoBlockingMap, Node, Noop, OperateBufferAccess, OperateDynamicGate, OperateSplit,
+    OperateStaticGate, Output, ProvideOnce, Provider, Scope, ScopeSettings, Sendish, Service,
+    Spread, StreamOf, StreamPack, StreamTargetMap, Trim, TrimBranch, UnusedTarget,
 };
 
 pub mod fork_clone_builder;
@@ -608,10 +608,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// will insert a split operation and provide your `build` function with the
     /// [`SplitBuilder`] for it. This returns the return value of your build
     /// function.
-    pub fn split<U>(
-        self,
-        build: impl FnOnce(SplitBuilder<T>) -> U,
-    ) -> U
+    pub fn split<U>(self, build: impl FnOnce(SplitBuilder<T>) -> U) -> U
     where
         T: Splittable,
     {
@@ -637,17 +634,12 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
 
     /// If the chain's response can be turned into an iterator with an appropriate
     /// item type, this will allow it to be split in a list-like way.
-    pub fn split_as_list<U>(
-        self,
-        build: impl FnOnce(SplitBuilder<SplitAsList<T>>) -> U,
-    ) -> U
+    pub fn split_as_list<U>(self, build: impl FnOnce(SplitBuilder<SplitAsList<T>>) -> U) -> U
     where
         T: IntoIterator,
         T::Item: 'static + Send + Sync,
     {
-        self
-        .map_block(|v| SplitAsList::new(v))
-        .split(build)
+        self.map_block(|v| SplitAsList::new(v)).split(build)
     }
 
     /// If the chain's response can be turned into an iterator with an appropriate
@@ -1014,13 +1006,8 @@ where
     /// If the chain's response type can be turned into an iterator that returns
     /// `(key, value)` pairs, then this will split it in a map-like way, whether
     /// or not it is a conventional map data structure.
-    pub fn split_as_map<U>(
-        self,
-        build: impl FnOnce(SplitBuilder<SplitAsMap<K, V, T>>) -> U,
-    ) -> U {
-        self
-        .map_block(|v| SplitAsMap::new(v))
-        .split(build)
+    pub fn split_as_map<U>(self, build: impl FnOnce(SplitBuilder<SplitAsMap<K, V, T>>) -> U) -> U {
+        self.map_block(|v| SplitAsMap::new(v)).split(build)
     }
 
     /// If the chain's response type can be turned into an iterator that returns

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1120,6 +1120,24 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     }
 }
 
+impl<'w, 's, 'a, 'b, K, V> Chain<'w, 's, 'a, 'b, (K, V)>
+where
+    K: 'static + Send + Sync,
+    V: 'static + Send + Sync,
+{
+    /// If the chain's response contains a `(key, value)` pair, get the `key`
+    /// component from it (the first element of the tuple).
+    pub fn key(self) -> Chain<'w, 's, 'a, 'b, K> {
+        self.map_block(|(key, _)| key)
+    }
+
+    /// If the chain's response contains a `(key, value)` pair, get the `value`
+    /// component from it (the second element of the tuple).
+    pub fn value(self) -> Chain<'w, 's, 'a, 'b, V> {
+        self.map_block(|(_, value)| value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{prelude::*, testing::*};

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -159,7 +159,6 @@ impl<'w, 's, 'a, 'b, T: 'static + Splittable> SplitBuilder<'w, 's, 'a, 'b, T> {
 
     /// Get the output slot for an element in the split.
     pub fn output_for(&mut self, key: T::Key) -> Result<Output<T::Item>, SplitConnectionError> {
-        let key: T::Key = key.into();
         if !T::validate(&key) {
             return Err(SplitConnectionError::KeyOutOfBounds);
         }
@@ -363,16 +362,13 @@ where
     ///
     /// If there is no connection associated with the specified key, the value
     /// will be returned as [`Err`].
-    pub fn outputs_for<'o, 'k>(&'o mut self, key: &'k Key) -> Option<&'o mut Vec<Item>> {
-        let Some(index) = self.connections.get(key) else {
-            return None;
-        };
-        let index = *index;
+    pub fn outputs_for<'o>(&'o mut self, key: &Key) -> Option<&'o mut Vec<Item>> {
+        let index = *self.connections.get(key)?;
 
         if self.outputs.len() <= index {
             // We do this just in case something bad happened with the cache
             // that reset its size.
-            self.outputs.resize_with(index + 1, || Vec::new());
+            self.outputs.resize_with(index + 1, Vec::new);
         }
 
         self.outputs.get_mut(index)

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -1,0 +1,479 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use thiserror::Error as ThisError;
+use std::{hash::Hash, fmt::Debug, collections::{HashSet, HashMap, BTreeMap}};
+use bevy_ecs::prelude::Entity;
+
+use crate::{
+    Builder, Chain, ConnectToSplit, Output, UnusedTarget, OperationResult,
+};
+
+/// Implementing this trait on a struct will allow the [`Chain::split`] operation
+/// to be performed on [outputs][crate::Output] of that type.
+pub trait Splittable: Sized {
+    /// The key used to identify different elements in the split
+    type Key: 'static + Send + Sync + Eq + Hash + Clone + Debug;
+
+    /// The type that the value gets split into
+    type Item: 'static + Send + Sync;
+
+    /// Return true if the key is feasible for this type of split, otherwise
+    /// return false. Returning false will cause the user to receive a
+    /// [`SplitConnectionError::IndexOutOfBounds`]. This will also cause iterating
+    /// to cease.
+    fn validate(key: &Self::Key) -> bool;
+
+    /// Get the next key value that would follow the provided one. If [`None`]
+    /// is passed in then return the first key. If you return [`None`] then
+    /// the connections will stop iterating.
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key>;
+
+    /// Split the value into its parts
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult;
+}
+
+/// This is returned by [`Chain::split`] and allows you to connect to the
+/// split pieces.
+#[must_use]
+pub struct SplitConnector<'w, 's, 'a, 'b, T: Splittable> {
+    connections: SplitConnections<T>,
+    builder: &'b mut Builder<'w, 's, 'a>,
+}
+
+impl<'w, 's, 'a, 'b, T: 'static + Splittable> SplitConnector<'w, 's, 'a, 'b, T> {
+    /// Get the state of connections for this split. You can resume building
+    /// more connections later by calling [`SplitConnections::build`] on the
+    /// connections.
+    pub fn connections(self) -> SplitConnections<T> {
+        self.connections
+    }
+
+    /// Build a branch for one of the elements in the split.
+    pub fn branch(
+        mut self,
+        key: impl Into<T::Key>,
+        f: impl FnOnce(Chain<T::Item>),
+    ) -> Result<SplitConnector<'w, 's, 'a, 'b, T>, SplitConnectionError> {
+        let output = self.output(key)?;
+        f(output.chain(self.builder));
+        Ok(self)
+    }
+
+    /// Build a branch for the next element in the split, if such an element may
+    /// be available. The second argument tells you what the key would be, but
+    /// you can safely ignore this if it doesn't matter to you.
+    ///
+    /// This changes what the next element will be if you later use this
+    /// [`SplitConnector`] as an iterator.
+    pub fn next_branch(
+        mut self,
+        f: impl FnOnce(Chain<T::Item>, T::Key),
+    ) -> Result<SplitConnector<'w, 's, 'a, 'b, T>, SplitConnectionError> {
+        let Some((key, output)) = self.next() else {
+            return Err(SplitConnectionError::KeyOutOfBounds);
+        };
+
+        f(output.chain(self.builder), key);
+        Ok(self)
+    }
+
+    /// Get the output slot for an element in the split.
+    pub fn output(
+        &mut self,
+        key: impl Into<T::Key>,
+    ) -> Result<Output<T::Item>, SplitConnectionError> {
+        let key: T::Key = key.into();
+        if !T::validate(&key) {
+            return Err(SplitConnectionError::KeyOutOfBounds);
+        }
+
+        if !self.connections.used.insert(key.clone()) {
+            return Err(SplitConnectionError::KeyAlreadyUsed);
+        }
+
+        let target = self.builder.commands.spawn(UnusedTarget).id();
+        self.builder.commands.add(ConnectToSplit::<T> {
+            source: self.connections.source,
+            target,
+            key
+        });
+        Ok(Output::new(self.builder.scope, target))
+    }
+
+    /// Used internally to create a new split connector
+    pub(crate) fn new(
+        source: Entity,
+        builder: &'b mut Builder<'w, 's, 'a>,
+    ) -> Self {
+        Self {
+            connections: SplitConnections {
+                source,
+                last_key: None,
+                used: Default::default(),
+            },
+            builder,
+        }
+    }
+}
+
+impl<'w, 's, 'a, 'b, T, K> SplitConnector<'w, 's, 'a, 'b, T>
+where
+    T: 'static + Splittable<Key = MapSplitKey<K>>,
+{
+    /// This is a convenience function for map-like splits that use [`MapSplitKey`]
+    /// to build a branch for an anonymous sequential element in the split.
+    pub fn sequential_branch(
+        self,
+        sequence_number: usize,
+        f: impl FnOnce(Chain<T::Item>),
+    ) -> Result<SplitConnector<'w, 's, 'a, 'b, T>, SplitConnectionError> {
+        self.branch(MapSplitKey::Sequential(sequence_number), f)
+    }
+}
+
+impl<'w, 's, 'a, 'b, T: 'static + Splittable> Iterator for SplitConnector<'w, 's, 'a, 'b, T> {
+    type Item = (T::Key, Output<T::Item>);
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next_key = T::next(&self.connections.last_key)?;
+            self.connections.last_key = Some(next_key.clone());
+
+            match self.output(next_key.clone()) {
+                Ok(output) => {
+                    return Some((next_key, output));
+                }
+                Err(SplitConnectionError::KeyAlreadyUsed) => {
+                    // Restart the loop and get the next key which might not be
+                    // used yet.
+                    continue;
+                }
+                Err(SplitConnectionError::KeyOutOfBounds) => {
+                    // We have reached the end of the valid range so just quit
+                    // iterating.
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+/// This tracks the connections that have been made to a split. This can be
+/// retrieved from [`SplitConnector`] by calling [`SplitConnector::connections`].
+/// You can then continue building connections by calling [`SplitConnector::build`].
+#[must_use]
+pub struct SplitConnections<T: Splittable> {
+    source: Entity,
+    last_key: Option<T::Key>,
+    used: HashSet<T::Key>,
+}
+
+impl<T: Splittable> SplitConnections<T> {
+    /// Resume building connections for this split.
+    pub fn build<'w, 's, 'a, 'b>(
+        self,
+        builder: &'b mut Builder<'w, 's, 'a>,
+    ) -> SplitConnector<'w, 's, 'a, 'b, T> {
+        SplitConnector { connections: self, builder }
+    }
+}
+
+/// Information about why a connection to a split failed
+#[derive(ThisError, Debug, Clone)]
+#[error("An error occurred while trying to connect to a split")]
+pub enum SplitConnectionError {
+    /// The requested index was already connected to.
+    KeyAlreadyUsed,
+    /// The requested index is out of bounds.
+    KeyOutOfBounds,
+}
+
+/// Used by implementers of the [`Splittable`] trait to help them send their
+/// split values to the proper input slots.
+pub struct SplitDispatcher<'a, Key, Item> {
+    pub(crate) connections: &'a HashMap<Key, usize>,
+    pub(crate) outputs: &'a mut Vec<Vec<Item>>,
+}
+
+impl<'a, Key, Item> SplitDispatcher<'a, Key, Item>
+where
+    Key: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    Item: 'static + Send + Sync,
+{
+    /// Send a value for a key. The split operation will make sure that this
+    /// value will be sent to the target associated with the key.
+    ///
+    /// If there is no connection associated with the specified key, the value
+    /// will be returned as [`Err`].
+    pub fn send(
+        &mut self,
+        key: &Key,
+        value: Item,
+    ) -> Result<(), Item> {
+        let Some(index) = self.connections.get(key) else {
+            return Err(value);
+        };
+        let index = *index;
+
+        if self.outputs.len() <= index {
+            // We do this just in case something bad happened with the cache
+            // that reset its size.
+            self.outputs.resize_with(index+1, || Vec::new());
+        }
+
+        self.outputs[index].push(value);
+
+        Ok(())
+    }
+}
+
+/// This is a newtype that implements [`Splittable`] for anything that can be
+/// turned into an iterator, but always splits it as if the iterator is list-like.
+///
+/// If used with a map-type (e.g. [`HashMap`] or [BTreeMap]), the items will be
+/// the `(key, value)` pairs of the maps, and the key for the split will be the
+/// order in which the map is iterated through. For [`BTreeMap`] this will always
+/// be a sorted order (e.g. alphabetical or numerical) but for [`HashMap`] this
+/// order can be completely arbitrary and may be unstable.
+pub struct SplitAsList<T: 'static + Send + Sync + IntoIterator> {
+    pub contents: T
+}
+
+impl<T: 'static + Send + Sync + IntoIterator> SplitAsList<T> {
+    pub fn new(contents: T) -> Self {
+        Self { contents }
+    }
+}
+
+impl<T> Splittable for SplitAsList<T>
+where
+    T: 'static + Send + Sync + IntoIterator,
+    T::Item: 'static + Send + Sync,
+{
+    type Key = usize;
+    type Item = T::Item;
+
+    fn validate(_: &Self::Key) -> bool {
+        // We don't know if there are any restrictions for the iterable, so just
+        // return say all keys are valid
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        if let Some(key) = key {
+            Some(*key + 1)
+        } else {
+            Some(0)
+        }
+    }
+
+    fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        for (index, value) in self.contents.into_iter().enumerate() {
+            dispatcher.send(&index, value).ok();
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: 'static + Send + Sync> Splittable for Vec<T> {
+    type Key = usize;
+    type Item = T;
+
+    fn validate(_: &Self::Key) -> bool {
+        // Vec has no restrictions on what index is valid
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsList::<Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsList::new(self).split(dispatcher)
+    }
+}
+
+impl<T: 'static + Send + Sync, const N: usize> Splittable for smallvec::SmallVec<[T; N]> {
+    type Key = usize;
+    type Item = T;
+
+    fn validate(_: &Self::Key) -> bool {
+        // SmallVec has no restrictions on what index is valid
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsList::<Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsList::new(self).split(dispatcher)
+    }
+}
+
+impl<T: 'static + Send + Sync, const N: usize> Splittable for [T; N] {
+    type Key = usize;
+    type Item = T;
+
+    fn validate(key: &Self::Key) -> bool {
+        // Static arrays have a firm limit of N
+        return *key < N;
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        // Static arrays have a firm limit of N
+        SplitAsList::<Self>::next(key).take_if(|key| *key < N)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsList::new(self).split(dispatcher)
+    }
+}
+
+/// This enum allows users to key into splittable map-like structures based on
+/// the presence of a specific value or based on the sequence in which a value
+/// is reached that wasn't associated with a specific key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MapSplitKey<K> {
+    /// Key into the item associated with this specific key.
+    Specific(K),
+    /// Key into an anonymous sequential item. Anonymous items are items for
+    /// which no specific connection was made to their key.
+    Sequential(usize),
+}
+
+impl<K> From<K> for MapSplitKey<K> {
+    fn from(value: K) -> Self {
+        MapSplitKey::Specific(value)
+    }
+}
+
+/// This is a newtype that implements [`Splittable`] for anything that can be
+/// turned into an iterator whose items take the form of a `(key, value)` pair
+/// where `key` meets all the bounds needed for a [`Splittable`] key.
+///
+/// This is used to implement [`Splittable`] for map-like structures.
+pub struct SplitAsMap<K, V, M>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+    M: 'static + Send + Sync + IntoIterator<Item = (K, V)>,
+{
+    pub contents: M,
+    _ignore: std::marker::PhantomData<(K, V)>,
+}
+
+impl<K, V, M> SplitAsMap<K, V, M>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+    M: 'static + Send + Sync + IntoIterator<Item = (K, V)>,
+{
+    pub fn new(contents: M) -> Self {
+        Self { contents, _ignore: Default::default() }
+    }
+}
+
+impl<K, V, M> Splittable for SplitAsMap<K, V, M>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+    M: 'static + Send + Sync + IntoIterator<Item = (K, V)>,
+{
+    type Key = MapSplitKey<K>;
+    type Item = V;
+
+    fn validate(_: &Self::Key) -> bool {
+        // We have no way of knowing what the key bounds are for an arbitrary map
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        match key {
+            Some(key) => {
+                match key {
+                    // Give the next key in the sequence
+                    MapSplitKey::Sequential(index) => Some(MapSplitKey::Sequential(index + 1)),
+                    // For an arbitrary map we don't know what would follow a specific key, so
+                    // just stop iterating. This should never be reached in practice anyway.
+                    MapSplitKey::Specific(_) => None,
+                }
+            }
+            None => Some(MapSplitKey::Sequential(0))
+        }
+    }
+
+    fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        let mut next_seq = 0;
+        for (key, value) in self.contents.into_iter() {
+            if let Err(value) = dispatcher.send(&MapSplitKey::Specific(key), value) {
+                // The specific key is not being used, so send this as a sequential
+                // value instead.
+                let seq = MapSplitKey::Sequential(next_seq);
+                next_seq += 1;
+                // We don't care if whether we get an error from this
+                dispatcher.send(&seq, value).ok();
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<K, V> Splittable for HashMap<K, V>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+{
+    type Key = MapSplitKey<K>;
+    type Item = V;
+
+    fn validate(_: &Self::Key) -> bool {
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsMap::<K, V, Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsMap::new(self).split(dispatcher)
+    }
+}
+
+impl<K, V> Splittable for BTreeMap<K, V>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+{
+    type Key = MapSplitKey<K>;
+    type Item = V;
+
+    fn validate(_: &Self::Key) -> bool {
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsMap::<K, V, Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsMap::new(self).split(dispatcher)
+    }
+}
+

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -36,7 +36,7 @@ pub trait Splittable: Sized {
 
     /// Return true if the key is feasible for this type of split, otherwise
     /// return false. Returning false will cause the user to receive a
-    /// [`SplitConnectionError::IndexOutOfBounds`]. This will also cause iterating
+    /// [`SplitConnectionError::KeyOutOfBounds`]. This will also cause iterating
     /// to cease.
     fn validate(key: &Self::Key) -> bool;
 
@@ -357,11 +357,11 @@ where
     Key: 'static + Send + Sync + Eq + Hash + Clone + Debug,
     Item: 'static + Send + Sync,
 {
-    /// Send a value for a key. The split operation will make sure that this
-    /// value will be sent to the target associated with the key.
+    /// Get the output buffer a certain key. If there are no connections for the
+    /// given key, then this will return [`None`].
     ///
-    /// If there is no connection associated with the specified key, the value
-    /// will be returned as [`Err`].
+    /// Push items into the output buffer to send them to the input connected to
+    /// this key.
     pub fn outputs_for<'o>(&'o mut self, key: &Key) -> Option<&'o mut Vec<Item>> {
         let index = *self.connections.get(key)?;
 

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -122,6 +122,13 @@ impl Disposal {
         }
         .into()
     }
+
+    pub fn incomplete_split(
+        split_node: Entity,
+        missing_keys: SmallVec<[Option<Arc<str>>; 16]>,
+    ) -> Self {
+        IncompleteSplit { split_node, missing_keys }.into()
+    }
 }
 
 #[derive(Debug)]
@@ -176,6 +183,10 @@ pub enum DisposalCause {
     /// been sent out to indicate that the workflow is blocked up on the
     /// collection.
     DeficientCollection(DeficientCollection),
+
+    /// A split operation took place, but not all connections to the split
+    /// received a value.
+    IncompleteSplit(IncompleteSplit),
 }
 
 /// A variant of [`DisposalCause`]
@@ -384,6 +395,21 @@ pub struct DeficientCollection {
 impl From<DeficientCollection> for DisposalCause {
     fn from(value: DeficientCollection) -> Self {
         Self::DeficientCollection(value)
+    }
+}
+
+/// A variant of [`DisposalCause`]
+#[derive(Debug)]
+pub struct IncompleteSplit {
+    /// The node that does the splitting
+    pub split_node: Entity,
+    /// The debug text of each key that was missing in the split
+    pub missing_keys: SmallVec<[Option<Arc<str>>; 16]>,
+}
+
+impl From<IncompleteSplit> for DisposalCause {
+    fn from(value: IncompleteSplit) -> Self {
+        Self::IncompleteSplit(value)
     }
 }
 

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -127,7 +127,11 @@ impl Disposal {
         split_node: Entity,
         missing_keys: SmallVec<[Option<Arc<str>>; 16]>,
     ) -> Self {
-        IncompleteSplit { split_node, missing_keys }.into()
+        IncompleteSplit {
+            split_node,
+            missing_keys,
+        }
+        .into()
     }
 }
 

--- a/src/node.rs
+++ b/src/node.rs
@@ -87,6 +87,9 @@ impl<Request> InputSlot<Request> {
 /// `Response` parameter can be cloned then you can call [`Self::fork_clone`] to
 /// transform this into a [`ForkCloneOutput`] and then connect the output into
 /// any number of input slots.
+///
+/// `Output` intentionally does not implement copy or clone because it must only
+/// be consumed exactly once.
 #[must_use]
 pub struct Output<Response> {
     scope: Entity,

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -80,6 +80,9 @@ pub(crate) use operate_map::*;
 mod operate_service;
 pub(crate) use operate_service::*;
 
+mod operate_split;
+pub(crate) use operate_split::*;
+
 mod operate_task;
 pub(crate) use operate_task::*;
 

--- a/src/operation/operate_split.rs
+++ b/src/operation/operate_split.rs
@@ -178,7 +178,7 @@ impl<T: 'static + Splittable> ConnectToSplit<T> {
 
         if let Some(previous_index) = previous_index {
             // If something was already using this key then there is a flaw in
-            // the implementation of SplitConnector and we should log it.
+            // the implementation of SplitBuilder and we should log it.
             let target_storage = world.get::<ForkTargetStorage>(self.source).or_broken()?;
             let previous_target = *target_storage.0.get(previous_index).or_broken()?;
 

--- a/src/operation/operate_split.rs
+++ b/src/operation/operate_split.rs
@@ -147,7 +147,7 @@ impl<T: 'static + Splittable> Command for ConnectToSplit<T> {
         let node = self.source;
         if let Err(OperationError::Broken(backtrace)) = self.connect(world) {
             world
-                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .get_resource_or_insert_with(UnhandledErrors::default)
                 .broken
                 .push(Broken { node, backtrace });
         }
@@ -173,7 +173,7 @@ impl<T: 'static + Splittable> ConnectToSplit<T> {
             .outputs_cache
             .as_mut()
             .or_broken()?
-            .resize_with(index + 1, || Vec::new());
+            .resize_with(index + 1, Vec::new);
         if split.index_to_key.len() != index {
             // If the next element of the reverse map does not match the new index
             // then something has fallen out of sync. This doesn't really break
@@ -181,7 +181,7 @@ impl<T: 'static + Splittable> ConnectToSplit<T> {
             // disposal messages, but it does indicate a bug is present.
             let reverse_map_size = split.index_to_key.len();
             world
-                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .get_resource_or_insert_with(UnhandledErrors::default)
                 .miscellaneous
                 .push(MiscellaneousFailure {
                     error: Arc::new(anyhow::anyhow!(
@@ -204,7 +204,7 @@ impl<T: 'static + Splittable> ConnectToSplit<T> {
             let previous_target = *target_storage.0.get(previous_index).or_broken()?;
 
             world
-                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .get_resource_or_insert_with(UnhandledErrors::default)
                 .miscellaneous
                 .push(MiscellaneousFailure {
                     error: Arc::new(anyhow::anyhow!(

--- a/src/operation/operate_split.rs
+++ b/src/operation/operate_split.rs
@@ -152,6 +152,8 @@ impl<T: 'static + Splittable> ConnectToSplit<T> {
         let index = target_storage.0.len();
         target_storage.0.push(self.target);
 
+        world.get_entity_mut(self.target).or_broken()?.insert(SingleInputStorage::new(self.source));
+
         let mut split = world.get_mut::<OperateSplit<T>>(self.source).or_broken()?;
         let previous_index = split.connections.insert(self.key.clone(), index);
         split.outputs_cache.as_mut().or_broken()?.resize_with(index + 1, || Vec::new());

--- a/src/operation/operate_split.rs
+++ b/src/operation/operate_split.rs
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use std::{
+    sync::Arc,
+    collections::HashMap,
+};
+use bevy_ecs::{
+    prelude::{Component, Entity, World},
+    system::Command,
+};
+use smallvec::SmallVec;
+
+use crate::{
+    Splittable, Broken, OrBroken, UnhandledErrors, Operation, OperationCleanup, OperationError,
+    OperationSetup, OperationResult, OperationReachability, OperationRequest, ReachabilityResult,
+    ForkTargetStorage, MiscellaneousFailure, InputBundle, ManageInput, Input,
+    SplitDispatcher, Disposal, ManageDisposal, SingleInputStorage,
+};
+
+#[derive(Component)]
+pub(crate) struct OperateSplit<T: Splittable> {
+    /// The connections that lead out of this split operation. These only change
+    /// while the workflow is being built, afterwards they should be frozen.
+    connections: HashMap<T::Key, usize>,
+    /// A reverse map that keeps track of what key is at each index
+    index_to_key: Vec<Arc<str>>,
+    /// A cache used to transfer the split values from the input to the outputs.
+    /// Every iteration this must be reset to all None values. If any one of them
+    /// is a None after the Splittable has filled it in, we must issue a disposal
+    /// notice because one of the outputs might not be receiving anything.
+    outputs_cache: Option<Vec<Vec<T::Item>>>,
+}
+
+impl<T: Splittable> Default for OperateSplit<T> {
+    fn default() -> Self {
+        Self {
+            connections: Default::default(),
+            index_to_key: Vec::new(),
+            outputs_cache: Some(Vec::new()),
+        }
+    }
+}
+
+impl<T: 'static + Splittable + Send + Sync> Operation for OperateSplit<T> {
+    fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
+        world
+            .entity_mut(source)
+            .insert((
+                self,
+                InputBundle::<T>::new(),
+                ForkTargetStorage::default(),
+            ));
+        Ok(())
+    }
+
+    fn execute(
+        OperationRequest { source, world, roster }: OperationRequest,
+    ) -> OperationResult {
+        let mut source_mut = world.get_entity_mut(source).or_broken()?;
+        let Input { session, data } = source_mut.take_input::<T>()?;
+        let targets = source_mut.get::<ForkTargetStorage>().or_broken()?.0.clone();
+
+        let mut split = source_mut.get_mut::<OperateSplit<T>>().or_broken()?;
+        let mut outputs = split.outputs_cache.take().unwrap_or(Vec::new());
+        let dispatcher = SplitDispatcher {
+            connections: &split.connections,
+            outputs: &mut outputs,
+        };
+        data.split(dispatcher)?;
+
+        let mut missed_indices: SmallVec<[usize; 16]> = SmallVec::new();
+        for (index, (items, target)) in outputs.iter_mut().zip(targets).enumerate() {
+            if items.is_empty() {
+                missed_indices.push(index);
+            }
+
+            for output in items.drain(..) {
+                world
+                    .get_entity_mut(target)
+                    .or_broken()?
+                    .give_input(session, output, roster)?;
+            }
+        }
+
+        let mut source_mut = world.get_entity_mut(source).or_broken()?;
+
+        if !missed_indices.is_empty() {
+            let split = source_mut.get::<OperateSplit<T>>().or_broken()?;
+            let missing_keys: SmallVec<[Option<Arc<str>>; 16]> = missed_indices.into_iter()
+                .map(|index| split.index_to_key.get(index).cloned())
+                .collect();
+
+            source_mut.emit_disposal(session, Disposal::incomplete_split(source, missing_keys), roster);
+        }
+
+        // Return the cache into the component
+        source_mut.get_mut::<OperateSplit<T>>().or_broken()?.outputs_cache.replace(outputs);
+
+        Ok(())
+    }
+
+    fn cleanup(mut clean: OperationCleanup) -> OperationResult {
+        clean.cleanup_inputs::<T>()?;
+        clean.notify_cleaned()
+    }
+
+    fn is_reachable(mut reachability: OperationReachability) -> ReachabilityResult {
+        if reachability.has_input::<T>()? {
+            return Ok(true);
+        }
+
+        SingleInputStorage::is_reachable(&mut reachability)
+    }
+}
+
+pub(crate) struct ConnectToSplit<T: Splittable> {
+    pub(crate) source: Entity,
+    pub(crate) target: Entity,
+    pub(crate) key: T::Key,
+}
+
+impl<T: 'static + Splittable> Command for ConnectToSplit<T> {
+    fn apply(self, world: &mut World) {
+        let node = self.source;
+        if let Err(OperationError::Broken(backtrace)) = self.connect(world) {
+            world
+                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .broken
+                .push(Broken { node, backtrace });
+        }
+    }
+}
+
+impl<T: 'static + Splittable> ConnectToSplit<T> {
+    fn connect(self, world: &mut World) -> Result<(), OperationError> {
+        let mut target_storage = world.get_mut::<ForkTargetStorage>(self.source).or_broken()?;
+        let index = target_storage.0.len();
+        target_storage.0.push(self.target);
+
+        let mut split = world.get_mut::<OperateSplit<T>>(self.source).or_broken()?;
+        let previous_index = split.connections.insert(self.key.clone(), index);
+        split.outputs_cache.as_mut().or_broken()?.resize_with(index + 1, || Vec::new());
+        if split.index_to_key.len() != index {
+            // If the next element of the reverse map does not match the new index
+            // then something has fallen out of sync. This doesn't really break
+            // the workflow because this reverse map is only used to generate
+            // disposal messages, but it does indicate a bug is present.
+            let reverse_map_size = split.index_to_key.len();
+            world
+                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .miscellaneous
+                .push(MiscellaneousFailure {
+                    error: Arc::new(anyhow::anyhow!(
+                        "Mismatch between reverse map size [{}] and new connection index [{}]",
+                        reverse_map_size,
+                        index,
+                    )),
+                    backtrace: Some(backtrace::Backtrace::new()),
+                });
+        } else {
+            split.index_to_key.push(format!("{:?}", self.key).as_str().into());
+        }
+
+        if let Some(previous_index) = previous_index {
+            // If something was already using this key then there is a flaw in
+            // the implementation of SplitConnector and we should log it.
+            let target_storage = world.get::<ForkTargetStorage>(self.source).or_broken()?;
+            let previous_target = *target_storage.0.get(previous_index).or_broken()?;
+
+            world
+                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .miscellaneous
+                .push(MiscellaneousFailure {
+                    error: Arc::new(anyhow::anyhow!(
+                        "Double-connected key [{:?}] for split node {:?}. Original target: {:?}, new target: {:?}",
+                        self.key,
+                        self.source,
+                        previous_target,
+                        self.target,
+                    )),
+                    backtrace: Some(backtrace::Backtrace::new()),
+                });
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR introduces a new operation: split.

Split fills in a gap that has existed between unzip and spread:
* unzip breaks apart a tuple and allows each element to be sent to a different connection
* spread separates the elements of a collection and feeds them to a single connection one at a time

Split is like an unzip that acts on collections. The split operation supports keys that you can latch downstream connections onto. The nature of these keys can vary based on the specific type of data that is being split. For example splitting a list-like object lets you make different connections based on the sequence of items, while splitting a map-like object lets you make different connections based on specific keys in the map and/or based on the order that items appear in the map.

Unlike unzip, all items produced in a split have to have the same output type. This will be the core differentiator between the two operations.

@koonpeng after this is merged in to main, I'll merge it into your branch for #27 and then I'll implement `split` for `serde_json::Value`. After that I think we shouldn't need to worry about unzip for serialized workflows: If users want to split a value, they can serialize it, split it, then deserialize it. We can mandate (at least for our initial releases) that values which can't be serialized also can't be split/unzipped by a serialized workflow.