### PR TITLE
Implement Split for json_serde::Value

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -608,7 +608,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// will insert a split operation and provide your `build` function with the
     /// [`SplitBuilder`] for it. This returns the return value of your build
     /// function.
-    pub fn split<U>(self, build: impl FnOnce(SplitBuilder<T>) -> U) -> U
+    pub fn split<U>(self, build: impl FnOnce(SplitBuilder<'w, 's, 'a, 'b, T>) -> U) -> U
     where
         T: Splittable,
     {
@@ -644,7 +644,10 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// ```text
     /// .map_block(SplitAsList::new).split(build)
     /// ```
-    pub fn split_as_list<U>(self, build: impl FnOnce(SplitBuilder<SplitAsList<T>>) -> U) -> U
+    pub fn split_as_list<U>(
+        self,
+        build: impl FnOnce(SplitBuilder<'w, 's, 'a, 'b, SplitAsList<T>>) -> U,
+    ) -> U
     where
         T: IntoIterator,
         T::Item: 'static + Send + Sync,
@@ -1026,7 +1029,10 @@ where
     /// ```text
     /// .map_block(SplitAsMap::new).split(build)
     /// ```
-    pub fn split_as_map<U>(self, build: impl FnOnce(SplitBuilder<SplitAsMap<K, V, T>>) -> U) -> U {
+    pub fn split_as_map<U>(
+        self,
+        build: impl FnOnce(SplitBuilder<'w, 's, 'a, 'b, SplitAsMap<K, V, T>>) -> U,
+    ) -> U {
         self.map_block(SplitAsMap::new).split(build)
     }
 

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -561,6 +561,22 @@ impl<K> MapSplitKey<K> {
             _ => None,
         }
     }
+
+    pub fn next(this: &Option<Self>) -> Option<Self> {
+        match this {
+            Some(key) => {
+                match key {
+                    // Give the next key in the sequence
+                    MapSplitKey::Sequential(index) => Some(MapSplitKey::Sequential(index + 1)),
+                    // For an arbitrary map we don't know what would follow a specific key, so
+                    // just stop iterating. This should never be reached in practice anyway.
+                    MapSplitKey::Specific(_) => None,
+                    MapSplitKey::Remaining => None,
+                }
+            }
+            None => Some(MapSplitKey::Sequential(0)),
+        }
+    }
 }
 
 impl<K> From<K> for MapSplitKey<K> {
@@ -632,19 +648,7 @@ where
     }
 
     fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
-        match key {
-            Some(key) => {
-                match key {
-                    // Give the next key in the sequence
-                    MapSplitKey::Sequential(index) => Some(MapSplitKey::Sequential(index + 1)),
-                    // For an arbitrary map we don't know what would follow a specific key, so
-                    // just stop iterating. This should never be reached in practice anyway.
-                    MapSplitKey::Specific(_) => None,
-                    MapSplitKey::Remaining => None,
-                }
-            }
-            None => Some(MapSplitKey::Sequential(0)),
-        }
+        MapSplitKey::next(key)
     }
 
     fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -1,10 +1,12 @@
 mod node_registry;
 mod serialization;
+mod split_serialized;
 mod workflow_builder;
 
 use log::debug;
 pub use node_registry::*;
 pub use serialization::*;
+pub use split_serialized::*;
 pub use workflow_builder::*;
 
 // ----------

