### PR TITLE
Expand lifetimes of SplitBuilder

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -608,7 +608,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// will insert a split operation and provide your `build` function with the
     /// [`SplitBuilder`] for it. This returns the return value of your build
     /// function.
-    pub fn split<U>(self, build: impl FnOnce(SplitBuilder<T>) -> U) -> U
+    pub fn split<U>(self, build: impl FnOnce(SplitBuilder<'w, 's, 'a, 'b, T>) -> U) -> U
     where
         T: Splittable,
     {
@@ -644,7 +644,10 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// ```text
     /// .map_block(SplitAsList::new).split(build)
     /// ```
-    pub fn split_as_list<U>(self, build: impl FnOnce(SplitBuilder<SplitAsList<T>>) -> U) -> U
+    pub fn split_as_list<U>(
+        self,
+        build: impl FnOnce(SplitBuilder<'w, 's, 'a, 'b, SplitAsList<T>>) -> U,
+    ) -> U
     where
         T: IntoIterator,
         T::Item: 'static + Send + Sync,
@@ -1026,7 +1029,10 @@ where
     /// ```text
     /// .map_block(SplitAsMap::new).split(build)
     /// ```
-    pub fn split_as_map<U>(self, build: impl FnOnce(SplitBuilder<SplitAsMap<K, V, T>>) -> U) -> U {
+    pub fn split_as_map<U>(
+        self,
+        build: impl FnOnce(SplitBuilder<'w, 's, 'a, 'b, SplitAsMap<K, V, T>>) -> U,
+    ) -> U {
         self.map_block(SplitAsMap::new).split(build)
     }
 

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -566,6 +566,22 @@ impl<K> MapSplitKey<K> {
             _ => None,
         }
     }
+
+    pub fn next(this: &Option<Self>) -> Option<Self> {
+        match this {
+            Some(key) => {
+                match key {
+                    // Give the next key in the sequence
+                    MapSplitKey::Sequential(index) => Some(MapSplitKey::Sequential(index + 1)),
+                    // For an arbitrary map we don't know what would follow a specific key, so
+                    // just stop iterating. This should never be reached in practice anyway.
+                    MapSplitKey::Specific(_) => None,
+                    MapSplitKey::Remaining => None,
+                }
+            }
+            None => Some(MapSplitKey::Sequential(0)),
+        }
+    }
 }
 
 impl<K> From<K> for MapSplitKey<K> {
@@ -637,19 +653,7 @@ where
     }
 
     fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
-        match key {
-            Some(key) => {
-                match key {
-                    // Give the next key in the sequence
-                    MapSplitKey::Sequential(index) => Some(MapSplitKey::Sequential(index + 1)),
-                    // For an arbitrary map we don't know what would follow a specific key, so
-                    // just stop iterating. This should never be reached in practice anyway.
-                    MapSplitKey::Specific(_) => None,
-                    MapSplitKey::Remaining => None,
-                }
-            }
-            None => Some(MapSplitKey::Sequential(0)),
-        }
+        MapSplitKey::next(key)
     }
 
     fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {


### PR DESCRIPTION
This spins out some changes to `split` that were introduced by #35 and redirects the changes at `main`.