### PR TITLE
Merge main into 0.1 release branch

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustdocflags = ["-D", "warnings"]

--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -16,17 +16,10 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        rust-version: [stable, 1.75]
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Setup rust
-      run: rustup default ${{ matrix.rust-version }}
 
     - name: Build default features
       run: cargo build

--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -16,11 +16,17 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        rust-version: [stable, 1.75]
 
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
+
+    - name: Setup rust
+      run: rustup default ${{ matrix.rust-version }}
 
     - name: Build default features
       run: cargo build
@@ -31,3 +37,7 @@ jobs:
       run: cargo build --features single_threaded_async
     - name: Test single_threaded_async
       run: cargo test --features single_threaded_async
+
+    - name: Build docs
+      run: cargo doc
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["reactive", "workflow", "behavior", "agent", "bevy"]
 categories = ["science::robotics", "asynchronous", "concurrency", "game-development"]
 
 [dependencies]
-bevy_impulse_derive = { path = "macros", version = "0.0.1" }
+bevy_impulse_derive = { path = "macros", version = "0.0.2" }
 bevy_ecs = "0.13"
 bevy_utils = "0.13"
 bevy_hierarchy = "0.13"
@@ -25,7 +25,6 @@ async-task = { version = "4.7.1", optional = true }
 # bevy_tasks::Task, so we're leaving it as a mandatory dependency for now.
 bevy_tasks = { version = "0.13", features = ["multi-threaded"] }
 
