### PR TITLE
Message registry

### DIFF
--- a/examples/diagram/calculator/src/main.rs
+++ b/examples/diagram/calculator/src/main.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, fs::File, str::FromStr};
 
 use bevy_impulse::{
-    Diagram, DiagramError, ImpulsePlugin, NodeBuilderOptions, NodeRegistry, Promise, RequestExt,
+    Diagram, DiagramError, ImpulsePlugin, NodeBuilderOptions, Promise, Registry, RequestExt,
     RunCommandsOnWorldExt,
 };
 use clap::Parser;
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     tracing_subscriber::fmt::init();
 
-    let mut registry = NodeRegistry::default();
+    let mut registry = Registry::new();
     registry.register_node_builder(
         NodeBuilderOptions::new("add").with_name("Add"),
         |builder, config: f64| builder.create_map_block(move |req: f64| req + config),

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -2,7 +2,7 @@ mod fork_clone;
 mod fork_result;
 mod impls;
 mod join;
-mod node_registry;
+mod registry;
 mod serialization;
 mod split_serialized;
 mod transform;
@@ -14,7 +14,7 @@ use fork_clone::ForkCloneOp;
 use fork_result::ForkResultOp;
 use join::JoinOp;
 pub use join::JoinOutput;
-pub use node_registry::*;
+pub use registry::*;
 pub use serialization::*;
 pub use split_serialized::*;
 use tracing::debug;
@@ -380,10 +380,10 @@ impl Diagram {
     /// # Examples
     ///
     /// ```
-    /// use bevy_impulse::{Diagram, DiagramError, NodeBuilderOptions, NodeRegistry, RunCommandsOnWorldExt};
+    /// use bevy_impulse::{Diagram, DiagramError, NodeBuilderOptions, Registry, RunCommandsOnWorldExt};
     ///
     /// let mut app = bevy_app::App::new();
-    /// let mut registry = NodeRegistry::default();
+    /// let mut registry = Registry::new();
     /// registry.register_node_builder(NodeBuilderOptions::new("echo".to_string()), |builder, _config: ()| {
     ///     builder.create_map_block(|msg: String| msg)
     /// });
@@ -411,7 +411,7 @@ impl Diagram {
     fn spawn_workflow<Streams>(
         &self,
         cmds: &mut Commands,
-        registry: &NodeRegistry,
+        registry: &Registry,
     ) -> Result<Service<DiagramStart, DiagramTerminate, Streams>, DiagramError>
     where
         Streams: StreamPack,
@@ -451,7 +451,7 @@ impl Diagram {
     pub fn spawn_io_workflow(
         &self,
         cmds: &mut Commands,
-        registry: &NodeRegistry,
+        registry: &Registry,
     ) -> Result<Service<DiagramStart, DiagramTerminate, ()>, DiagramError> {
         self.spawn_workflow::<()>(cmds, registry)
     }

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -506,6 +506,9 @@ pub enum DiagramError {
     #[error("response cannot be split")]
     NotSplittable,
 
+    #[error("responses cannot be joined")]
+    NotJoinable,
+
     #[error("empty join is not allowed")]
     EmptyJoin,
 
@@ -557,7 +560,7 @@ mod tests {
             "ops": {
                 "op1": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "dispose" },
                 },
             },
@@ -625,7 +628,7 @@ mod tests {
             "ops": {
                 "op1": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": "op2",
                 },
                 "op2": {
@@ -651,12 +654,12 @@ mod tests {
             "ops": {
                 "op1": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": "op2",
                 },
                 "op2": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": "op1",
                 },
             },
@@ -691,7 +694,7 @@ mod tests {
                 },
                 "op2": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "terminate" },
                 },
             },
@@ -728,11 +731,11 @@ mod tests {
         let json_str = r#"
         {
             "version": "0.1.0",
-            "start": "multiply3_uncloneable",
+            "start": "multiply3",
             "ops": {
-                "multiply3_uncloneable": {
+                "multiply3": {
                     "type": "node",
-                    "builder": "multiplyBy",
+                    "builder": "multiply_by",
                     "config": 7,
                     "next": { "builtin": "terminate" }
                 }

--- a/src/diagram/join.rs
+++ b/src/diagram/join.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
@@ -30,7 +28,7 @@ where
     T: Send + Sync + 'static,
     Serializer: SerializeMessage<Vec<T>>,
 {
-    registry.register_join(TypeId::of::<T>(), Box::new(join_impl::<T>));
+    registry.register_join::<T>(Box::new(join_impl::<T>));
 }
 
 /// Serialize the outputs before joining them, and convert the resulting joined output into a

--- a/src/diagram/registry.rs
+++ b/src/diagram/registry.rs
@@ -106,7 +106,9 @@ where
 pub(super) struct NodeMetadata {
     pub(super) id: BuilderId,
     pub(super) name: String,
+    /// type name of the request
     pub(super) request: &'static str,
+    /// type name of the response
     pub(super) response: &'static str,
     pub(super) config_schema: Schema,
 }

--- a/src/diagram/registry.rs
+++ b/src/diagram/registry.rs
@@ -1292,13 +1292,17 @@ mod tests {
             foo: Foo,
         }
 
-        reg.register_node_builder(NodeBuilderOptions::new("test"), |builder, _config: ()| {
-            builder.create_map_block(|_: ()| Bar {
-                foo: Foo {
-                    hello: "hello".to_string(),
-                },
-            })
-        });
+        struct Opaque;
+
+        reg.opt_out()
+            .no_request_deserializing()
+            .register_node_builder(NodeBuilderOptions::new("test"), |builder, _config: ()| {
+                builder.create_map_block(|_: Opaque| Bar {
+                    foo: Foo {
+                        hello: "hello".to_string(),
+                    },
+                })
+            });
 
         // print out a pretty json for manual inspection
         println!("{}", serde_json::to_string_pretty(&reg).unwrap());

--- a/src/diagram/serialization.rs
+++ b/src/diagram/serialization.rs
@@ -30,24 +30,6 @@ where
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct RequestMetadata {
-    /// The JSON Schema of the request.
-    pub(super) schema: Schema,
-}
-
-#[derive(Clone, Debug, Serialize)]
-pub struct ResponseMetadata {
-    /// The JSON Schema of the response.
-    pub(super) schema: Schema,
-}
-
-impl ResponseMetadata {
-    pub(super) fn new(schema: Schema) -> ResponseMetadata {
-        ResponseMetadata { schema }
-    }
-}
-
 pub trait SerializeMessage<T> {
     fn type_name() -> String;
 

--- a/src/diagram/serialization.rs
+++ b/src/diagram/serialization.rs
@@ -1,10 +1,5 @@
-use std::any::TypeId;
-
 use schemars::{gen::SchemaGenerator, schema::Schema, JsonSchema};
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::debug;
-
-use super::MessageRegistry;
 
 #[derive(thiserror::Error, Debug)]
 pub enum SerializationError {
@@ -39,44 +34,17 @@ where
 pub struct RequestMetadata {
     /// The JSON Schema of the request.
     pub(super) schema: Schema,
-
-    /// Indicates if the request is deserializable.
-    pub(super) deserializable: bool,
 }
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ResponseMetadata {
     /// The JSON Schema of the response.
     pub(super) schema: Schema,
-
-    /// Indicates if the response is serializable.
-    pub(super) serializable: bool,
-
-    /// Indicates if the response is cloneable, a node must have a cloneable response
-    /// in order to connect it to a "fork clone" operation.
-    pub(super) cloneable: bool,
-
-    /// The number of unzip slots that a response have, a value of 0 means that the response
-    /// cannot be unzipped. This should be > 0 only if the response is a tuple.
-    pub(super) unzip_slots: usize,
-
-    /// Indicates if the response can fork result
-    pub(super) fork_result: bool,
-
-    /// Indiciates if the response can be split
-    pub(super) splittable: bool,
 }
 
 impl ResponseMetadata {
-    pub(super) fn new(schema: Schema, serializable: bool, cloneable: bool) -> ResponseMetadata {
-        ResponseMetadata {
-            schema,
-            serializable,
-            cloneable,
-            unzip_slots: 0,
-            fork_result: false,
-            splittable: false,
-        }
+    pub(super) fn new(schema: Schema) -> ResponseMetadata {
+        ResponseMetadata { schema }
     }
 }
 
@@ -188,66 +156,4 @@ impl<T> DeserializeMessage<T> for OpaqueMessageDeserializer {
     fn deserializable() -> bool {
         false
     }
-}
-
-pub(super) fn register_deserialize<T, Deserializer>(registry: &mut MessageRegistry)
-where
-    Deserializer: DeserializeMessage<T>,
-    T: Send + Sync + 'static,
-{
-    if registry.deserialize_impls.contains_key(&TypeId::of::<T>())
-        || !Deserializer::deserializable()
-    {
-        return;
-    }
-
-    debug!(
-        "register deserialize for type: {}, with deserializer: {}",
-        std::any::type_name::<T>(),
-        std::any::type_name::<Deserializer>()
-    );
-    registry.deserialize_impls.insert(
-        TypeId::of::<T>(),
-        Box::new(|builder, output| {
-            debug!("deserialize output: {:?}", output);
-            let receiver =
-                builder.create_map_block(|json: serde_json::Value| Deserializer::from_json(json));
-            builder.connect(output, receiver.input);
-            let deserialized_output = receiver
-                .output
-                .chain(builder)
-                .cancel_on_err()
-                .output()
-                .into();
-            debug!("deserialized output: {:?}", deserialized_output);
-            Ok(deserialized_output)
-        }),
-    );
-}
-
-pub(super) fn register_serialize<T, Serializer>(registry: &mut MessageRegistry)
-where
-    Serializer: SerializeMessage<T>,
-    T: Send + Sync + 'static,
-{
-    if registry.serialize_impls.contains_key(&TypeId::of::<T>()) || !Serializer::serializable() {
-        return;
-    }
-
-    debug!(
-        "register serialize for type: {}, with serializer: {}",
-        std::any::type_name::<T>(),
-        std::any::type_name::<Serializer>()
-    );
-    registry.serialize_impls.insert(
-        TypeId::of::<T>(),
-        Box::new(|builder, output| {
-            debug!("serialize output: {:?}", output);
-            let n = builder.create_map_block(|resp: T| Serializer::to_json(&resp));
-            builder.connect(output.into_output()?, n.input);
-            let serialized_output = n.output.chain(builder).cancel_on_err().output();
-            debug!("serialized output: {:?}", serialized_output);
-            Ok(serialized_output)
-        }),
-    );
 }

--- a/src/diagram/split_serialized.rs
+++ b/src/diagram/split_serialized.rs
@@ -30,7 +30,7 @@ use crate::{
 use super::{
     impls::{DefaultImpl, NotSupported},
     join::register_join_impl,
-    register_serialize, DiagramError, DynOutput, MessageRegistry, NextOperation, SerializeMessage,
+    DiagramError, DynOutput, MessageRegistry, NextOperation, SerializeMessage,
 };
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -256,7 +256,7 @@ where
     }
 
     fn on_register(registry: &mut MessageRegistry) {
-        register_serialize::<T::Item, Serializer>(registry);
+        registry.register_serialize::<T::Item, Serializer>();
         register_join_impl::<T::Item, Serializer>(registry);
     }
 }

--- a/src/diagram/testing.rs
+++ b/src/diagram/testing.rs
@@ -1,5 +1,8 @@
 use std::error::Error;
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
 use crate::{
     testing::TestingContext, Builder, RequestExt, RunCommandsOnWorldExt, Service, StreamPack,
 };
@@ -63,8 +66,15 @@ impl DiagramTestFixture {
     }
 }
 
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct Uncloneable<T>(T);
+
 fn multiply3(i: i64) -> i64 {
     i * 3
+}
+
+fn multiply3_uncloneable(i: i64) -> Uncloneable<i64> {
+    Uncloneable(i * 3)
 }
 
 fn multiply3_5(x: i64) -> (i64, i64) {
@@ -91,7 +101,7 @@ fn new_registry_with_basic_nodes() -> NodeRegistry {
         .no_response_cloning()
         .register_node_builder(
             NodeBuilderOptions::new("multiply3_uncloneable"),
-            |builder: &mut Builder, _config: ()| builder.create_map_block(multiply3),
+            |builder: &mut Builder, _config: ()| builder.create_map_block(multiply3_uncloneable),
         );
     registry.register_node_builder(
         NodeBuilderOptions::new("multiply3"),
@@ -105,7 +115,7 @@ fn new_registry_with_basic_nodes() -> NodeRegistry {
         .with_unzip();
 
     registry.register_node_builder(
-        NodeBuilderOptions::new("multiplyBy"),
+        NodeBuilderOptions::new("multiply_by"),
         |builder: &mut Builder, config: i64| builder.create_map_block(move |a: i64| a * config),
     );
 

--- a/src/diagram/testing.rs
+++ b/src/diagram/testing.rs
@@ -7,13 +7,11 @@ use crate::{
     testing::TestingContext, Builder, RequestExt, RunCommandsOnWorldExt, Service, StreamPack,
 };
 
-use super::{
-    Diagram, DiagramError, DiagramStart, DiagramTerminate, NodeBuilderOptions, NodeRegistry,
-};
+use super::{Diagram, DiagramError, DiagramStart, DiagramTerminate, NodeBuilderOptions, Registry};
 
 pub(super) struct DiagramTestFixture {
     pub(super) context: TestingContext,
-    pub(super) registry: NodeRegistry,
+    pub(super) registry: Registry,
 }
 
 impl DiagramTestFixture {
@@ -94,8 +92,8 @@ fn opaque_response(_: i64) -> Unserializable {
 }
 
 /// create a new node registry with some basic nodes registered
-fn new_registry_with_basic_nodes() -> NodeRegistry {
-    let mut registry = NodeRegistry::default();
+fn new_registry_with_basic_nodes() -> Registry {
+    let mut registry = Registry::new();
     registry
         .opt_out()
         .no_response_cloning()

--- a/src/diagram/transform.rs
+++ b/src/diagram/transform.rs
@@ -40,12 +40,7 @@ pub(super) fn transform_output(
     let json_output = if output.type_id == TypeId::of::<serde_json::Value>() {
         output.into_output()
     } else {
-        let serialize = registry
-            .data
-            .serialize_impls
-            .get(&output.type_id)
-            .ok_or(DiagramError::NotSerializable)?;
-        serialize(builder, output)
+        registry.data.serialize(builder, output)
     }?;
 
     let program = Program::compile(&transform_op.cel).map_err(|err| TransformError::Parse(err))?;
@@ -90,7 +85,7 @@ mod tests {
             "ops": {
                 "op1": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": "transform",
                 },
                 "transform": {

--- a/src/diagram/transform.rs
+++ b/src/diagram/transform.rs
@@ -8,7 +8,7 @@ use tracing::debug;
 
 use crate::{Builder, Output};
 
-use super::{DiagramError, DynOutput, NextOperation, NodeRegistry};
+use super::{DiagramError, DynOutput, NextOperation, Registry};
 
 #[derive(Error, Debug)]
 pub enum TransformError {
@@ -31,7 +31,7 @@ pub struct TransformOp {
 
 pub(super) fn transform_output(
     builder: &mut Builder,
-    registry: &NodeRegistry,
+    registry: &Registry,
     output: DynOutput,
     transform_op: &TransformOp,
 ) -> Result<Output<serde_json::Value>, DiagramError> {
@@ -40,7 +40,7 @@ pub(super) fn transform_output(
     let json_output = if output.type_id == TypeId::of::<serde_json::Value>() {
         output.into_output()
     } else {
-        registry.data.serialize(builder, output)
+        registry.messages.serialize(builder, output)
     }?;
 
     let program = Program::compile(&transform_op.cel).map_err(|err| TransformError::Parse(err))?;

--- a/src/diagram/unzip.rs
+++ b/src/diagram/unzip.rs
@@ -8,8 +8,7 @@ use crate::Builder;
 use super::{
     impls::{DefaultImpl, NotSupported},
     join::register_join_impl,
-    register_serialize as register_serialize_impl, DiagramError, DynOutput, MessageRegistry,
-    NextOperation, SerializeMessage,
+    DiagramError, DynOutput, MessageRegistry, NextOperation, SerializeMessage,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -71,7 +70,7 @@ macro_rules! dyn_unzip_impl {
                 // Register serialize functions for all items in the tuple.
                 // For a tuple of (T1, T2, T3), registers serialize for T1, T2 and T3.
                 $(
-                    register_serialize_impl::<$P, Serializer>(registry);
+                    registry.register_serialize::<$P, Serializer>();
                 )*
 
                 // Register join impls for T1, T2, T3...
@@ -102,7 +101,7 @@ mod tests {
             "ops": {
                 "op1": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": "unzip"
                 },
                 "unzip": {
@@ -136,17 +135,17 @@ mod tests {
                 },
                 "op2": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "terminate" },
                 },
                 "op3": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "terminate" },
                 },
                 "op4": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "terminate" },
                 },
             },
@@ -203,7 +202,7 @@ mod tests {
                 },
                 "op2": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "terminate" },
                 },
             },
@@ -238,7 +237,7 @@ mod tests {
                 },
                 "op2": {
                     "type": "node",
-                    "builder": "multiply3_uncloneable",
+                    "builder": "multiply3",
                     "next": { "builtin": "terminate" },
                 },
             },

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -298,11 +298,7 @@ fn connect_vertex<'a>(
             }
 
             let joined_output = if join_op.no_serialize.unwrap_or(false) {
-                registry.data.join(
-                    &ordered_outputs[0].type_id.clone(),
-                    builder,
-                    ordered_outputs,
-                )?
+                registry.data.join(builder, ordered_outputs)?
             } else {
                 serialize_and_join(builder, &registry.data, ordered_outputs)?.into()
             };

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -250,8 +250,8 @@ pub(super) fn create_workflow<'a, Streams: StreamPack>(
     for edge_id in terminate_edges {
         let edge = edges.remove(&edge_id).ok_or(unknown_diagram_error!())?;
         match edge.state {
-            EdgeState::Ready { output, origin } => {
-                let serialized_output = serialize(builder, registry, output, origin)?;
+            EdgeState::Ready { output, origin: _ } => {
+                let serialized_output = registry.data.serialize(builder, output)?;
                 builder.connect(serialized_output, scope.terminate);
             }
             EdgeState::Pending => return Err(DiagramError::BadInterconnectChain),
@@ -298,8 +298,11 @@ fn connect_vertex<'a>(
             }
 
             let joined_output = if join_op.no_serialize.unwrap_or(false) {
-                let join_impl = &registry.data.join_impls[&ordered_outputs[0].type_id];
-                join_impl(builder, ordered_outputs)?
+                registry.data.join(
+                    &ordered_outputs[0].type_id.clone(),
+                    builder,
+                    ordered_outputs,
+                )?
             } else {
                 serialize_and_join(builder, &registry.data, ordered_outputs)?.into()
             };
@@ -353,8 +356,7 @@ fn connect_edge<'a>(
     match target.op {
         DiagramOperation::Node(_) => {
             let input = inputs[target.op_id];
-            let deserialized_output =
-                deserialize(builder, registry, output, target, input.type_id)?;
+            let deserialized_output = registry.data.deserialize(&input.type_id, builder, output)?;
             dyn_connect(builder, deserialized_output, input)?;
         }
         DiagramOperation::ForkClone(fork_clone_op) => {
@@ -364,14 +366,7 @@ fn connect_edge<'a>(
                     builder, output, amount,
                 )
             } else {
-                let origin = if let Some(origin_node) = origin {
-                    origin_node
-                } else {
-                    return Err(DiagramError::NotCloneable);
-                };
-
-                let reg = registry.get_registration(&origin.builder)?;
-                reg.fork_clone(builder, output, amount)
+                registry.data.fork_clone(builder, output, amount)
             }?;
             for (o, e) in outputs.into_iter().zip(target.out_edges.iter()) {
                 let out_edge = edges.get_mut(e).ok_or(unknown_diagram_error!())?;
@@ -382,14 +377,7 @@ fn connect_edge<'a>(
             let outputs = if output.type_id == TypeId::of::<serde_json::Value>() {
                 Err(DiagramError::NotUnzippable)
             } else {
-                let origin = if let Some(origin_node) = origin {
-                    origin_node
-                } else {
-                    return Err(DiagramError::NotUnzippable);
-                };
-
-                let reg = registry.get_registration(&origin.builder)?;
-                reg.unzip(builder, output)
+                registry.data.unzip(builder, output)
             }?;
             if outputs.len() < unzip_op.next.len() {
                 return Err(DiagramError::NotUnzippable);
@@ -403,14 +391,7 @@ fn connect_edge<'a>(
             let (ok, err) = if output.type_id == TypeId::of::<serde_json::Value>() {
                 Err(DiagramError::CannotForkResult)
             } else {
-                let origin = if let Some(origin_node) = origin {
-                    origin_node
-                } else {
-                    return Err(DiagramError::CannotForkResult);
-                };
-
-                let reg = registry.get_registration(&origin.builder)?;
-                reg.fork_result(builder, output)
+                registry.data.fork_result(builder, output)
             }?;
             {
                 let out_edge = edges
@@ -433,14 +414,7 @@ fn connect_edge<'a>(
                 let chain = output.into_output::<serde_json::Value>()?.chain(builder);
                 split_chain(chain, split_op)
             } else {
-                let origin = if let Some(origin_node) = origin {
-                    origin_node
-                } else {
-                    return Err(DiagramError::NotSplittable);
-                };
-
-                let reg = registry.get_registration(&origin.builder)?;
-                reg.split(builder, output, split_op)
+                registry.data.split(builder, output, split_op)
             }?;
 
             // Because of how we build `out_edges`, if the split op uses the `remaining` slot,
@@ -512,57 +486,4 @@ fn dyn_connect(
     let typed_input = InputSlot::<TypeErased>::new(input.scope(), input.id());
     builder.connect(typed_output, typed_input);
     Ok(())
-}
-
-/// Try to deserialize `output` into `input_type`. If `output` is not `serde_json::Value`, this does nothing.
-fn deserialize(
-    builder: &mut Builder,
-    registry: &NodeRegistry,
-    output: DynOutput,
-    target: &Vertex,
-    input_type: TypeId,
-) -> Result<DynOutput, DiagramError> {
-    if output.type_id != TypeId::of::<serde_json::Value>() || output.type_id == input_type {
-        Ok(output)
-    } else {
-        let serialized = output.into_output::<serde_json::Value>()?;
-        match target.op {
-            DiagramOperation::Node(node_op) => {
-                let reg = registry.get_registration(&node_op.builder)?;
-                if reg.metadata.request.deserializable {
-                    let deserialize_impl = &registry.data.deserialize_impls[&input_type];
-                    deserialize_impl(builder, serialized)
-                } else {
-                    Err(DiagramError::NotSerializable)
-                }
-            }
-            _ => Err(DiagramError::NotSerializable),
-        }
-    }
-}
-
-fn serialize(
-    builder: &mut Builder,
-    registry: &NodeRegistry,
-    output: DynOutput,
-    origin: Option<&NodeOp>,
-) -> Result<Output<serde_json::Value>, DiagramError> {
-    if output.type_id == TypeId::of::<serde_json::Value>() {
-        output.into_output()
-    } else {
-        // Cannot serialize if we don't know the origin, as we need it to know which serialize impl to use.
-        let origin = if let Some(origin) = origin {
-            origin
-        } else {
-            return Err(DiagramError::NotSerializable);
-        };
-
-        let reg = registry.get_registration(&origin.builder)?;
-        if reg.metadata.response.serializable {
-            let serialize_impl = &registry.data.serialize_impls[&output.type_id];
-            serialize_impl(builder, output)
-        } else {
-            Err(DiagramError::NotSerializable)
-        }
-    }
 }


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## New feature implementation

### Implemented feature

Move operation impl management to `MessageRegistry`.

### Implementation description

The move of impls is actually quite straightforward, the bigger change is in the need to move some node metadatas to messages, particularly flags that indicate if a node is serializable, fork cloneable etc.

The json for "NodeRegistry" (renamed to just "Registry", open to suggestions) now looks like this

```json
{
  "nodes": {
    "test": {
      "metadata": {
        "id": "test",
        "name": "test",
        "request": "bevy_impulse::diagram::registry::tests::test_serialize_registry::Opaque",
        "response": "bevy_impulse::diagram::registry::tests::test_serialize_registry::Bar",
        "config_schema": {
          "type": "null"
        }
      }
    }
  },
  "messages": {
    "bevy_impulse::diagram::registry::tests::test_serialize_registry::Bar": {
      "schema": {
        "$ref": "#/schemas/Bar"
      },
      "operations": [
        "serialize",
        "fork_clone"
      ],
      "unzip_slots": 0
    },
    "bevy_impulse::diagram::registry::tests::test_serialize_registry::Opaque": {
      "schema": null,
      "operations": [],
      "unzip_slots": 0
    }
  },
  "schemas": {
    "Bar": {
      "type": "object",
      "required": [
        "foo"
      ],
      "properties": {
        "foo": {
          "$ref": "#/schemas/Foo"
        }
      }
    },
    "Foo": {
      "type": "object",
      "required": [
        "hello"
      ],
      "properties": {
        "hello": {
          "type": "string"
        }
      }
    }
  }
}
```

There are some minor catches to this

1. The rust `std::any::type_name::<T>()` is used to key the messages, `TypeId` is still used as the key, type name is only used when serializing. The catch here is that type name and `TypeId` do not have a 1-to-1 relationship, i.e. type name is not unique, multiple types may have the same type name. In practice, conflicts shouldn't be common, but if it does, there isn't a solution atm (we will first need either derive or a system to register messages independent of nodes).
2. The rust type name is different from the json schema type name. This shouldn't cause any issue in practice, just a small confusion.