### PR TITLE
fix broken doc link

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustdocflags = ["-D", "warnings"]

--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -38,3 +38,6 @@ jobs:
     - name: Test single_threaded_async
       run: cargo test --features single_threaded_async
 
+    - name: Build docs
+      run: cargo doc
+

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -259,7 +259,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Splittable> Iterator for SplitBuilder<'w, 's, 
 
 /// This tracks the connections that have been made to a split. This can be
 /// retrieved from [`SplitBuilder`] by calling [`SplitBuilder::outputs`].
-/// You can then continue building connections by calling [`SplitBuilder::build`].
+/// You can then continue building connections by calling [`SplitOutputs::build`].
 #[must_use]
 pub struct SplitOutputs<T: Splittable> {
     scope: Entity,


### PR DESCRIPTION
Fix broken doc link in `split.rs`. Also build docs in CI to catch similar errors in the future.