-arrayvec = "0.7"
 itertools = "0.13"
 smallvec = "1.13"
 tokio = { version = "1.39", features = ["sync"]}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+[![style](https://github.com/open-rmf/bevy_impulse/actions/workflows/style.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/style.yaml)
+[![ci_linux](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_linux.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_linux.yaml)
+[![ci_windows](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_windows.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_windows.yaml)
+[![ci_web](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_web.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_web.yaml)
+
 # Reactive Programming for Bevy
 
 This library provides sophisticated [reactive programming](https://en.wikipedia.org/wiki/Reactive_programming) for the [bevy](https://bevyengine.org/) ECS. In addition to supporting one-shot chains of async operations, it can support reusable workflows with parallel branches, synchronization, races, and cycles. These workflows can be hierarchical, so a workflow can be used as a building block by other workflows.

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_impulse_derive"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["Grey <mxgrey@intrinsic.ai>"]
 license = "Apache-2.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -24,11 +24,36 @@ pub fn simple_stream_macro(item: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(item).unwrap();
     let struct_name = &ast.ident;
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
-    // let bevy_impulse_path: Path =
 
     quote! {
-        impl #impl_generics Stream for #struct_name #type_generics #where_clause {
+        impl #impl_generics ::bevy_impulse::Stream for #struct_name #type_generics #where_clause {
             type Container = ::bevy_impulse::DefaultStreamContainer<Self>;
+        }
+    }
+    .into()
+}
+
+#[proc_macro_derive(DeliveryLabel)]
+pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(item).unwrap();
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::bevy_impulse::DeliveryLabel for #struct_name #type_generics #where_clause {
+            fn dyn_clone(&self) -> Box<dyn DeliveryLabel> {
+                ::std::boxed::Box::new(::std::clone::Clone::clone(self))
+            }
+
+            fn as_dyn_eq(&self) -> &dyn ::bevy_impulse::utils::DynEq {
+                self
+            }
+
+            fn dyn_hash(&self, mut state: &mut dyn ::std::hash::Hasher) {
+                let ty_id = ::std::any::TypeId::of::<Self>();
+                ::std::hash::Hash::hash(&ty_id, &mut state);
+                ::std::hash::Hash::hash(self, &mut state);
+            }
         }
     }
     .into()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -26,9 +26,10 @@ use crate::{
     AddOperation, AsMap, BeginCleanupWorkflow, Buffer, BufferItem, BufferKeys, BufferSettings,
     Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
     GateRequest, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Node, OperateBuffer,
-    OperateBufferAccess, OperateDynamicGate, OperateScope, OperateStaticGate, Output, Provider,
-    RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage,
-    Sendish, Service, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
+    OperateBufferAccess, OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output,
+    Provider, RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings,
+    ScopeSettingsStorage, Sendish, Service, SplitOutputs, Splittable, StreamPack, StreamTargetMap,
+    StreamsOfMap, Trim, TrimBranch, UnusedTarget,
 };
 
 pub(crate) mod connect;
@@ -337,6 +338,26 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         T: 'static + Send + Sync,
     {
         self.create_collect(n, Some(n))
+    }
+
+    /// Create a new split operation in the workflow. The [`InputSlot`] can take
+    /// in values that you want to split, and [`SplitOutputs::build`] will let
+    /// you build connections to the split value.
+    pub fn create_split<T>(&mut self) -> (InputSlot<T>, SplitOutputs<T>)
+    where
+        T: 'static + Send + Sync + Splittable,
+    {
+        let source = self.commands.spawn(()).id();
+        self.commands.add(AddOperation::new(
+            Some(self.scope),
+            source,
+            OperateSplit::<T>::default(),
+        ));
+
+        (
+            InputSlot::new(self.scope, source),
+            SplitOutputs::new(self.scope, source),
+        )
     }
 
     /// This method allows you to define a cleanup workflow that branches off of
@@ -938,11 +959,15 @@ mod tests {
         let mut promise = context.command(|commands| commands.request(5, workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(2));
+        assert!(
+            context.no_unhandled_errors(),
+            "{:#?}",
+            context.get_unhandled_errors(),
+        );
         assert!(promise.peek().is_cancelled());
         let channel_output = receiver.try_recv().unwrap();
         assert_eq!(channel_output, 5);
         assert!(receiver.try_recv().is_err());
-        assert!(context.no_unhandled_errors());
         assert!(context.confirm_buffers_empty().is_ok());
 
         let (cancel_sender, mut cancel_receiver) = unbounded_channel();

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -1,0 +1,993 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_ecs::prelude::Entity;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Debug,
+    hash::Hash,
+};
+use thiserror::Error as ThisError;
+
+use crate::{Builder, Chain, ConnectToSplit, OperationResult, Output, UnusedTarget};
+
+/// Implementing this trait on a struct will allow the [`Chain::split`] operation
+/// to be performed on [outputs][crate::Output] of that type.
+pub trait Splittable: Sized {
+    /// The key used to identify different elements in the split
+    type Key: 'static + Send + Sync + Eq + Hash + Clone + Debug;
+
+    /// The type that the value gets split into
+    type Item: 'static + Send + Sync;
+
+    /// Return true if the key is feasible for this type of split, otherwise
+    /// return false. Returning false will cause the user to receive a
+    /// [`SplitConnectionError::KeyOutOfBounds`]. This will also cause iterating
+    /// to cease.
+    fn validate(key: &Self::Key) -> bool;
+
+    /// Get the next key value that would follow the provided one. If [`None`]
+    /// is passed in then return the first key. If you return [`None`] then
+    /// the connections will stop iterating.
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key>;
+
+    /// Split the value into its parts
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult;
+}
+
+/// This is returned by [`Chain::split`] and allows you to connect to the
+/// split pieces.
+#[must_use]
+pub struct SplitBuilder<'w, 's, 'a, 'b, T: Splittable> {
+    outputs: SplitOutputs<T>,
+    builder: &'b mut Builder<'w, 's, 'a>,
+}
+
+impl<'w, 's, 'a, 'b, T: Splittable> std::fmt::Debug for SplitBuilder<'w, 's, 'a, 'b, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SplitBuilder")
+            .field("outputs", &self.outputs)
+            .finish()
+    }
+}
+
+impl<'w, 's, 'a, 'b, T: 'static + Splittable> SplitBuilder<'w, 's, 'a, 'b, T> {
+    /// Get the state of connections for this split. You can resume building
+    /// more connections later by calling [`SplitOutputs::build`] on the
+    /// connections.
+    pub fn outputs(self) -> SplitOutputs<T> {
+        self.outputs
+    }
+
+    /// Unpack the split outputs from the builder so the two can be used
+    /// independently.
+    pub fn unpack(self) -> (SplitOutputs<T>, &'b mut Builder<'w, 's, 'a>) {
+        (self.outputs, self.builder)
+    }
+
+    /// Build a branch for one of the keys in the split.
+    pub fn branch_for(
+        mut self,
+        key: T::Key,
+        f: impl FnOnce(Chain<T::Item>),
+    ) -> SplitChainResult<'w, 's, 'a, 'b, T> {
+        let output = match self.output_for(key) {
+            Ok(output) => output,
+            Err(err) => return Err((self, err)),
+        };
+        f(output.chain(self.builder));
+        Ok(self)
+    }
+
+    /// This is a convenience function for splits whose keys implement
+    /// [`FromSpecific`] to build a branch for a specific key in the split. This
+    /// can be used by [`MapSplitKey`].
+    pub fn specific_branch(
+        self,
+        specific_key: <T::Key as FromSpecific>::SpecificKey,
+        f: impl FnOnce(Chain<T::Item>),
+    ) -> SplitChainResult<'w, 's, 'a, 'b, T>
+    where
+        T::Key: FromSpecific,
+    {
+        self.branch_for(T::Key::from_specific(specific_key), f)
+    }
+
+    /// This is a convenience function for splits whose keys implement
+    /// [`FromSequential`] to build a branch for an anonymous sequential key in
+    /// the split. This can be used by [`ListSplitKey`] and [`MapSplitKey`].
+    pub fn sequential_branch(
+        self,
+        sequence_number: usize,
+        f: impl FnOnce(Chain<T::Item>),
+    ) -> SplitChainResult<'w, 's, 'a, 'b, T>
+    where
+        T::Key: FromSequential,
+    {
+        self.branch_for(T::Key::from_sequential(sequence_number), f)
+    }
+
+    /// This is a convenience function for splits whose keys implement
+    /// [`ForRemaining`] to build a branch that takes in all items that did not
+    /// have a more specific connection available. This can be used by
+    /// [`ListSplitKey`] and [`MapSplitKey`].
+    ///
+    /// This can only be set once, so subsequent attempts to set the remaining
+    /// branch will return an error. It will also return an error after
+    /// [`Self::remaining_output`] has been used.
+    pub fn remaining_branch(
+        self,
+        f: impl FnOnce(Chain<T::Item>),
+    ) -> SplitChainResult<'w, 's, 'a, 'b, T>
+    where
+        T::Key: ForRemaining,
+    {
+        self.branch_for(T::Key::for_remaining(), f)
+    }
+
+    /// Build a branch for the next key in the split, if such a key may
+    /// be available. The first argument tells you what the key would be, but
+    /// you can safely ignore this if it doesn't matter to you.
+    ///
+    /// This changes what the next element will be if you later use this
+    /// [`SplitBuilder`] as an iterator.
+    pub fn next_branch(
+        mut self,
+        f: impl FnOnce(T::Key, Chain<T::Item>),
+    ) -> SplitChainResult<'w, 's, 'a, 'b, T> {
+        let Some((key, output)) = self.next() else {
+            return Err((self, SplitConnectionError::KeyOutOfBounds));
+        };
+
+        f(key, output.chain(self.builder));
+        Ok(self)
+    }
+
+    /// Get the output slot for an element in the split.
+    pub fn output_for(&mut self, key: T::Key) -> Result<Output<T::Item>, SplitConnectionError> {
+        if !T::validate(&key) {
+            return Err(SplitConnectionError::KeyOutOfBounds);
+        }
+
+        if !self.outputs.used.insert(key.clone()) {
+            return Err(SplitConnectionError::KeyAlreadyUsed);
+        }
+
+        let target = self.builder.commands.spawn(UnusedTarget).id();
+        self.builder.commands.add(ConnectToSplit::<T> {
+            source: self.outputs.source,
+            target,
+            key,
+        });
+        Ok(Output::new(self.outputs.scope, target))
+    }
+
+    /// This is a convenience function for splits whose keys implement
+    /// [`FromSpecific`] to get the output for a specific key in the split. This
+    /// can be used by [`MapSplitKey`].
+    pub fn specific_output(
+        &mut self,
+        specific_key: <T::Key as FromSpecific>::SpecificKey,
+    ) -> Result<Output<T::Item>, SplitConnectionError>
+    where
+        T::Key: FromSpecific,
+    {
+        self.output_for(T::Key::from_specific(specific_key))
+    }
+
+    /// This is a convenience function for splits whose keys implement
+    /// [`FromSequential`] to get the output for an anonymous sequential key in
+    /// the split. This can be used by [`ListSplitKey`] and [`MapSplitKey`].
+    pub fn sequential_output(
+        &mut self,
+        sequence_number: usize,
+    ) -> Result<Output<T::Item>, SplitConnectionError>
+    where
+        T::Key: FromSequential,
+    {
+        self.output_for(T::Key::from_sequential(sequence_number))
+    }
+
+    /// This is a convenience function for splits whose keys implement
+    /// [`ForRemaining`] to get the output for all keys remaining without a
+    /// connection after all the more specific connections have been considered.
+    /// This can be used by [`ListSplitKey`] and [`MapSplitKey`].
+    ///
+    /// This can only be used once, after which it will return an error. It will
+    /// also return an error after [`Self::remaining_branch`] has been used.
+    pub fn remaining_output(&mut self) -> Result<Output<T::Item>, SplitConnectionError>
+    where
+        T::Key: ForRemaining,
+    {
+        self.output_for(T::Key::for_remaining())
+    }
+
+    /// Explicitly stop building the split by indicating that you it to remain
+    /// unused.
+    pub fn unused(self) {
+        // Do nothing
+    }
+
+    /// Used internally to create a new split connector
+    pub(crate) fn new(source: Entity, builder: &'b mut Builder<'w, 's, 'a>) -> Self {
+        Self {
+            outputs: SplitOutputs::new(builder.scope, source),
+            builder,
+        }
+    }
+}
+
+impl<'w, 's, 'a, 'b, T: 'static + Splittable> Iterator for SplitBuilder<'w, 's, 'a, 'b, T> {
+    type Item = (T::Key, Output<T::Item>);
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next_key = T::next(&self.outputs.last_key)?;
+            self.outputs.last_key = Some(next_key.clone());
+
+            match self.output_for(next_key.clone()) {
+                Ok(output) => {
+                    return Some((next_key, output));
+                }
+                Err(SplitConnectionError::KeyAlreadyUsed) => {
+                    // Restart the loop and get the next key which might not be
+                    // used yet.
+                    continue;
+                }
+                Err(SplitConnectionError::KeyOutOfBounds) => {
+                    // We have reached the end of the valid range so just quit
+                    // iterating.
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+/// This tracks the connections that have been made to a split. This can be
+/// retrieved from [`SplitBuilder`] by calling [`SplitBuilder::outputs`].
+/// You can then continue building connections by calling [`SplitOutputs::build`].
+#[must_use]
+pub struct SplitOutputs<T: Splittable> {
+    scope: Entity,
+    source: Entity,
+    last_key: Option<T::Key>,
+    used: HashSet<T::Key>,
+}
+
+impl<T: Splittable> std::fmt::Debug for SplitOutputs<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct(&format!("SplitOutputs<{}>", std::any::type_name::<T>()))
+            .field("scope", &self.scope)
+            .field("source", &self.source)
+            .field("last_key", &self.last_key)
+            .field("used", &self.used)
+            .finish()
+    }
+}
+
+impl<T: Splittable> SplitOutputs<T> {
+    /// Resume building connections for this split.
+    pub fn build<'w, 's, 'a, 'b>(
+        self,
+        builder: &'b mut Builder<'w, 's, 'a>,
+    ) -> SplitBuilder<'w, 's, 'a, 'b, T> {
+        assert_eq!(self.scope, builder.scope);
+        SplitBuilder {
+            outputs: self,
+            builder,
+        }
+    }
+
+    pub(crate) fn new(scope: Entity, source: Entity) -> Self {
+        Self {
+            scope,
+            source,
+            last_key: None,
+            used: Default::default(),
+        }
+    }
+}
+
+/// This is a type alias for the result returned by chainable [`SplitBuilder`]
+/// functions. If the last connection succeeded, you will receive [`Ok`] with
+/// the [`SplitBuilder`] which you can keep building off of. Otherwise if the
+/// last connection failed, you will receive an [`Err`] with the [`SplitBuilder`]
+/// bundled with [`SplitConnectionError`] to tell you what went wrong. You can
+/// continue building with the [`SplitBuilder`] even if an error occurred.
+///
+/// You can use `ignore_result` from the [`IgnoreSplitChainResult`] trait to
+/// just keep chaining without checking whether the connection suceeded.
+pub type SplitChainResult<'w, 's, 'a, 'b, T> = Result<
+    SplitBuilder<'w, 's, 'a, 'b, T>,
+    (SplitBuilder<'w, 's, 'a, 'b, T>, SplitConnectionError),
+>;
+
+/// A helper trait that allows users to ignore any failures while chaining
+/// connections to a split.
+pub trait IgnoreSplitChainResult<'w, 's, 'a, 'b, T: Splittable> {
+    /// Ignore whether the result of the chaining connection was [`Ok`] or [`Err`]
+    /// and just keep chaining.
+    fn ignore_result(self) -> SplitBuilder<'w, 's, 'a, 'b, T>;
+}
+
+impl<'w, 's, 'a, 'b, T: Splittable> IgnoreSplitChainResult<'w, 's, 'a, 'b, T>
+    for SplitChainResult<'w, 's, 'a, 'b, T>
+{
+    fn ignore_result(self) -> SplitBuilder<'w, 's, 'a, 'b, T> {
+        match self {
+            Ok(split) => split,
+            Err((split, _)) => split,
+        }
+    }
+}
+
+/// Information about why a connection to a split failed
+#[derive(ThisError, Debug, Clone)]
+#[error("An error occurred while trying to connect to a split")]
+pub enum SplitConnectionError {
+    /// The requested index was already connected to.
+    KeyAlreadyUsed,
+    /// The requested index is out of bounds.
+    KeyOutOfBounds,
+}
+
+/// Used by implementers of the [`Splittable`] trait to help them send their
+/// split values to the proper input slots.
+pub struct SplitDispatcher<'a, Key, Item> {
+    pub(crate) connections: &'a HashMap<Key, usize>,
+    pub(crate) outputs: &'a mut Vec<Vec<Item>>,
+}
+
+impl<'a, Key, Item> SplitDispatcher<'a, Key, Item>
+where
+    Key: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    Item: 'static + Send + Sync,
+{
+    /// Get the output buffer a certain key. If there are no connections for the
+    /// given key, then this will return [`None`].
+    ///
+    /// Push items into the output buffer to send them to the input connected to
+    /// this key.
+    pub fn outputs_for<'o>(&'o mut self, key: &Key) -> Option<&'o mut Vec<Item>> {
+        let index = *self.connections.get(key)?;
+
+        if self.outputs.len() <= index {
+            // We do this just in case something bad happened with the cache
+            // that reset its size.
+            self.outputs.resize_with(index + 1, Vec::new);
+        }
+
+        self.outputs.get_mut(index)
+    }
+}
+
+/// Turn a sequence index into a split key. Implemented by [`ListSplitKey`] and
+/// [`MapSplitKey`].
+pub trait FromSequential {
+    /// Convert the sequence index into the split key type.
+    fn from_sequential(seq: usize) -> Self;
+}
+
+/// Get the key that represents all remaining/unspecified keys. Implemented by
+/// [`ListSplitKey`] and [`MapSplitKey`].
+pub trait ForRemaining {
+    /// Get the key for remaining items.
+    fn for_remaining() -> Self;
+}
+
+/// Turn a specific key into a split key. Implemented by [`MapSplitKey`].
+pub trait FromSpecific {
+    /// The specific key type
+    type SpecificKey;
+
+    /// Convert the specific key into the split key type
+    fn from_specific(specific: Self::SpecificKey) -> Self;
+}
+
+/// This enum allows users to key into splittable list-like structures based on
+/// the sequence in which an item appears in the list. It also has an option for
+/// keying into any items that were left over in the sequence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ListSplitKey {
+    /// Key into an item at a specific point in the sequence.
+    Sequential(usize),
+    /// Key into any remaining items that were not covered by the sequential keys.
+    Remaining,
+}
+
+impl FromSequential for ListSplitKey {
+    fn from_sequential(seq: usize) -> Self {
+        ListSplitKey::Sequential(seq)
+    }
+}
+
+impl ForRemaining for ListSplitKey {
+    fn for_remaining() -> Self {
+        ListSplitKey::Remaining
+    }
+}
+
+/// This is a newtype that implements [`Splittable`] for anything that can be
+/// turned into an iterator, but always splits it as if the iterator is list-like.
+///
+/// If used with a map-type (e.g. [`HashMap`] or [BTreeMap]), the items will be
+/// the `(key, value)` pairs of the maps, and the key for the split will be the
+/// order in which the map is iterated through. For [`BTreeMap`] this will always
+/// be a sorted order (e.g. alphabetical or numerical) but for [`HashMap`] this
+/// order can be completely arbitrary and may be unstable.
+pub struct SplitAsList<T: 'static + Send + Sync + IntoIterator> {
+    pub contents: T,
+}
+
+impl<T: 'static + Send + Sync + IntoIterator> SplitAsList<T> {
+    pub fn new(contents: T) -> Self {
+        Self { contents }
+    }
+}
+
+impl<T> Splittable for SplitAsList<T>
+where
+    T: 'static + Send + Sync + IntoIterator,
+    T::Item: 'static + Send + Sync,
+{
+    type Key = ListSplitKey;
+    type Item = (usize, T::Item);
+
+    fn validate(_: &Self::Key) -> bool {
+        // We don't know if there are any restrictions for the iterable, so just
+        // return say all keys are valid
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        if let Some(key) = key {
+            match key {
+                ListSplitKey::Sequential(k) => Some(ListSplitKey::Sequential(*k + 1)),
+                ListSplitKey::Remaining => None,
+            }
+        } else {
+            Some(ListSplitKey::Sequential(0))
+        }
+    }
+
+    fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        for (index, value) in self.contents.into_iter().enumerate() {
+            match dispatcher.outputs_for(&ListSplitKey::Sequential(index)) {
+                Some(outputs) => {
+                    outputs.push((index, value));
+                }
+                None => {
+                    if let Some(outputs) = dispatcher.outputs_for(&ListSplitKey::Remaining) {
+                        outputs.push((index, value));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: 'static + Send + Sync> Splittable for Vec<T> {
+    type Key = ListSplitKey;
+    type Item = (usize, T);
+
+    fn validate(_: &Self::Key) -> bool {
+        // Vec has no restrictions on what index is valid
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsList::<Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsList::new(self).split(dispatcher)
+    }
+}
+
+impl<T: 'static + Send + Sync, const N: usize> Splittable for smallvec::SmallVec<[T; N]> {
+    type Key = ListSplitKey;
+    type Item = (usize, T);
+
+    fn validate(_: &Self::Key) -> bool {
+        // SmallVec has no restrictions on what index is valid
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsList::<Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsList::new(self).split(dispatcher)
+    }
+}
+
+impl<T: 'static + Send + Sync, const N: usize> Splittable for [T; N] {
+    type Key = ListSplitKey;
+    type Item = (usize, T);
+
+    fn validate(key: &Self::Key) -> bool {
+        // Static arrays have a firm limit of N
+        match key {
+            ListSplitKey::Sequential(s) => *s < N,
+            ListSplitKey::Remaining => true,
+        }
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        // Static arrays have a firm limit of N
+        let mut key = SplitAsList::<Self>::next(key);
+        if key.map_or(false, |key| Self::validate(&key)) {
+            key.take()
+        } else {
+            None
+        }
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsList::new(self).split(dispatcher)
+    }
+}
+
+/// This enum allows users to key into splittable map-like structures based on
+/// the presence of a specific value or based on the sequence in which a value
+/// is reached that wasn't associated with a specific key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MapSplitKey<K> {
+    /// Key into the item associated with this specific key.
+    Specific(K),
+    /// Key into an anonymous sequential item. Anonymous items are items for
+    /// which no specific connection was made to their key.
+    Sequential(usize),
+    /// Key into any items that were not covered by one of the other types.
+    Remaining,
+}
+
+impl<K> MapSplitKey<K> {
+    pub fn specific(self) -> Option<K> {
+        match self {
+            MapSplitKey::Specific(key) => Some(key),
+            _ => None,
+        }
+    }
+
+    pub fn next(this: &Option<Self>) -> Option<Self> {
+        match this {
+            Some(key) => {
+                match key {
+                    // Give the next key in the sequence
+                    MapSplitKey::Sequential(index) => Some(MapSplitKey::Sequential(index + 1)),
+                    // For an arbitrary map we don't know what would follow a specific key, so
+                    // just stop iterating. This should never be reached in practice anyway.
+                    MapSplitKey::Specific(_) => None,
+                    MapSplitKey::Remaining => None,
+                }
+            }
+            None => Some(MapSplitKey::Sequential(0)),
+        }
+    }
+}
+
+impl<K> From<K> for MapSplitKey<K> {
+    fn from(value: K) -> Self {
+        MapSplitKey::Specific(value)
+    }
+}
+
+impl<K> FromSpecific for MapSplitKey<K> {
+    type SpecificKey = K;
+    fn from_specific(specific: Self::SpecificKey) -> Self {
+        Self::Specific(specific)
+    }
+}
+
+impl<K> FromSequential for MapSplitKey<K> {
+    fn from_sequential(seq: usize) -> Self {
+        Self::Sequential(seq)
+    }
+}
+
+impl<K> ForRemaining for MapSplitKey<K> {
+    fn for_remaining() -> Self {
+        Self::Remaining
+    }
+}
+
+/// This is a newtype that implements [`Splittable`] for anything that can be
+/// turned into an iterator whose items take the form of a `(key, value)` pair
+/// where `key` meets all the bounds needed for a [`Splittable`] key.
+///
+/// This is used to implement [`Splittable`] for map-like structures.
+pub struct SplitAsMap<K, V, M>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+    M: 'static + Send + Sync + IntoIterator<Item = (K, V)>,
+{
+    pub contents: M,
+    _ignore: std::marker::PhantomData<(K, V)>,
+}
+
+impl<K, V, M> SplitAsMap<K, V, M>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+    M: 'static + Send + Sync + IntoIterator<Item = (K, V)>,
+{
+    pub fn new(contents: M) -> Self {
+        Self {
+            contents,
+            _ignore: Default::default(),
+        }
+    }
+}
+
+impl<K, V, M> Splittable for SplitAsMap<K, V, M>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+    M: 'static + Send + Sync + IntoIterator<Item = (K, V)>,
+{
+    type Key = MapSplitKey<K>;
+    type Item = (K, V);
+
+    fn validate(_: &Self::Key) -> bool {
+        // We have no way of knowing what the key bounds are for an arbitrary map
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        MapSplitKey::next(key)
+    }
+
+    fn split(self, mut dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        let mut next_seq = 0;
+        for (specific_key, value) in self.contents.into_iter() {
+            let key = MapSplitKey::Specific(specific_key);
+            match dispatcher.outputs_for(&key) {
+                Some(outputs) => {
+                    outputs.push((key.specific().unwrap(), value));
+                }
+                None => {
+                    // No connection to the specific key, so let's check for a
+                    // sequential connection.
+                    let seq = MapSplitKey::Sequential(next_seq);
+                    next_seq += 1;
+                    match dispatcher.outputs_for(&seq) {
+                        Some(outputs) => {
+                            outputs.push((key.specific().unwrap(), value));
+                        }
+                        None => {
+                            // No connection to this point in the sequence, so
+                            // let's send it to any remaining connection.
+                            let remaining = MapSplitKey::Remaining;
+                            if let Some(outputs) = dispatcher.outputs_for(&remaining) {
+                                outputs.push((key.specific().unwrap(), value));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<K, V> Splittable for HashMap<K, V>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+{
+    type Key = MapSplitKey<K>;
+    type Item = (K, V);
+
+    fn validate(_: &Self::Key) -> bool {
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsMap::<K, V, Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsMap::new(self).split(dispatcher)
+    }
+}
+
+impl<K, V> Splittable for BTreeMap<K, V>
+where
+    K: 'static + Send + Sync + Eq + Hash + Clone + Debug,
+    V: 'static + Send + Sync,
+{
+    type Key = MapSplitKey<K>;
+    type Item = (K, V);
+
+    fn validate(_: &Self::Key) -> bool {
+        true
+    }
+
+    fn next(key: &Option<Self::Key>) -> Option<Self::Key> {
+        SplitAsMap::<K, V, Self>::next(key)
+    }
+
+    fn split(self, dispatcher: SplitDispatcher<'_, Self::Key, Self::Item>) -> OperationResult {
+        SplitAsMap::new(self).split(dispatcher)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{testing::*, *};
+    use std::collections::{BTreeMap, HashMap};
+
+    #[test]
+    fn test_split_array() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            scope
+                .input
+                .chain(builder)
+                .split(|split| {
+                    let mut outputs = Vec::new();
+                    split
+                        .sequential_branch(0, |chain| {
+                            outputs.push(chain.value().map_block(|v| v + 0.0).output());
+                        })
+                        .unwrap()
+                        .sequential_branch(2, |chain| {
+                            outputs
+                                .push(chain.value().map_async(|v| async move { v + 2.0 }).output());
+                        })
+                        .unwrap()
+                        .sequential_branch(4, |chain| {
+                            outputs.push(chain.value().map_block(|v| v + 4.0).output());
+                        })
+                        .unwrap()
+                        .unused();
+
+                    outputs
+                })
+                .join_vec::<5>(builder)
+                .connect(scope.terminate);
+        });
+
+        let mut promise = context.command(|commands| {
+            commands
+                .request([5.0, 4.0, 3.0, 2.0, 1.0], workflow)
+                .take_response()
+        });
+
+        context.run_with_conditions(&mut promise, Duration::from_secs(30));
+        assert!(context.no_unhandled_errors());
+        let value = promise.take().available().unwrap();
+        assert_eq!(value, [5.0, 5.0, 5.0].into());
+
+        let workflow = context.spawn_io_workflow(|scope: Scope<[f64; 3], f64>, builder| {
+            scope.input.chain(builder).split(|split| {
+                let split = split
+                    .sequential_branch(0, |chain| {
+                        chain
+                            // Do some nonsense with the first element in the split
+                            .fork_clone((
+                                |chain: Chain<_>| chain.unused(),
+                                |chain: Chain<_>| chain.unused(),
+                                |chain: Chain<_>| chain.unused(),
+                            ));
+                    })
+                    .unwrap();
+
+                // This is outside the valid range for the array, so it should
+                // fail
+                let err = split.sequential_branch(3, |chain| {
+                    chain.value().connect(scope.terminate);
+                });
+                assert!(matches!(
+                    &err,
+                    Err((_, SplitConnectionError::KeyOutOfBounds))
+                ));
+
+                let split = err
+                    .ignore_result()
+                    .sequential_branch(1, |chain| {
+                        chain.unused();
+                    })
+                    .unwrap();
+
+                // We already connected to this key, so it should fail
+                let err = split.sequential_branch(0, |chain| {
+                    chain.value().connect(scope.terminate);
+                });
+                assert!(matches!(
+                    &err,
+                    Err((_, SplitConnectionError::KeyAlreadyUsed))
+                ));
+
+                // Connect the last element in the split to the termination node
+                err.ignore_result()
+                    .sequential_branch(2, |chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .unused();
+            });
+        });
+
+        let mut promise =
+            context.command(|commands| commands.request([1.0, 2.0, 3.0], workflow).take_response());
+
+        context.run_with_conditions(&mut promise, 1);
+        assert!(context.no_unhandled_errors());
+        // Only the third element in the split gets connected to the workflow
+        // termination, the rest are discarded. This ensures that SplitBuilder
+        // connections still work after multiple failed connection attempts.
+        assert_eq!(promise.take().available().unwrap(), 3.0);
+    }
+
+    #[test]
+    fn test_split_map() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let km_to_miles = 0.621371;
+        let per_second_to_per_hour = 3600.0;
+        let convert_speed = move |v: f64| v * km_to_miles * per_second_to_per_hour;
+        let convert_distance = move |d: f64| d * km_to_miles;
+
+        let workflow =
+            context.spawn_io_workflow(|scope: Scope<BTreeMap<String, f64>, _>, builder| {
+                let collector = builder.create_collect_all::<_, 16>();
+
+                scope.input.chain(builder).split(|split| {
+                    split
+                        .specific_branch("speed".to_owned(), |chain| {
+                            chain
+                                .map_block(move |(k, v)| (k, convert_speed(v)))
+                                .connect(collector.input);
+                        })
+                        .ignore_result()
+                        .specific_branch("velocity".to_owned(), |chain| {
+                            chain
+                                .map_async(move |(k, v)| async move { (k, convert_speed(v)) })
+                                .connect(collector.input);
+                        })
+                        .unwrap()
+                        .specific_branch("distance".to_owned(), |chain| {
+                            chain
+                                .map_block(move |(k, v)| (k, convert_distance(v)))
+                                .connect(collector.input);
+                        })
+                        .unwrap()
+                        .sequential_branch(0, |chain| {
+                            chain
+                                .map_block(move |(k, v)| (k, 0.0 * v))
+                                .connect(collector.input);
+                        })
+                        .unwrap()
+                        .sequential_branch(1, |chain| {
+                            chain
+                                .map_async(move |(k, v)| async move { (k, 1.0 * v) })
+                                .connect(collector.input);
+                        })
+                        .unwrap()
+                        .sequential_branch(2, |chain| {
+                            chain
+                                .map_block(move |(k, v)| (k, 2.0 * v))
+                                .connect(collector.input);
+                        })
+                        .unwrap()
+                        .remaining_branch(|chain| {
+                            chain.connect(collector.input);
+                        })
+                        .unwrap()
+                        .unused();
+                });
+
+                collector
+                    .output
+                    .chain(builder)
+                    .map_block(|v| HashMap::<String, f64>::from_iter(v))
+                    .connect(scope.terminate);
+            });
+
+        // We input a BTreeMap so we can ensure the first three sequence items
+        // are always the same: a, b, and c. Make sure that no other keys in the
+        // map come before c alphabetically.
+        let input_map: BTreeMap<String, f64> = [
+            ("a", 3.14159),
+            ("b", 2.71828),
+            ("c", 4.0),
+            ("speed", 16.1),
+            ("velocity", -32.4),
+            ("distance", 4325.78),
+            ("foo", 42.0),
+            ("fib", 78.3),
+            ("dib", -22.1),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_owned(), v))
+        .collect();
+
+        let mut promise = context.command(|commands| {
+            commands
+                .request(input_map.clone(), workflow)
+                .take_response()
+        });
+
+        context.run_with_conditions(&mut promise, Duration::from_secs(30));
+        assert!(context.no_unhandled_errors());
+
+        let result = promise.take().available().unwrap();
+        assert_eq!(result.len(), input_map.len());
+        assert_eq!(result["a"], input_map["a"] * 0.0);
+        assert_eq!(result["b"], input_map["b"] * 1.0);
+        assert_eq!(result["c"], input_map["c"] * 2.0);
+        assert_eq!(result["speed"], convert_speed(input_map["speed"]));
+        assert_eq!(result["velocity"], convert_speed(input_map["velocity"]));
+        assert_eq!(result["distance"], convert_distance(input_map["distance"]));
+        assert_eq!(result["foo"], input_map["foo"]);
+        assert_eq!(result["fib"], input_map["fib"]);
+        assert_eq!(result["dib"], input_map["dib"]);
+    }
+
+    #[test]
+    fn test_array_split_limit() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            scope.input.chain(builder).split(|split| {
+                let err = split
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    })
+                    .unwrap()
+                    // This last one should fail because it should exceed the
+                    // array limit
+                    .next_branch(|_, chain| {
+                        chain.value().connect(scope.terminate);
+                    });
+
+                assert!(matches!(err, Err(_)));
+            })
+        });
+
+        let mut promise =
+            context.command(|commands| commands.request([1, 2, 3, 4], workflow).take_response());
+
+        context.run_with_conditions(&mut promise, 1);
+        assert!(context.no_unhandled_errors());
+
+        let result = promise.take().available().unwrap();
+        // All the values in the array are racing to finish, but the first value
+        // should finish first since it will naturally get queued first.
+        assert_eq!(result, 1);
+    }
+}

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -122,6 +122,17 @@ impl Disposal {
         }
         .into()
     }
