### PR TITLE
WIP: Fix 1.75 build failure / add CI

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -31,3 +31,11 @@ jobs:
       run: cargo build --features single_threaded_async
     - name: Test single_threaded_async
       run: cargo test --features single_threaded_async
+
+    # Build and test with 1.75
+    - name: Install Rust 1.75
+      run: rustup default 1.75
+    - name: Build default features with Rust 1.75
+      run: cargo build
+    - name: Test default features with Rust 1.75
+      run: cargo test

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -532,7 +532,12 @@ impl<T: 'static + Send + Sync, const N: usize> Splittable for [T; N] {
 
     fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
         // Static arrays have a firm limit of N
-        SplitAsList::<Self>::next(key).take_if(|key| Self::validate(key))
+        let mut key = SplitAsList::<Self>::next(key);
+        if key.map_or(false, |key| Self::validate(&key)) {
+            key.take()
+        } else {
+            None
+        }
     }
 
     fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -941,4 +941,49 @@ mod tests {
         assert_eq!(result["fib"], input_map["fib"]);
         assert_eq!(result["dib"], input_map["dib"]);
     }
+
+    #[test]
+    fn test_array_split_limit() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            scope.input.chain(builder).split(|split| {
+                let err = split
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    // This last one should fail because it should exceed the
+                    // array limit
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    });
+
+                assert!(matches!(err, Err(_)));
+            })
+        });
+
+        let mut promise =
+            context.command(|commands| commands.request([1, 2, 3, 4], workflow).take_response());
+
+        context.run_with_conditions(&mut promise, 1);
+        assert!(context.no_unhandled_errors());
+
+        let result = promise.take().available().unwrap();
+        // All the values in the array are racing to finish, but the first value
+        // should finish first since it will naturally get queued first.
+        assert_eq!(result, 1);
+    }
 }


### PR DESCRIPTION
`take_if` is only stable in Rust 1.80 so removed it inspired on its [implementation in the standard library](https://doc.rust-lang.org/src/core/option.rs.html#1758-1760).

I don't think that is really covered by tests since I had a first implementation that was wrong and it was not caught by `cargo test` so big :warning: there.
I also added a few steps to the Linux CI to install and try Rust 1.75, happy to put it in a different workflow if that is a better option