--- a/src/diagram/split_serialized.rs
+++ b/src/diagram/split_serialized.rs
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{MapSplitKey, OperationResult, SplitDispatcher, Splittable};
+
+impl Splittable for Value {
+    type Key = MapSplitKey<String>;
+    type Item = (JsonPosition, Value);
+
+    fn validate(_: &Self::Key) -> bool {
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        MapSplitKey::next(key)
+    }
+
+    fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        match self {
+            Value::Array(array) => {
+                for (index, value) in array.into_iter().enumerate() {
+                    let position = JsonPosition::ArrayElement(index);
+                    match dispatcher.outputs_for(&MapSplitKey::Sequential(index)) {
+                        Some(outputs) => {
+                            outputs.push((position, value));
+                        }
+                        None => {
+                            if let Some(outputs) = dispatcher.outputs_for(&MapSplitKey::Remaining) {
+                                outputs.push((position, value));
+                            }
+                        }
+                    }
+                }
+            }
+            Value::Object(map) => {
+                let mut next_seq = 0;
+                for (name, value) in map.into_iter() {
+                    let key = MapSplitKey::Specific(name);
+                    match dispatcher.outputs_for(&key) {
+                        Some(outputs) => {
+                            let position = JsonPosition::ObjectField(key.specific().unwrap());
+                            outputs.push((position, value));
+                        }
+                        None => {
+                            // No connection to the specific field name, so let's
+                            // check for a sequential connection.
+                            let seq = MapSplitKey::Sequential(next_seq);
+                            next_seq += 1;
+
+                            let position = JsonPosition::ObjectField(key.specific().unwrap());
+                            match dispatcher.outputs_for(&seq) {
+                                Some(outputs) => outputs.push((position, value)),
+                                None => {
+                                    // No connection to this point in the sequence
+                                    // so let's send it to any remaining connection.
+                                    let remaining = MapSplitKey::Remaining;
+                                    if let Some(outputs) = dispatcher.outputs_for(&remaining) {
+                                        outputs.push((position, value));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            singular => {
+                // This is a singular value, so it cannot be split. We will
+                // send it to the first sequential connection or else to the
+                // remaining connection.
+                let position = JsonPosition::Singular;
+                match dispatcher.outputs_for(&MapSplitKey::Sequential(0)) {
+                    Some(outputs) => outputs.push((position, singular)),
+                    None => {
+                        let remaining = MapSplitKey::Remaining;
+                        if let Some(outputs) = dispatcher.outputs_for(&remaining) {
+                            outputs.push((position, singular));
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Where was this positioned within the JSON structure.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum JsonPosition {
+    /// This was the only item, e.g. the [`Value`] was a [`Null`][Value::Null],
+    /// [`Bool`][Value::Bool], [`Number`][Value::Number], or [`String`][Value::String].
+    Singular,
+    /// The item came from an array.
+    ArrayElement(usize),
+    /// The item was a field of an object.
+    ObjectField(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{testing::*, *};
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+
+    #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+    struct Person {
+        name: String,
+        age: i8,
+    }
+
+    impl Person {
+        fn new(name: impl Into<String>, age: i8) -> Self {
+            Self {
+                name: name.into(),
+                age,
+            }
+        }
+    }
+
+    #[test]
+    fn test_json_value_split() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let value = json!(
+            {
+                "foo": 10,
+                "bar": "hello",
+                "jobs": {
+                    "engineer": {
+                        "name": "Alice",
+                        "age": 28,
+                    },
+                    "designer": {
+                        "name": "Bob",
+                        "age": 67,
+                    }
+                }
+            }
+        );
+
+        // Test multiple layers of splitting
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            scope.input.chain(builder).split(|split| {
+                split
+                    // Get only the jobs data from the json
+                    .specific_branch("jobs".to_owned(), |chain| {
+                        chain.value().split(|jobs| {
+                            jobs
+                                // Grab the "first" job in the list, which should be
+                                // alphabetical by default, so we should get the
+                                // "designer" job.
+                                .next_branch(|_, person| {
+                                    person
+                                        .value()
+                                        .map_block(serde_json::from_value)
+                                        .cancel_on_err()
+                                        .connect(scope.terminate);
+                                })
+                                .unwrap()
+                                .unused();
+                        });
+                    })
+                    .unwrap()
+                    .unused();
+            });
+        });
+
+        let mut promise =
+            context.command(|commands| commands.request(value, workflow).take_response());
+
+        context.run_with_conditions(&mut promise, 1);
+        assert!(context.no_unhandled_errors());
+
+        let result: Person = promise.take().available().unwrap();
+        assert_eq!(result, Person::new("Bob", 67));
+
+        // Test serializing and splitting a tuple, then deserializing the split item
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            scope
+                .input
+                .chain(builder)
+                .map_block(serde_json::to_value)
+                .cancel_on_err()
+                .split(|split| {
+                    split
+                        // The second branch of our test input should have
+                        // seralized Person data
+                        .sequential_branch(1, |chain| {
+                            chain
+                                .value()
+                                .map_block(serde_json::from_value)
+                                .cancel_on_err()
+                                .connect(scope.terminate);
+                        })
+                        .unwrap()
+                        .unused();
+                });
+        });
+
+        let mut promise = context.command(|commands| {
+            commands
+                .request((3.14159, Person::new("Charlie", 42)), workflow)
+                .take_response()
+        });
+
+        context.run_with_conditions(&mut promise, 1);
+        assert!(context.no_unhandled_errors());
+
+        let result: Person = promise.take().available().unwrap();
+        assert_eq!(result, Person::new("Charlie", 42));
+    }
+}


### PR DESCRIPTION
This PR implements the new split operation for `serde_json::Value`. I also cleaned up two more things while working on that:
* Give explicit lifetimes to `Chain::split` operations so the `FnOnce` build functions could output something that utilizes those lifetimes
* Refactor `SplitAsMap::next` so that anything using `MapSplitKey` can take advantage of the premade `next` for it.