+
+    pub fn incomplete_split(
+        split_node: Entity,
+        missing_keys: SmallVec<[Option<Arc<str>>; 16]>,
+    ) -> Self {
+        IncompleteSplit {
+            split_node,
+            missing_keys,
+        }
+        .into()
+    }
 }
 
 #[derive(Debug)]
@@ -176,6 +187,10 @@ pub enum DisposalCause {
     /// been sent out to indicate that the workflow is blocked up on the
     /// collection.
     DeficientCollection(DeficientCollection),
+
+    /// A split operation took place, but not all connections to the split
+    /// received a value.
+    IncompleteSplit(IncompleteSplit),
 }
 
 /// A variant of [`DisposalCause`]
@@ -384,6 +399,21 @@ pub struct DeficientCollection {
 impl From<DeficientCollection> for DisposalCause {
     fn from(value: DeficientCollection) -> Self {
         Self::DeficientCollection(value)
+    }
+}
+
+/// A variant of [`DisposalCause`]
+#[derive(Debug)]
+pub struct IncompleteSplit {
+    /// The node that does the splitting
+    pub split_node: Entity,
+    /// The debug text of each key that was missing in the split
+    pub missing_keys: SmallVec<[Option<Arc<str>>; 16]>,
+}
+
+impl From<IncompleteSplit> for DisposalCause {
+    fn from(value: IncompleteSplit) -> Self {
+        Self::IncompleteSplit(value)
     }
 }
 

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -87,6 +87,12 @@ fn flush_impulses_impl(
 
     let mut loop_count = 0;
     while !roster.is_empty() {
+        for e in roster.deferred_despawn.drain(..) {
+            if let Some(e_mut) = world.get_entity_mut(e) {
+                e_mut.despawn_recursive();
+            }
+        }
+
         let parameters = world.get_resource_or_insert_with(FlushParameters::default);
         let flush_loop_limit = parameters.flush_loop_limit;
         let single_threaded_poll_limit = parameters.single_threaded_poll_limit;

--- a/src/input.rs
+++ b/src/input.rs
@@ -26,8 +26,9 @@ use smallvec::SmallVec;
 use backtrace::Backtrace;
 
 use crate::{
-    Broken, BufferStorage, Cancel, Cancellation, CancellationCause, DeferredRoster, OperationError,
-    OperationRoster, OrBroken, SessionStatus, UnusedTarget,
+    Broken, BufferStorage, Cancel, Cancellation, CancellationCause, DeferredRoster, Detached,
+    MiscellaneousFailure, OperationError, OperationRoster, OrBroken, SessionStatus,
+    UnhandledErrors, UnusedTarget,
 };
 
 /// This contains data that has been provided as input into an operation, along
@@ -69,15 +70,31 @@ impl<T> Default for InputStorage<T> {
     }
 }
 
+/// Used to keep track of the expected input type for an operation
+#[derive(Component)]
+pub(crate) struct InputTypeIndicator {
+    pub(crate) name: &'static str,
+}
+
+impl InputTypeIndicator {
+    fn new<T>() -> Self {
+        Self {
+            name: std::any::type_name::<T>(),
+        }
+    }
+}
+
 #[derive(Bundle)]
 pub struct InputBundle<T: 'static + Send + Sync> {
     storage: InputStorage<T>,
+    indicator: InputTypeIndicator,
 }
 
 impl<T: 'static + Send + Sync> InputBundle<T> {
     pub fn new() -> Self {
         Self {
             storage: Default::default(),
+            indicator: InputTypeIndicator::new::<T>(),
         }
     }
 }
@@ -125,6 +142,7 @@ pub trait ManageInput {
         session: Entity,
         data: T,
         only_if_active: bool,
+        roster: &mut OperationRoster,
     ) -> Result<bool, OperationError>;
 
     /// Get an input that is ready to be taken, or else produce an error.
@@ -150,7 +168,7 @@ impl<'w> ManageInput for EntityWorldMut<'w> {
         data: T,
         roster: &mut OperationRoster,
     ) -> Result<(), OperationError> {
-        if unsafe { self.sneak_input(session, data, true)? } {
+        if unsafe { self.sneak_input(session, data, true, roster)? } {
             roster.queue(self.id());
         }
         Ok(())
@@ -162,7 +180,7 @@ impl<'w> ManageInput for EntityWorldMut<'w> {
         data: T,
         roster: &mut OperationRoster,
     ) -> Result<(), OperationError> {
-        if unsafe { self.sneak_input(session, data, true)? } {
+        if unsafe { self.sneak_input(session, data, true, roster)? } {
             roster.defer(self.id());
         }
         Ok(())
@@ -173,6 +191,7 @@ impl<'w> ManageInput for EntityWorldMut<'w> {
         session: Entity,
         data: T,
         only_if_active: bool,
+        roster: &mut OperationRoster,
     ) -> Result<bool, OperationError> {
         if only_if_active {
             let active_session =
@@ -193,6 +212,21 @@ impl<'w> ManageInput for EntityWorldMut<'w> {
         if let Some(mut storage) = self.get_mut::<InputStorage<T>>() {
             storage.reverse_queue.insert(0, Input { session, data });
         } else if !self.contains::<UnusedTarget>() {
+            let id = self.id();
+            if let Some(detached) = self.get::<Detached>() {
+                if detached.is_detached() {
+                    // The input is going to a detached impulse that will not
+                    // react any further. We need to tell that detached impulse
+                    // to despawn since it is no longer needed.
+                    roster.defer_despawn(id);
+
+                    // No error occurred, but the caller should not queue the
+                    // operation into the roster because it is being despawned.
+                    return Ok(false);
+                }
+            }
+
+            let expected = self.get::<InputTypeIndicator>().map(|i| i.name);
             // If the input is being fed to an unused target then we can
             // generally ignore it, although it may indicate a bug in the user's
             // workflow because workflow branches that end in an unused target
@@ -200,6 +234,18 @@ impl<'w> ManageInput for EntityWorldMut<'w> {
 
             // However in this case, the target is not unused but also does not
             // have the correct input storage type. This indicates
+            self.world_mut()
+                .get_resource_or_insert_with(|| UnhandledErrors::default())
+                .miscellaneous
+                .push(MiscellaneousFailure {
+                    error: std::sync::Arc::new(anyhow::anyhow!(
+                        "Incorrect input type for operation [{:?}]: received [{}], expected [{}]",
+                        id,
+                        std::any::type_name::<T>(),
+                        expected.unwrap_or("<null>"),
+                    )),
+                    backtrace: None,
+                });
             None.or_broken()?;
         }
         Ok(true)

--- a/src/node.rs
+++ b/src/node.rs
@@ -87,6 +87,9 @@ impl<Request> InputSlot<Request> {
 /// `Response` parameter can be cloned then you can call [`Self::fork_clone`] to
 /// transform this into a [`ForkCloneOutput`] and then connect the output into
 /// any number of input slots.
+///
+/// `Output` intentionally does not implement copy or clone because it must only
+/// be consumed exactly once.
 #[must_use]
 pub struct Output<Response> {
     scope: Entity,

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -80,6 +80,9 @@ pub(crate) use operate_map::*;
 mod operate_service;
 pub(crate) use operate_service::*;
 
+mod operate_split;
+pub(crate) use operate_split::*;
+
 mod operate_task;
 pub(crate) use operate_task::*;
 
@@ -220,6 +223,9 @@ pub struct OperationRoster {
     pub(crate) disposed: Vec<DisposalNotice>,
     /// Tell a scope to attempt cleanup
     pub(crate) cleanup_finished: Vec<Cleanup>,
+    /// Despawn these entities while no other operation is running. This is used
+    /// to cleanup detached impulses that receive no input.
+    pub(crate) deferred_despawn: Vec<Entity>,
 }
 
 impl OperationRoster {
@@ -259,6 +265,10 @@ impl OperationRoster {
         self.cleanup_finished.push(cleanup);
     }
 
+    pub fn defer_despawn(&mut self, source: Entity) {
+        self.deferred_despawn.push(source);
+    }
+
     pub fn is_empty(&self) -> bool {
         self.queue.is_empty()
             && self.awake.is_empty()
@@ -267,6 +277,7 @@ impl OperationRoster {
             && self.unblock.is_empty()
             && self.disposed.is_empty()
             && self.cleanup_finished.is_empty()
+            && self.deferred_despawn.is_empty()
     }
 
     pub fn append(&mut self, other: &mut Self) {
@@ -314,6 +325,17 @@ pub(crate) struct Blocker {
     pub(crate) label: Option<DeliveryLabelId>,
     /// Function pointer to call when this is no longer blocking
     pub(crate) serve_next: fn(Blocker, &mut World, &mut OperationRoster),
+}
+
+impl std::fmt::Debug for Blocker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Blocker")
+            .field("provider", &self.provider)
+            .field("source", &self.source)
+            .field("session", &self.session)
+            .field("label", &self.label)
+            .finish()
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/operation/injection.rs
+++ b/src/operation/injection.rs
@@ -120,10 +120,16 @@ where
         // roster to register the task as an operation. In fact it does not
         // implement Operation at all. It is just a temporary container for the
         // input and the stream targets.
-        unsafe {
+        let execute = unsafe {
             world
                 .entity_mut(task)
-                .sneak_input(session, request, false)?;
+                .sneak_input(session, request, false, roster)?
+        };
+
+        if !execute {
+            // If giving the input failed then this workflow will not be able to
+            // proceed. Therefore we should report that this is broken.
+            None.or_broken()?;
         }
 
         let mut storage = world.get_mut::<InjectionStorage>(source).or_broken()?;

--- a/src/operation/operate_split.rs
+++ b/src/operation/operate_split.rs
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2024 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_ecs::{
+    prelude::{Component, Entity, World},
+    system::Command,
+};
+use smallvec::SmallVec;
+use std::{collections::HashMap, sync::Arc};
+
+use crate::{
+    Broken, Disposal, ForkTargetStorage, Input, InputBundle, ManageDisposal, ManageInput,
+    MiscellaneousFailure, Operation, OperationCleanup, OperationError, OperationReachability,
+    OperationRequest, OperationResult, OperationSetup, OrBroken, ReachabilityResult,
+    SingleInputStorage, SplitDispatcher, Splittable, UnhandledErrors,
+};
+
+#[derive(Component)]
+pub(crate) struct OperateSplit<T: Splittable> {
+    /// The connections that lead out of this split operation. These only change
+    /// while the workflow is being built, afterwards they should be frozen.
+    connections: HashMap<T::Key, usize>,
+    /// A reverse map that keeps track of what key is at each index
+    index_to_key: Vec<Arc<str>>,
+    /// A cache used to transfer the split values from the input to the outputs.
+    /// Every iteration this must be reset to all None values. If any one of them
+    /// is a None after the Splittable has filled it in, we must issue a disposal
+    /// notice because one of the outputs might not be receiving anything.
+    outputs_cache: Option<Vec<Vec<T::Item>>>,
+}
+
+impl<T: Splittable> Default for OperateSplit<T> {
+    fn default() -> Self {
+        Self {
+            connections: Default::default(),
+            index_to_key: Vec::new(),
+            outputs_cache: Some(Vec::new()),
+        }
+    }
+}
+
+impl<T: 'static + Splittable + Send + Sync> Operation for OperateSplit<T> {
+    fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
+        world.entity_mut(source).insert((
+            self,
+            InputBundle::<T>::new(),
+            ForkTargetStorage::default(),
+        ));
+        Ok(())
+    }
+
+    fn execute(
+        OperationRequest {
+            source,
+            world,
+            roster,
+        }: OperationRequest,
+    ) -> OperationResult {
+        let mut source_mut = world.get_entity_mut(source).or_broken()?;
+        let Input { session, data } = source_mut.take_input::<T>()?;
+        let targets = source_mut.get::<ForkTargetStorage>().or_broken()?.0.clone();
+
+        let mut split = source_mut.get_mut::<OperateSplit<T>>().or_broken()?;
+        let mut outputs = split.outputs_cache.take().unwrap_or(Vec::new());
+        let dispatcher = SplitDispatcher {
+            connections: &split.connections,
+            outputs: &mut outputs,
+        };
+        data.split(dispatcher)?;
+
+        let mut missed_indices: SmallVec<[usize; 16]> = SmallVec::new();
+        for (index, (items, target)) in outputs.iter_mut().zip(targets).enumerate() {
+            if items.is_empty() {
+                missed_indices.push(index);
+            }
+
+            for output in items.drain(..) {
+                world
+                    .get_entity_mut(target)
+                    .or_broken()?
+                    .give_input(session, output, roster)?;
+            }
+        }
+
+        let mut source_mut = world.get_entity_mut(source).or_broken()?;
+
+        if !missed_indices.is_empty() {
+            let split = source_mut.get::<OperateSplit<T>>().or_broken()?;
+            let missing_keys: SmallVec<[Option<Arc<str>>; 16]> = missed_indices
+                .into_iter()
+                .map(|index| split.index_to_key.get(index).cloned())
+                .collect();
+
+            source_mut.emit_disposal(
+                session,
+                Disposal::incomplete_split(source, missing_keys),
+                roster,
+            );
+        }
+
+        // Return the cache into the component
+        source_mut
+            .get_mut::<OperateSplit<T>>()
+            .or_broken()?
+            .outputs_cache
+            .replace(outputs);
+
+        Ok(())
+    }
+
+    fn cleanup(mut clean: OperationCleanup) -> OperationResult {
+        clean.cleanup_inputs::<T>()?;
+        clean.notify_cleaned()
+    }
+
+    fn is_reachable(mut reachability: OperationReachability) -> ReachabilityResult {
+        if reachability.has_input::<T>()? {
+            return Ok(true);
+        }
+
+        SingleInputStorage::is_reachable(&mut reachability)
+    }
+}
+
+pub(crate) struct ConnectToSplit<T: Splittable> {
+    pub(crate) source: Entity,
+    pub(crate) target: Entity,
+    pub(crate) key: T::Key,
+}
+
+impl<T: 'static + Splittable> Command for ConnectToSplit<T> {
+    fn apply(self, world: &mut World) {
+        let node = self.source;
+        if let Err(OperationError::Broken(backtrace)) = self.connect(world) {
+            world
+                .get_resource_or_insert_with(UnhandledErrors::default)
+                .broken
+                .push(Broken { node, backtrace });
+        }
+    }
+}
+
+impl<T: 'static + Splittable> ConnectToSplit<T> {
+    fn connect(self, world: &mut World) -> Result<(), OperationError> {
+        let mut target_storage = world
+            .get_mut::<ForkTargetStorage>(self.source)
+            .or_broken()?;
+        let index = target_storage.0.len();
+        target_storage.0.push(self.target);
+
+        world
+            .get_entity_mut(self.target)
+            .or_broken()?
+            .insert(SingleInputStorage::new(self.source));
+
+        let mut split = world.get_mut::<OperateSplit<T>>(self.source).or_broken()?;
+        let previous_index = split.connections.insert(self.key.clone(), index);
+        split
+            .outputs_cache
+            .as_mut()
+            .or_broken()?
+            .resize_with(index + 1, Vec::new);
+        if split.index_to_key.len() != index {
+            // If the next element of the reverse map does not match the new index
+            // then something has fallen out of sync. This doesn't really break
+            // the workflow because this reverse map is only used to generate
+            // disposal messages, but it does indicate a bug is present.
+            let reverse_map_size = split.index_to_key.len();
+            world
+                .get_resource_or_insert_with(UnhandledErrors::default)
+                .miscellaneous
+                .push(MiscellaneousFailure {
+                    error: Arc::new(anyhow::anyhow!(
+                        "Mismatch between reverse map size [{}] and new connection index [{}]",
+                        reverse_map_size,
+                        index,
+                    )),
+                    backtrace: Some(backtrace::Backtrace::new()),
+                });
+        } else {
+            split
+                .index_to_key
+                .push(format!("{:?}", self.key).as_str().into());
+        }
+
+        if let Some(previous_index) = previous_index {
+            // If something was already using this key then there is a flaw in
+            // the implementation of SplitBuilder and we should log it.
+            let target_storage = world.get::<ForkTargetStorage>(self.source).or_broken()?;
+            let previous_target = *target_storage.0.get(previous_index).or_broken()?;
+
+            world
+                .get_resource_or_insert_with(UnhandledErrors::default)
+                .miscellaneous
+                .push(MiscellaneousFailure {
+                    error: Arc::new(anyhow::anyhow!(
+                        "Double-connected key [{:?}] for split node {:?}. Original target: {:?}, new target: {:?}",
+                        self.key,
+                        self.source,
+                        previous_target,
+                        self.target,
+                    )),
+                    backtrace: Some(backtrace::Backtrace::new()),
+                });
+        }
+
+        Ok(())
+    }
+}

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -765,17 +765,6 @@ where
 
         let is_terminated = awaiting.info.status.is_terminated();
 
-        unsafe {
-            // INVARIANT: We use sneak_input here to side-step the protection of
-            // only allowing inputs for Active sessions. This current session is
-            // not active because cleaning already started for it. It's okay to
-            // use this session as input despite not being active because we are
-            // passing it to an operation that will only use it to begin a
-            // cleanup workflow.
-            finish_cleanup_workflow_mut.sneak_input(scoped_session, CheckAwaitingSession, false)?;
-            roster.queue(finish_cleanup);
-        }
-
         for begin in begin_cleanup_workflows {
             let run_this_workflow =
                 (is_terminated && begin.on_terminate) || (!is_terminated && begin.on_cancelled);
@@ -787,20 +776,31 @@ where
             // We execute the begin nodes immediately so that they can load up the
             // finish_cancel node with all their cancellation behavior IDs before
             // the finish_cancel node gets executed.
-            unsafe {
+            let execute = unsafe {
                 // INVARIANT: We can use sneak_input here because we execute the
                 // recipient node immediately after giving the input.
                 world
                     .get_entity_mut(begin.source)
                     .or_broken()?
-                    .sneak_input(scoped_session, (), false)?;
+                    .sneak_input(scoped_session, (), false, roster)?
+            };
+            if execute {
+                execute_operation(OperationRequest {
+                    source: begin.source,
+                    world,
+                    roster,
+                });
             }
-            execute_operation(OperationRequest {
-                source: begin.source,
-                world,
-                roster,
-            });
         }
+
+        // Check if there are any cleanup workflows waiting to be run. If not,
+        // the workflow can fully terminate.
+        FinishCleanup::<Response>::check_awaiting_session(
+            finish_cleanup,
+            scoped_session,
+            world,
+            roster,
+        )?;
 
         Ok(())
     }
@@ -1235,7 +1235,6 @@ impl<T: 'static + Send + Sync> Operation for FinishCleanup<T> {
         world.entity_mut(source).insert((
             CleanupForScope(self.from_scope),
             InputBundle::<()>::new(),
-            InputBundle::<CheckAwaitingSession>::new(),
             Cancellable::new(Self::receive_cancel),
             AwaitingCleanupStorage::default(),
         ));
@@ -1250,43 +1249,15 @@ impl<T: 'static + Send + Sync> Operation for FinishCleanup<T> {
         }: OperationRequest,
     ) -> OperationResult {
         let mut source_mut = world.get_entity_mut(source).or_broken()?;
-        if let Some(Input {
-            session: new_scoped_session,
-            ..
-        }) = source_mut.try_take_input::<CheckAwaitingSession>()?
-        {
-            let mut awaiting = source_mut.get_mut::<AwaitingCleanupStorage>().or_broken()?;
-            if let Some((index, a)) = awaiting
-                .0
-                .iter_mut()
-                .enumerate()
-                .find(|(_, a)| a.scoped_session == new_scoped_session)
-            {
-                if a.cleanup_workflow_sessions
-                    .as_ref()
-                    .is_some_and(|s| s.is_empty())
-                {
-                    // No cancellation sessions were started for this scoped
-                    // session so we can immediately clean it up.
-                    Self::finalize_scoped_session(
-                        index,
-                        OperationRequest {
-                            source,
-                            world,
-                            roster,
-                        },
-                    )?;
-                }
-            }
-        } else if let Some(Input {
+        let Some(Input {
             session: cancellation_session,
             ..
         }) = source_mut.try_take_input::<()>()?
-        {
-            Self::deduct_finished_cleanup(source, cancellation_session, world, roster, None)?;
-        }
+        else {
+            return Ok(());
+        };
 
-        Ok(())
+        Self::deduct_finished_cleanup(source, cancellation_session, world, roster, None)
     }
 
     fn cleanup(_: OperationCleanup) -> OperationResult {
@@ -1355,6 +1326,40 @@ impl<T: 'static + Send + Sync> FinishCleanup<T> {
                     .get_resource_or_insert_with(UnhandledErrors::default)
                     .operations
                     .push(error);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn check_awaiting_session(
+        source: Entity,
+        new_scoped_session: Entity,
+        world: &mut World,
+        roster: &mut OperationRoster,
+    ) -> OperationResult {
+        let mut source_mut = world.get_entity_mut(source).or_broken()?;
+        let mut awaiting = source_mut.get_mut::<AwaitingCleanupStorage>().or_broken()?;
+        if let Some((index, a)) = awaiting
+            .0
+            .iter_mut()
+            .enumerate()
+            .find(|(_, a)| a.scoped_session == new_scoped_session)
+        {
+            if a.cleanup_workflow_sessions
+                .as_ref()
+                .is_some_and(|s| s.is_empty())
+            {
+                // No cancellation sessions were started for this scoped
+                // session so we can immediately clean it up.
+                Self::finalize_scoped_session(
+                    index,
+                    OperationRequest {
+                        source,
+                        world,
+                        roster,
+                    },
+                )?;
             }
         }
 
@@ -1605,14 +1610,13 @@ impl AwaitingCleanup {
     }
 }
 
-struct CheckAwaitingSession;
-
 #[derive(Component, Default)]
 pub(crate) struct ExitTargetStorage {
     /// Map from session value to the target
     pub(crate) map: HashMap<Entity, ExitTarget>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ExitTarget {
     pub(crate) target: Entity,
     pub(crate) source: Entity,

--- a/src/service.rs
+++ b/src/service.rs
@@ -26,8 +26,9 @@ use bevy_ecs::{
     prelude::{Commands, Component, Entity, Event, World},
     schedule::ScheduleLabel,
 };
+pub use bevy_impulse_derive::DeliveryLabel;
 use bevy_utils::{define_label, intern::Interned};
-use std::{any::TypeId, collections::HashSet};
+use std::{any::TypeId, collections::HashSet, sync::OnceLock};
 use thiserror::Error as ThisError;
 
 mod async_srv;
@@ -75,11 +76,30 @@ pub(crate) use workflow::*;
 /// [App]: bevy_app::prelude::App
 /// [Commands]: bevy_ecs::prelude::Commands
 /// [World]: bevy_ecs::prelude::World
-#[derive(Debug, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct Service<Request, Response, Streams = ()> {
     provider: Entity,
     instructions: Option<DeliveryInstructions>,
     _ignore: std::marker::PhantomData<fn(Request, Response, Streams)>,
+}
+
+impl<Req, Res, S> std::fmt::Debug for Service<Req, Res, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        static NAME: OnceLock<String> = OnceLock::new();
+        let name = NAME.get_or_init(|| {
+            format!(
+                "Service<{}, {}, {}>",
+                std::any::type_name::<Req>(),
+                std::any::type_name::<Res>(),
+                std::any::type_name::<S>(),
+            )
+        });
+
+        f.debug_struct(name.as_str())
+            .field("provider", &self.provider)
+            .field("instructions", &self.instructions)
+            .finish()
+    }
 }
 
 impl<Req, Res, S> Clone for Service<Req, Res, S> {
@@ -195,6 +215,11 @@ define_label!(
     DeliveryLabel,
     DELIVERY_LABEL_INTERNER
 );
+
+pub mod utils {
+    /// Used by the procedural macro for DeliveryLabel
+    pub use bevy_utils::label::DynEq;
+}
 
 /// When using a service, you can bundle in delivery instructions that affect
 /// how multiple requests to the same service may interact with each other.

--- a/src/service/discovery.rs
+++ b/src/service/discovery.rs
@@ -17,7 +17,7 @@
 
 use bevy_ecs::{
     prelude::{Entity, Query, With},
-    query::{QueryEntityError, QueryIter, QueryFilter},
+    query::{QueryEntityError, QueryFilter, QueryIter},
     system::SystemParam,
 };
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -18,7 +18,7 @@
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::{Bundle, Commands, Component, Entity, With, World},
-    query::{QueryFilter, WorldQuery, ReadOnlyQueryData},
+    query::{QueryFilter, ReadOnlyQueryData, WorldQuery},
     system::Command,
 };
 use bevy_hierarchy::BuildChildren;


### PR DESCRIPTION
This PR just brings in the latest changes from `main` into the `release-0.1` branch. Specifically, to unblock downstream migrations on `rmf_site` we need the `DeliveryLabel` macro PR https://github.com/open-rmf/bevy_impulse/pull/30, which is not released.

Eventually I'd like to bring the change all the way to the `release-0.2` branch for Bevy 0.14 migration, I thought the sequence would be a `main` -> `0.1, followed by a `0.1 -> 0.2` but I might have missed something