### PR TITLE
Support for dynamic dictionaries of buffers

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -50,5 +50,5 @@ jobs:
       run: cargo test --features single_threaded_async
 
     - name: Build docs
-      run: cargo doc
+      run: cargo doc --all-features
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,3 +16,4 @@ proc-macro = true
 [dependencies]
 syn = "2.0"
 quote = "1.0"
+proc-macro2 = "1.0.93"

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -57,7 +57,7 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
     let impl_joined = impl_joined(&buffer_struct, &input_struct, &field_ident)?;
 
     let gen = quote! {
-        impl #impl_generics ::bevy_impulse::JoinedValue for #struct_ident #ty_generics #where_clause {
+        impl #impl_generics ::bevy_impulse::Joined for #struct_ident #ty_generics #where_clause {
             type Buffers = #buffer_struct_ident #ty_generics;
         }
 
@@ -122,7 +122,7 @@ pub(crate) fn impl_buffer_key_map(input_struct: &ItemStruct) -> Result<TokenStre
     let impl_accessed = impl_accessed(&buffer_struct, &input_struct, &field_ident, &field_type)?;
 
     let gen = quote! {
-        impl #impl_generics ::bevy_impulse::BufferKeyMap for #struct_ident #ty_generics #where_clause {
+        impl #impl_generics ::bevy_impulse::Accessor for #struct_ident #ty_generics #where_clause {
             type Buffers = #buffer_struct_ident #ty_generics;
         }
 
@@ -413,8 +413,8 @@ fn impl_buffer_map_layout(
 }
 
 /// Params:
-///   joined_struct: The struct to implement `Joined`.
-///   item_struct: The associated `Item` type to use for the `Joined` implementation.
+///   joined_struct: The struct to implement `Joining`.
+///   item_struct: The associated `Item` type to use for the `Joining` implementation.
 fn impl_joined(
     joined_struct: &ItemStruct,
     item_struct: &ItemStruct,
@@ -425,7 +425,7 @@ fn impl_joined(
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
 
     Ok(quote! {
-        impl #impl_generics ::bevy_impulse::Joined for #struct_ident #ty_generics #where_clause {
+        impl #impl_generics ::bevy_impulse::Joining for #struct_ident #ty_generics #where_clause {
             type Item = #item_struct_ident #ty_generics;
 
             fn pull(&self, session: ::bevy_impulse::re_exports::Entity, world: &mut ::bevy_impulse::re_exports::World) -> Result<Self::Item, ::bevy_impulse::OperationError> {
@@ -452,7 +452,7 @@ fn impl_accessed(
     let (impl_generics, ty_generics, where_clause) = key_struct.generics.split_for_impl();
 
     Ok(quote! {
-        impl #impl_generics ::bevy_impulse::Accessed for #struct_ident #ty_generics #where_clause {
+        impl #impl_generics ::bevy_impulse::Accessing for #struct_ident #ty_generics #where_clause {
             type Key = #key_struct_ident #ty_generics;
 
             fn add_accessor(
@@ -461,7 +461,7 @@ fn impl_accessed(
                 world: &mut ::bevy_impulse::re_exports::World,
             ) -> ::bevy_impulse::OperationResult {
                 #(
-                    ::bevy_impulse::Accessed::add_accessor(&self.#field_ident, accessor, world)?;
+                    ::bevy_impulse::Accessing::add_accessor(&self.#field_ident, accessor, world)?;
                 )*
                 Ok(())
             }

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -1,58 +1,60 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_quote, Field, Generics, Ident, ItemStruct, Type, TypePath};
+use syn::{
+    parse_quote, Field, Generics, Ident, ImplGenerics, ItemStruct, Type, TypeGenerics, TypePath,
+    Visibility, WhereClause,
+};
 
 use crate::Result;
+
+const JOINED_ATTR_TAG: &'static str = "joined";
+const KEY_ATTR_TAG: &'static str = "key";
 
 pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream> {
     let struct_ident = &input_struct.ident;
     let (impl_generics, ty_generics, where_clause) = input_struct.generics.split_for_impl();
     let StructConfig {
         buffer_struct_name: buffer_struct_ident,
-    } = StructConfig::from_data_struct(&input_struct);
+    } = StructConfig::from_data_struct(&input_struct, &JOINED_ATTR_TAG);
     let buffer_struct_vis = &input_struct.vis;
 
-    let (field_ident, _, field_config) = get_fields_map(&input_struct.fields)?;
+    let (field_ident, _, field_config) =
+        get_fields_map(&input_struct.fields, FieldSettings::for_joined())?;
     let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
     let noncopy = field_config.iter().any(|config| config.noncopy);
 
-    let buffer_struct: ItemStruct = parse_quote! {
-        #[allow(non_camel_case_types, unused)]
-        #buffer_struct_vis struct #buffer_struct_ident #impl_generics #where_clause {
-            #(
-                #buffer_struct_vis #field_ident: #buffer,
-            )*
-        }
-    };
+    let buffer_struct: ItemStruct = generate_buffer_struct(
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
 
-    let impl_buffer_clone = if noncopy {
-        // Clone impl for structs with a buffer that is not copyable
-        quote! {
-            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
-                fn clone(&self) -> Self {
-                    Self {
-                        #(
-                            #field_ident: self.#field_ident.clone(),
-                        )*
-                    }
-                }
-            }
-        }
-    } else {
-        // Clone and copy impl for structs with buffers that are all copyable
-        quote! {
-            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
-                fn clone(&self) -> Self {
-                    *self
-                }
-            }
+    let impl_buffer_clone = impl_buffer_clone(
+        &buffer_struct_ident,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        noncopy,
+    );
 
-            impl #impl_generics ::std::marker::Copy for #buffer_struct_ident #ty_generics #where_clause {}
-        }
-    };
+    let impl_select_buffers = impl_select_buffers(
+        struct_ident,
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
 
-    let impl_buffer_map_layout = impl_buffer_map_layout(&buffer_struct, &input_struct)?;
-    let impl_joined = impl_joined(&buffer_struct, &input_struct)?;
+    let impl_buffer_map_layout =
+        impl_buffer_map_layout(&buffer_struct, &field_ident, &field_config)?;
+    let impl_joined = impl_joined(&buffer_struct, &input_struct, &field_ident)?;
 
     let gen = quote! {
         impl #impl_generics ::bevy_impulse::JoinedValue for #struct_ident #ty_generics #where_clause {
@@ -63,23 +65,76 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
 
         #impl_buffer_clone
 
-        impl #impl_generics #struct_ident #ty_generics #where_clause {
-            fn select_buffers(
-                #(
-                    #field_ident: #buffer,
-                )*
-            ) -> #buffer_struct_ident #ty_generics {
-                #buffer_struct_ident {
-                    #(
-                        #field_ident,
-                    )*
-                }
-            }
-        }
+        #impl_select_buffers
 
         #impl_buffer_map_layout
 
         #impl_joined
+    };
+
+    Ok(gen.into())
+}
+
+pub(crate) fn impl_buffer_key_map(input_struct: &ItemStruct) -> Result<TokenStream> {
+    let struct_ident = &input_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = input_struct.generics.split_for_impl();
+    let StructConfig {
+        buffer_struct_name: buffer_struct_ident,
+    } = StructConfig::from_data_struct(&input_struct, &KEY_ATTR_TAG);
+    let buffer_struct_vis = &input_struct.vis;
+
+    let (field_ident, field_type, field_config) =
+        get_fields_map(&input_struct.fields, FieldSettings::for_key())?;
+    let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
+    let noncopy = field_config.iter().any(|config| config.noncopy);
+
+    let buffer_struct: ItemStruct = generate_buffer_struct(
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
+
+    let impl_buffer_clone = impl_buffer_clone(
+        &buffer_struct_ident,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        noncopy,
+    );
+
+    let impl_select_buffers = impl_select_buffers(
+        struct_ident,
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
+
+    let impl_buffer_map_layout =
+        impl_buffer_map_layout(&buffer_struct, &field_ident, &field_config)?;
+    let impl_accessed = impl_accessed(&buffer_struct, &input_struct, &field_ident, &field_type)?;
+
+    let gen = quote! {
+        impl #impl_generics ::bevy_impulse::BufferKeyMap for #struct_ident #ty_generics #where_clause {
+            type Buffers = #buffer_struct_ident #ty_generics;
+        }
+
+        #buffer_struct
+
+        #impl_buffer_clone
+
+        #impl_select_buffers
+
+        #impl_buffer_map_layout
+
+        #impl_accessed
     };
 
     Ok(gen.into())
@@ -112,7 +167,7 @@ struct StructConfig {
 }
 
 impl StructConfig {
-    fn from_data_struct(data_struct: &ItemStruct) -> Self {
+    fn from_data_struct(data_struct: &ItemStruct, attr_tag: &str) -> Self {
         let mut config = Self {
             buffer_struct_name: format_ident!("__bevy_impulse_{}_Buffers", data_struct.ident),
         };
@@ -120,7 +175,7 @@ impl StructConfig {
         let attr = data_struct
             .attrs
             .iter()
-            .find(|attr| attr.path().is_ident("joined"));
+            .find(|attr| attr.path().is_ident(attr_tag));
 
         if let Some(attr) = attr {
             attr.parse_nested_meta(|meta| {
@@ -137,23 +192,52 @@ impl StructConfig {
     }
 }
 
+struct FieldSettings {
+    default_buffer: fn(&Type) -> Type,
+    attr_tag: &'static str,
+}
+
+impl FieldSettings {
+    fn for_joined() -> Self {
+        Self {
+            default_buffer: Self::default_field_for_joined,
+            attr_tag: JOINED_ATTR_TAG,
+        }
+    }
+
+    fn for_key() -> Self {
+        Self {
+            default_buffer: Self::default_field_for_key,
+            attr_tag: KEY_ATTR_TAG,
+        }
+    }
+
+    fn default_field_for_joined(ty: &Type) -> Type {
+        parse_quote! { ::bevy_impulse::Buffer<#ty> }
+    }
+
+    fn default_field_for_key(ty: &Type) -> Type {
+        parse_quote! { <#ty as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer }
+    }
+}
+
 struct FieldConfig {
     buffer: Type,
     noncopy: bool,
 }
 
 impl FieldConfig {
-    fn from_field(field: &Field) -> Self {
+    fn from_field(field: &Field, settings: &FieldSettings) -> Self {
         let ty = &field.ty;
         let mut config = Self {
-            buffer: parse_quote! { ::bevy_impulse::Buffer<#ty> },
+            buffer: (settings.default_buffer)(ty),
             noncopy: false,
         };
 
         for attr in field
             .attrs
             .iter()
-            .filter(|attr| attr.path().is_ident("joined"))
+            .filter(|attr| attr.path().is_ident(settings.attr_tag))
         {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("buffer") {
@@ -172,7 +256,10 @@ impl FieldConfig {
     }
 }
 
-fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<FieldConfig>)> {
+fn get_fields_map(
+    fields: &syn::Fields,
+    settings: FieldSettings,
+) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<FieldConfig>)> {
     match fields {
         syn::Fields::Named(data) => {
             let mut idents = Vec::new();
@@ -185,7 +272,7 @@ fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<
                     .ok_or("expected named fields".to_string())?;
                 idents.push(ident);
                 types.push(&field.ty);
-                configs.push(FieldConfig::from_field(field));
+                configs.push(FieldConfig::from_field(field, &settings));
             }
             Ok((idents, types, configs))
         }
@@ -193,16 +280,98 @@ fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<
     }
 }
 
+fn generate_buffer_struct(
+    buffer_struct_ident: &Ident,
+    buffer_struct_vis: &Visibility,
+    impl_generics: &ImplGenerics,
+    where_clause: &Option<&WhereClause>,
+    field_ident: &Vec<&Ident>,
+    buffer: &Vec<&Type>,
+) -> ItemStruct {
+    parse_quote! {
+        #[allow(non_camel_case_types, unused)]
+        #buffer_struct_vis struct #buffer_struct_ident #impl_generics #where_clause {
+            #(
+                #buffer_struct_vis #field_ident: #buffer,
+            )*
+        }
+    }
+}
+
+fn impl_select_buffers(
+    struct_ident: &Ident,
+    buffer_struct_ident: &Ident,
+    buffer_struct_vis: &Visibility,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    field_ident: &Vec<&Ident>,
+    buffer: &Vec<&Type>,
+) -> TokenStream {
+    quote! {
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
+            #buffer_struct_vis fn select_buffers(
+                #(
+                    #field_ident: #buffer,
+                )*
+            ) -> #buffer_struct_ident #ty_generics {
+                #buffer_struct_ident {
+                    #(
+                        #field_ident,
+                    )*
+                }
+            }
+        }
+    }
+    .into()
+}
+
+fn impl_buffer_clone(
+    buffer_struct_ident: &Ident,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    field_ident: &Vec<&Ident>,
+    noncopy: bool,
+) -> TokenStream {
+    if noncopy {
+        // Clone impl for structs with a buffer that is not copyable
+        quote! {
+            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+                fn clone(&self) -> Self {
+                    Self {
+                        #(
+                            #field_ident: self.#field_ident.clone(),
+                        )*
+                    }
+                }
+            }
+        }
+    } else {
+        // Clone and copy impl for structs with buffers that are all copyable
+        quote! {
+            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl #impl_generics ::std::marker::Copy for #buffer_struct_ident #ty_generics #where_clause {}
+        }
+    }
+}
+
 /// Params:
 ///   buffer_struct: The struct to implement `BufferMapLayout`.
 ///   item_struct: The struct which `buffer_struct` is derived from.
+///   settings: [`FieldSettings`] to use when parsing the field attributes
 fn impl_buffer_map_layout(
     buffer_struct: &ItemStruct,
-    item_struct: &ItemStruct,
+    field_ident: &Vec<&Ident>,
+    field_config: &Vec<FieldConfig>,
 ) -> Result<proc_macro2::TokenStream> {
     let struct_ident = &buffer_struct.ident;
     let (impl_generics, ty_generics, where_clause) = buffer_struct.generics.split_for_impl();
-    let (field_ident, _, field_config) = get_fields_map(&item_struct.fields)?;
     let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
     let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
 
@@ -249,17 +418,17 @@ fn impl_buffer_map_layout(
 fn impl_joined(
     joined_struct: &ItemStruct,
     item_struct: &ItemStruct,
+    field_ident: &Vec<&Ident>,
 ) -> Result<proc_macro2::TokenStream> {
     let struct_ident = &joined_struct.ident;
     let item_struct_ident = &item_struct.ident;
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
-    let (field_ident, _, _) = get_fields_map(&item_struct.fields)?;
 
     Ok(quote! {
         impl #impl_generics ::bevy_impulse::Joined for #struct_ident #ty_generics #where_clause {
             type Item = #item_struct_ident #ty_generics;
 
-            fn pull(&self, session: ::bevy_ecs::prelude::Entity, world: &mut ::bevy_ecs::prelude::World) -> Result<Self::Item, ::bevy_impulse::OperationError> {
+            fn pull(&self, session: ::bevy_impulse::re_exports::Entity, world: &mut ::bevy_impulse::re_exports::World) -> Result<Self::Item, ::bevy_impulse::OperationError> {
                 #(
                     let #field_ident = self.#field_ident.pull(session, world)?;
                 )*
@@ -267,6 +436,57 @@ fn impl_joined(
                 Ok(Self::Item {#(
                     #field_ident,
                 )*})
+            }
+        }
+    }.into())
+}
+
+fn impl_accessed(
+    accessed_struct: &ItemStruct,
+    key_struct: &ItemStruct,
+    field_ident: &Vec<&Ident>,
+    field_type: &Vec<&Type>,
+) -> Result<proc_macro2::TokenStream> {
+    let struct_ident = &accessed_struct.ident;
+    let key_struct_ident = &key_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = key_struct.generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics ::bevy_impulse::Accessed for #struct_ident #ty_generics #where_clause {
+            type Key = #key_struct_ident #ty_generics;
+
+            fn add_accessor(
+                &self,
+                accessor: ::bevy_impulse::re_exports::Entity,
+                world: &mut ::bevy_impulse::re_exports::World,
+            ) -> ::bevy_impulse::OperationResult {
+                #(
+                    ::bevy_impulse::Accessed::add_accessor(&self.#field_ident, accessor, world)?;
+                )*
+                Ok(())
+            }
+
+            fn create_key(&self, builder: &::bevy_impulse::BufferKeyBuilder) -> Self::Key {
+                Self::Key {#(
+                    // TODO(@mxgrey): This currently does not have good support for the user
+                    // substituting in a different key type than what the BufferKeyLifecycle expects.
+                    // We could consider adding a .clone().into() to help support that use case, but
+                    // this would be such a niche use case that I think we can ignore it for now.
+                    #field_ident: <#field_type as ::bevy_impulse::BufferKeyLifecycle>::create_key(&self.#field_ident, builder),
+                )*}
+            }
+
+            fn deep_clone_key(key: &Self::Key) -> Self::Key {
+                Self::Key {#(
+                    #field_ident: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.#field_ident),
+                )*}
+            }
+
+            fn is_key_in_use(key: &Self::Key) -> bool {
+                false
+                    #(
+                        || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.#field_ident)
+                    )*
             }
         }
     }.into())

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -211,14 +211,14 @@ fn impl_buffer_map_layout(
             fn buffer_list(&self) -> ::smallvec::SmallVec<[AnyBuffer; 8]> {
                 use smallvec::smallvec;
                 smallvec![#(
-                    self.#field_ident.as_any_buffer(),
+                    ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.#field_ident),
                 )*]
             }
 
             fn try_from_buffer_map(buffers: &::bevy_impulse::BufferMap) -> Result<Self, ::bevy_impulse::IncompatibleLayout> {
                 let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
                 #(
-                    let #field_ident = if let Ok(buffer) = compatibility.require_buffer_type::<#buffer>(#map_key, buffers) {
+                    let #field_ident = if let Ok(buffer) = compatibility.require_buffer_by_literal::<#buffer>(#map_key, buffers) {
                         buffer
                     } else {
                         return Err(compatibility);

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -380,7 +380,7 @@ fn impl_buffer_map_layout(
             fn try_from_buffer_map(buffers: &::bevy_impulse::BufferMap) -> Result<Self, ::bevy_impulse::IncompatibleLayout> {
                 let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
                 #(
-                    let #field_ident = compatibility.require_buffer_by_literal::<#buffer>(#map_key, buffers);
+                    let #field_ident = compatibility.require_buffer_for_identifier::<#buffer>(#map_key, buffers);
                 )*
 
                 // Unwrap the Ok after inspecting every field so that the

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -1,0 +1,266 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+use syn::{parse_quote, Field, Generics, Ident, ItemStruct, Type, TypePath};
+
+use crate::Result;
+
+pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream> {
+    let struct_ident = &input_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = input_struct.generics.split_for_impl();
+    let StructConfig {
+        buffer_struct_name: buffer_struct_ident,
+    } = StructConfig::from_data_struct(&input_struct);
+    let buffer_struct_vis = &input_struct.vis;
+
+    let (field_ident, _, field_config) = get_fields_map(&input_struct.fields)?;
+    let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
+    let noncopy = field_config.iter().any(|config| config.noncopy);
+
+    let buffer_struct: ItemStruct = parse_quote! {
+        #[allow(non_camel_case_types, unused)]
+        #buffer_struct_vis struct #buffer_struct_ident #impl_generics #where_clause {
+            #(
+                #buffer_struct_vis #field_ident: #buffer,
+            )*
+        }
+    };
+
+    let buffer_clone_impl = if noncopy {
+        // Clone impl for structs with a buffer that is not copyable
+        quote! {
+            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+                fn clone(&self) -> Self {
+                    Self {
+                        #(
+                            #field_ident: self.#field_ident.clone(),
+                        )*
+                    }
+                }
+            }
+        }
+    } else {
+        // Clone and copy impl for structs with buffers that are all copyable
+        quote! {
+            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl #impl_generics ::std::marker::Copy for #buffer_struct_ident #ty_generics #where_clause {}
+        }
+    };
+
+    let impl_buffer_map_layout = impl_buffer_map_layout(&buffer_struct, &input_struct)?;
+    let impl_joined = impl_joined(&buffer_struct, &input_struct)?;
+
+    let gen = quote! {
+        impl #impl_generics ::bevy_impulse::JoinedValue for #struct_ident #ty_generics #where_clause {
+            type Buffers = #buffer_struct_ident #ty_generics;
+        }
+
+        #buffer_struct
+
+        #buffer_clone_impl
+
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
+            fn select_buffers(
+                #(
+                    #field_ident: #buffer,
+                )*
+            ) -> #buffer_struct_ident #ty_generics {
+                #buffer_struct_ident {
+                    #(
+                        #field_ident,
+                    )*
+                }
+            }
+        }
+
+        #impl_buffer_map_layout
+
+        #impl_joined
+    };
+
+    Ok(gen.into())
+}
+
+/// Code that are currently unused but could be used in the future, move them out of this mod if
+/// they are ever used.
+#[allow(unused)]
+mod _unused {
+    use super::*;
+
+    /// Converts a list of generics to a [`PhantomData`] TypePath.
+    /// e.g. `::std::marker::PhantomData<fn(T,)>`
+    fn to_phantom_data(generics: &Generics) -> TypePath {
+        let lifetimes: Vec<Type> = generics
+            .lifetimes()
+            .map(|lt| {
+                let lt = &lt.lifetime;
+                let ty: Type = parse_quote! { & #lt () };
+                ty
+            })
+            .collect();
+        let ty_params: Vec<&Ident> = generics.type_params().map(|ty| &ty.ident).collect();
+        parse_quote! { ::std::marker::PhantomData<fn(#(#lifetimes,)* #(#ty_params,)*)> }
+    }
+}
+
+struct StructConfig {
+    buffer_struct_name: Ident,
+}
+
+impl StructConfig {
+    fn from_data_struct(data_struct: &ItemStruct) -> Self {
+        let mut config = Self {
+            buffer_struct_name: format_ident!("__bevy_impulse_{}_Buffers", data_struct.ident),
+        };
+
+        let attr = data_struct
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("joined"));
+
+        if let Some(attr) = attr {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("buffers_struct_name") {
+                    config.buffer_struct_name = meta.value()?.parse()?;
+                }
+                Ok(())
+            })
+            // panic if attribute is malformed, this will result in a compile error which is intended.
+            .unwrap();
+        }
+
+        config
+    }
+}
+
+struct FieldConfig {
+    buffer: Type,
+    noncopy: bool,
+}
+
+impl FieldConfig {
+    fn from_field(field: &Field) -> Self {
+        let ty = &field.ty;
+        let mut config = Self {
+            buffer: parse_quote! { ::bevy_impulse::Buffer<#ty> },
+            noncopy: false,
+        };
+
+        for attr in field
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("joined"))
+        {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("buffer") {
+                    config.buffer = meta.value()?.parse()?;
+                }
+                if meta.path.is_ident("noncopy_buffer") {
+                    config.noncopy = true;
+                }
+                Ok(())
+            })
+            // panic if attribute is malformed, this will result in a compile error which is intended.
+            .unwrap();
+        }
+
+        config
+    }
+}
+
+fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<FieldConfig>)> {
+    match fields {
+        syn::Fields::Named(data) => {
+            let mut idents = Vec::new();
+            let mut types = Vec::new();
+            let mut configs = Vec::new();
+            for field in &data.named {
+                let ident = field
+                    .ident
+                    .as_ref()
+                    .ok_or("expected named fields".to_string())?;
+                idents.push(ident);
+                types.push(&field.ty);
+                configs.push(FieldConfig::from_field(field));
+            }
+            Ok((idents, types, configs))
+        }
+        _ => return Err("expected named fields".to_string()),
+    }
+}
+
+/// Params:
+///   buffer_struct: The struct to implement `BufferMapLayout`.
+///   item_struct: The struct which `buffer_struct` is derived from.
+fn impl_buffer_map_layout(
+    buffer_struct: &ItemStruct,
+    item_struct: &ItemStruct,
+) -> Result<proc_macro2::TokenStream> {
+    let struct_ident = &buffer_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = buffer_struct.generics.split_for_impl();
+    let (field_ident, _, field_config) = get_fields_map(&item_struct.fields)?;
+    let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
+    let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
+
+    Ok(quote! {
+        impl #impl_generics ::bevy_impulse::BufferMapLayout for #struct_ident #ty_generics #where_clause {
+            fn buffer_list(&self) -> ::smallvec::SmallVec<[AnyBuffer; 8]> {
+                use smallvec::smallvec;
+                smallvec![#(
+                    self.#field_ident.as_any_buffer(),
+                )*]
+            }
+
+            fn try_from_buffer_map(buffers: &::bevy_impulse::BufferMap) -> Result<Self, ::bevy_impulse::IncompatibleLayout> {
+                let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
+                #(
+                    let #field_ident = if let Ok(buffer) = compatibility.require_buffer_type::<#buffer>(#map_key, buffers) {
+                        buffer
+                    } else {
+                        return Err(compatibility);
+                    };
+                )*
+
+                Ok(Self {
+                    #(
+                        #field_ident,
+                    )*
+                })
+            }
+        }
+    }
+    .into())
+}
+
+/// Params:
+///   joined_struct: The struct to implement `Joined`.
+///   item_struct: The associated `Item` type to use for the `Joined` implementation.
+fn impl_joined(
+    joined_struct: &ItemStruct,
+    item_struct: &ItemStruct,
+) -> Result<proc_macro2::TokenStream> {
+    let struct_ident = &joined_struct.ident;
+    let item_struct_ident = &item_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
+    let (field_ident, _, _) = get_fields_map(&item_struct.fields)?;
+
+    Ok(quote! {
+        impl #impl_generics ::bevy_impulse::Joined for #struct_ident #ty_generics #where_clause {
+            type Item = #item_struct_ident #ty_generics;
+
+            fn pull(&self, session: ::bevy_ecs::prelude::Entity, world: &mut ::bevy_ecs::prelude::World) -> Result<Self::Item, ::bevy_impulse::OperationError> {
+                #(
+                    let #field_ident = self.#field_ident.pull(session, world)?;
+                )*
+
+                Ok(Self::Item {#(
+                    #field_ident,
+                )*})
+            }
+        }
+    }.into())
+}

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -25,7 +25,7 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
         }
     };
 
-    let buffer_clone_impl = if noncopy {
+    let impl_buffer_clone = if noncopy {
         // Clone impl for structs with a buffer that is not copyable
         quote! {
             impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
@@ -61,7 +61,7 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
 
         #buffer_struct
 
-        #buffer_clone_impl
+        #impl_buffer_clone
 
         impl #impl_generics #struct_ident #ty_generics #where_clause {
             fn select_buffers(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -65,7 +65,7 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
 /// The result error is the compiler error message to be displayed.
 type Result<T> = std::result::Result<T, String>;
 
-#[proc_macro_derive(JoinedValue, attributes(joined))]
+#[proc_macro_derive(Joined, attributes(joined))]
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_joined_value(&input) {
@@ -77,7 +77,7 @@ pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     }
 }
 
-#[proc_macro_derive(BufferKeyMap, attributes(key))]
+#[proc_macro_derive(Accessor, attributes(key))]
 pub fn derive_buffer_key_map(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_buffer_key_map(&input) {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -16,7 +16,7 @@
 */
 
 mod buffer;
-use buffer::impl_joined_value;
+use buffer::{impl_buffer_key_map, impl_joined_value};
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -69,6 +69,18 @@ type Result<T> = std::result::Result<T, String>;
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_joined_value(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(msg) => quote! {
+            compile_error!(#msg);
+        }
+        .into(),
+    }
+}
+
+#[proc_macro_derive(BufferKeyMap, attributes(key))]
+pub fn derive_buffer_key_map(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    match impl_buffer_key_map(&input) {
         Ok(tokens) => tokens.into(),
         Err(msg) => quote! {
             compile_error!(#msg);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,9 +15,12 @@
  *
 */
 
+mod buffer;
+use buffer::impl_joined_value;
+
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::DeriveInput;
+use syn::{parse_macro_input, DeriveInput, ItemStruct};
 
 #[proc_macro_derive(Stream)]
 pub fn simple_stream_macro(item: TokenStream) -> TokenStream {
@@ -57,4 +60,19 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+/// The result error is the compiler error message to be displayed.
+type Result<T> = std::result::Result<T, String>;
+
+#[proc_macro_derive(JoinedValue, attributes(joined))]
+pub fn derive_joined_value(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    match impl_joined_value(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(msg) => quote! {
+            compile_error!(#msg);
+        }
+        .into(),
+    }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -267,7 +267,7 @@ impl<T> BufferKey<T> {
 }
 
 #[derive(Clone)]
-pub struct DynBufferKey {
+pub struct AnyBufferKey {
     buffer: Entity,
     session: Entity,
     accessor: Entity,
@@ -275,7 +275,7 @@ pub struct DynBufferKey {
     type_id: TypeId,
 }
 
-impl std::fmt::Debug for DynBufferKey {
+impl std::fmt::Debug for AnyBufferKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f
             .debug_struct("DynBufferKey")
@@ -288,7 +288,7 @@ impl std::fmt::Debug for DynBufferKey {
     }
 }
 
-impl DynBufferKey {
+impl AnyBufferKey {
     /// Downcast this into a concrete [`BufferKey`] type.
     pub fn into_buffer_key<T: 'static>(&self) -> Option<BufferKey<T>> {
         if TypeId::of::<T>() == self.type_id {
@@ -305,10 +305,10 @@ impl DynBufferKey {
     }
 }
 
-impl<T: 'static> From<BufferKey<T>> for DynBufferKey {
+impl<T: 'static> From<BufferKey<T>> for AnyBufferKey {
     fn from(value: BufferKey<T>) -> Self {
         let type_id = TypeId::of::<T>();
-        DynBufferKey {
+        AnyBufferKey {
             buffer: value.buffer,
             session: value.session,
             accessor: value.accessor,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -52,6 +52,9 @@ pub use bufferable::*;
 mod manage_buffer;
 pub use manage_buffer::*;
 
+#[cfg(feature = "diagram")]
+mod json_buffer;
+
 /// A buffer is a special type of node within a workflow that is able to store
 /// and release data. When a session is finished, the buffered data from the
 /// session will be automatically cleared.

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -113,6 +113,14 @@ impl<T> Buffer<T> {
     pub fn location(&self) -> BufferLocation {
         self.location
     }
+
+    /// Cast this into an [`AnyBuffer`].
+    pub fn as_any_buffer(&self) -> AnyBuffer
+    where
+        T: 'static + Send + Sync,
+    {
+        self.clone().into()
+    }
 }
 
 impl<T> Clone for Buffer<T> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -22,7 +22,7 @@ use bevy_ecs::{
     system::SystemParam,
 };
 
-use std::{ops::RangeBounds, sync::Arc, any::TypeId};
+use std::{ops::RangeBounds, sync::Arc};
 
 use crate::{
     Builder, Chain, Gate, GateState, InputSlot, NotifyBufferUpdate, OnNewBufferValue, UnusedTarget,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -233,7 +233,7 @@ impl Default for RetentionPolicy {
 /// To obtain a `BufferKey`, use [`Chain::with_access`][1], or [`listen`][2].
 ///
 /// [1]: crate::Chain::with_access
-/// [2]: crate::Bufferable::listen
+/// [2]: crate::Accessible::listen
 pub struct BufferKey<T> {
     tag: BufferKeyTag,
     _ignore: std::marker::PhantomData<fn(T)>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -56,6 +56,8 @@ pub use manage_buffer::*;
 
 #[cfg(feature = "diagram")]
 mod json_buffer;
+#[cfg(feature = "diagram")]
+pub use json_buffer::*;
 
 /// A buffer is a special type of node within a workflow that is able to store
 /// and release data. When a session is finished, the buffered data from the

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -509,7 +509,7 @@ where
         self.len() == 0
     }
 
-    /// Check whether the gate of this buffer is open or closed
+    /// Check whether the gate of this buffer is open or closed.
     pub fn gate(&self) -> Gate {
         self.gate
             .map
@@ -552,7 +552,7 @@ where
         self.storage.drain(self.session, range)
     }
 
-    /// Pull the oldest item from the buffer
+    /// Pull the oldest item from the buffer.
     pub fn pull(&mut self) -> Option<T> {
         self.modified = true;
         self.storage.pull(self.session)
@@ -585,7 +585,7 @@ where
     // continuous systems with BufferAccessMut from running at the same time no
     // matter what the buffer type is.
 
-    /// Tell the buffer [`Gate`] to open
+    /// Tell the buffer [`Gate`] to open.
     pub fn open_gate(&mut self) {
         if let Some(gate) = self.gate.map.get_mut(&self.session) {
             if *gate != Gate::Open {
@@ -595,7 +595,7 @@ where
         }
     }
 
-    /// Tell the buffer [`Gate`] to close
+    /// Tell the buffer [`Gate`] to close.
     pub fn close_gate(&mut self) {
         if let Some(gate) = self.gate.map.get_mut(&self.session) {
             *gate = Gate::Closed;
@@ -604,7 +604,7 @@ where
         }
     }
 
-    /// Perform an action on the gate of the buffer
+    /// Perform an action on the gate of the buffer.
     pub fn gate_action(&mut self, action: Gate) {
         match action {
             Gate::Open => self.open_gate(),

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -113,14 +113,6 @@ impl<T> Buffer<T> {
     pub fn location(&self) -> BufferLocation {
         self.location
     }
-
-    /// Cast this into an [`AnyBuffer`].
-    pub fn as_any_buffer(&self) -> AnyBuffer
-    where
-        T: 'static + Send + Sync,
-    {
-        self.clone().into()
-    }
 }
 
 impl<T> Clone for Buffer<T> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -251,7 +251,7 @@ impl<T> BufferKey<T> {
         self.tag.session
     }
 
-    pub(crate) fn tag(&self) -> &BufferKeyTag {
+    pub fn tag(&self) -> &BufferKeyTag {
         &self.tag
     }
 
@@ -286,11 +286,8 @@ impl<T> std::fmt::Debug for BufferKey<T> {
 
 /// The identifying information for a buffer key. This does not indicate
 /// anything about the type of messages that the buffer can contain.
-///
-/// This struct will be internal to the crate until we decide to make
-/// [`BufferAccessLifecycle`] a public struct.
 #[derive(Clone)]
-pub(crate) struct BufferKeyTag {
+pub struct BufferKeyTag {
     pub buffer: Entity,
     pub session: Entity,
     pub accessor: Entity,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -110,40 +110,6 @@ pub struct CloneFromBuffer<T: Clone> {
     pub(crate) _ignore: std::marker::PhantomData<fn(T)>,
 }
 
-/// A [`Buffer`] whose type has been anonymized.
-#[derive(Clone, Copy, Debug)]
-pub struct DynBuffer {
-    pub(crate) scope: Entity,
-    pub(crate) source: Entity,
-    pub(crate) type_id: TypeId,
-}
-
-impl DynBuffer {
-    /// Downcast this into a concrete [`Buffer`] type.
-    pub fn into_buffer<T: 'static>(&self) -> Option<Buffer<T>> {
-        if TypeId::of::<T>() == self.type_id {
-            Some(Buffer {
-                scope: self.scope,
-                source: self.source,
-                _ignore: Default::default(),
-            })
-        } else {
-            None
-        }
-    }
-}
-
-impl<T: 'static> From<Buffer<T>> for DynBuffer {
-    fn from(value: Buffer<T>) -> Self {
-        let type_id = TypeId::of::<T>();
-        DynBuffer {
-            scope: value.scope,
-            source: value.source,
-            type_id,
-        }
-    }
-}
-
 /// Settings to describe the behavior of a buffer.
 #[derive(Default, Clone, Copy)]
 pub struct BufferSettings {
@@ -263,58 +229,6 @@ impl<T> BufferKey<T> {
             .as_ref()
             .map(|l| Arc::new(l.as_ref().clone()));
         deep
-    }
-}
-
-#[derive(Clone)]
-pub struct AnyBufferKey {
-    buffer: Entity,
-    session: Entity,
-    accessor: Entity,
-    lifecycle: Option<Arc<BufferAccessLifecycle>>,
-    type_id: TypeId,
-}
-
-impl std::fmt::Debug for AnyBufferKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f
-            .debug_struct("DynBufferKey")
-            .field("buffer", &self.buffer)
-            .field("session", &self.session)
-            .field("accessor", &self.accessor)
-            .field("in_use", &self.lifecycle.as_ref().is_some_and(|l| l.is_in_use()))
-            .field("type_id", &self.type_id)
-            .finish()
-    }
-}
-
-impl AnyBufferKey {
-    /// Downcast this into a concrete [`BufferKey`] type.
-    pub fn into_buffer_key<T: 'static>(&self) -> Option<BufferKey<T>> {
-        if TypeId::of::<T>() == self.type_id {
-            Some(BufferKey {
-                buffer: self.buffer,
-                session: self.session,
-                accessor: self.accessor,
-                lifecycle: self.lifecycle.clone(),
-                _ignore: Default::default(),
-            })
-        } else {
-            None
-        }
-    }
-}
-
-impl<T: 'static> From<BufferKey<T>> for AnyBufferKey {
-    fn from(value: BufferKey<T>) -> Self {
-        let type_id = TypeId::of::<T>();
-        AnyBufferKey {
-            buffer: value.buffer,
-            session: value.session,
-            accessor: value.accessor,
-            lifecycle: value.lifecycle.clone(),
-            type_id,
-        }
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -46,8 +46,8 @@ pub use buffer_map::*;
 mod buffer_storage;
 pub(crate) use buffer_storage::*;
 
-mod buffered;
-pub use buffered::*;
+mod buffering;
+pub use buffering::*;
 
 mod bufferable;
 pub use bufferable::*;

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,9 +17,9 @@
 
 use bevy_ecs::{
     change_detection::Mut,
-    prelude::{Commands, Entity, Query},
+    prelude::{Commands, Entity, Query, World},
     query::QueryEntityError,
-    system::SystemParam,
+    system::{SystemParam, SystemState},
 };
 
 use std::{ops::RangeBounds, sync::Arc};
@@ -38,7 +38,7 @@ pub use buffer_access_lifecycle::BufferKeyLifecycle;
 pub(crate) use buffer_access_lifecycle::*;
 
 mod buffer_key_builder;
-pub(crate) use buffer_key_builder::*;
+pub use buffer_key_builder::*;
 
 mod buffer_map;
 pub use buffer_map::*;
@@ -399,6 +399,67 @@ where
         self.query.get_mut(key.buffer()).map(|(storage, gate)| {
             BufferMut::new(storage, gate, buffer, session, accessor, &mut self.commands)
         })
+    }
+}
+
+/// This trait allows [`World`] to give you access to any buffer using a [`BufferKey`]
+pub trait BufferWorldAccess {
+    /// Call this to get read-only access to a buffer from a [`World`].
+    ///
+    /// Alternatively you can use [`BufferAccess`] as a regular bevy system parameter,
+    /// which does not need direct world access.
+    fn buffer_view<T>(&self, key: &BufferKey<T>) -> Result<BufferView<'_, T>, BufferError>
+    where
+        T: 'static + Send + Sync;
+
+    /// Call this to get mutable access to a buffer.
+    ///
+    /// Pass in a callback that will receive [`BufferMut`], allowing it to view
+    /// and modify the contents of the buffer.
+    fn buffer_mut<T, U>(
+        &mut self,
+        key: &BufferKey<T>,
+        f: impl FnOnce(BufferMut<T>) -> U,
+    ) -> Result<U, BufferError>
+    where
+        T: 'static + Send + Sync;
+}
+
+impl BufferWorldAccess for World {
+    fn buffer_view<T>(&self, key: &BufferKey<T>) -> Result<BufferView<'_, T>, BufferError>
+    where
+        T: 'static + Send + Sync,
+    {
+        let buffer_ref = self
+            .get_entity(key.tag.buffer)
+            .ok_or(BufferError::BufferMissing)?;
+        let storage = buffer_ref
+            .get::<BufferStorage<T>>()
+            .ok_or(BufferError::BufferMissing)?;
+        let gate = buffer_ref
+            .get::<GateState>()
+            .ok_or(BufferError::BufferMissing)?;
+        Ok(BufferView {
+            storage,
+            gate,
+            session: key.tag.session,
+        })
+    }
+
+    fn buffer_mut<T, U>(
+        &mut self,
+        key: &BufferKey<T>,
+        f: impl FnOnce(BufferMut<T>) -> U,
+    ) -> Result<U, BufferError>
+    where
+        T: 'static + Send + Sync,
+    {
+        let mut state = SystemState::<BufferAccessMut<T>>::new(self);
+        let mut buffer_access_mut = state.get_mut(self);
+        let buffer_mut = buffer_access_mut
+            .get_mut(key)
+            .map_err(|_| BufferError::BufferMissing)?;
+        Ok(f(buffer_mut))
     }
 }
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -24,6 +24,8 @@ use bevy_ecs::{
 
 use std::{ops::RangeBounds, sync::Arc};
 
+use thiserror::Error as ThisError;
+
 use crate::{
     Builder, Chain, Gate, GateState, InputSlot, NotifyBufferUpdate, OnNewBufferValue, UnusedTarget,
 };
@@ -569,6 +571,12 @@ where
             ));
         }
     }
+}
+
+#[derive(ThisError, Debug, Clone)]
+pub enum BufferError {
+    #[error("The key was unable to identify a buffer")]
+    BufferMissing,
 }
 
 #[cfg(test)]

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -121,10 +121,6 @@ impl AnyBuffer {
             .ok()
             .map(|x| *x)
     }
-
-    pub fn as_any_buffer(&self) -> Self {
-        self.clone().into()
-    }
 }
 
 impl<T: 'static + Send + Sync + Any> From<Buffer<T>> for AnyBuffer {
@@ -134,6 +130,25 @@ impl<T: 'static + Send + Sync + Any> From<Buffer<T>> for AnyBuffer {
             location: value.location,
             interface,
         }
+    }
+}
+
+/// A trait for turning a buffer into an [`AnyBuffer`]. It is expected that all
+/// buffer types implement this trait.
+pub trait AsAnyBuffer {
+    /// Convert this buffer into an [`AnyBuffer`].
+    fn as_any_buffer(&self) -> AnyBuffer;
+}
+
+impl AsAnyBuffer for AnyBuffer {
+    fn as_any_buffer(&self) -> AnyBuffer {
+        *self
+    }
+}
+
+impl<T: 'static + Send + Sync> AsAnyBuffer for Buffer<T> {
+    fn as_any_buffer(&self) -> AnyBuffer {
+        (*self).into()
     }
 }
 

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -64,6 +64,10 @@ impl AnyBuffer {
         self.interface.message_type_id()
     }
 
+    pub fn message_type_name(&self) -> &'static str {
+        self.interface.message_type_name()
+    }
+
     /// Get the [`AnyBufferAccessInterface`] for this specific instance of [`AnyBuffer`].
     pub fn get_interface(&self) -> &'static (dyn AnyBufferAccessInterface + Send + Sync) {
         self.interface
@@ -176,11 +180,11 @@ impl AnyBufferKey {
         self.tag.session
     }
 
-    fn is_in_use(&self) -> bool {
+    pub(crate) fn is_in_use(&self) -> bool {
         self.tag.is_in_use()
     }
 
-    fn deep_clone(&self) -> Self {
+    pub(crate) fn deep_clone(&self) -> Self {
         Self {
             tag: self.tag.deep_clone(),
             interface: self.interface,
@@ -338,14 +342,14 @@ impl<'w, 's, 'a> AnyBufferMut<'w, 's, 'a> {
     }
 
     /// Pull the oldest message from the buffer.
-    pub fn pull(&mut self) -> Option<AnyMessage> {
+    pub fn pull(&mut self) -> Option<AnyMessageBox> {
         self.modified = true;
         self.storage.any_pull(self.session)
     }
 
     /// Pull the message that was most recently put into the buffer (instead of the
     /// oldest, which is what [`Self::pull`] gives).
-    pub fn pull_newest(&mut self) -> Option<AnyMessage> {
+    pub fn pull_newest(&mut self) -> Option<AnyMessageBox> {
         self.modified = true;
         self.storage.any_pull_newest(self.session)
     }
@@ -385,7 +389,7 @@ impl<'w, 's, 'a> AnyBufferMut<'w, 's, 'a> {
     /// If the input value does not match the message type of the buffer, this
     /// will return [`Err`] and give back an error with the message that you
     /// tried to push and the type information for the expected message type.
-    pub fn push_any(&mut self, value: AnyMessage) -> Result<Option<AnyMessage>, AnyMessageError> {
+    pub fn push_any(&mut self, value: AnyMessageBox) -> Result<Option<AnyMessageBox>, AnyMessageError> {
         self.storage.any_push(self.session, value)
     }
 
@@ -420,8 +424,8 @@ impl<'w, 's, 'a> AnyBufferMut<'w, 's, 'a> {
     /// The result follows the same rules as [`Self::push_any`].
     pub fn push_any_as_oldest(
         &mut self,
-        value: AnyMessage,
-    ) -> Result<Option<AnyMessage>, AnyMessageError> {
+        value: AnyMessageBox,
+    ) -> Result<Option<AnyMessageBox>, AnyMessageError> {
         self.storage.any_push_as_oldest(self.session, value)
     }
 
@@ -520,10 +524,10 @@ trait AnyBufferViewing {
 }
 
 trait AnyBufferManagement: AnyBufferViewing {
-    fn any_push(&mut self, session: Entity, value: AnyMessage) -> AnyMessagePushResult;
-    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessage) -> AnyMessagePushResult;
-    fn any_pull(&mut self, session: Entity) -> Option<AnyMessage>;
-    fn any_pull_newest(&mut self, session: Entity) -> Option<AnyMessage>;
+    fn any_push(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult;
+    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult;
+    fn any_pull(&mut self, session: Entity) -> Option<AnyMessageBox>;
+    fn any_pull_newest(&mut self, session: Entity) -> Option<AnyMessageBox>;
     fn any_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<AnyMessageMut<'a>>;
     fn any_newest_mut<'a>(&'a mut self, session: Entity) -> Option<AnyMessageMut<'a>>;
     fn any_get_mut<'a>(&'a mut self, session: Entity, index: usize) -> Option<AnyMessageMut<'a>>;
@@ -650,37 +654,37 @@ impl<T: 'static + Send + Sync + Any> AnyBufferViewing for Mut<'_, BufferStorage<
 
 pub type AnyMessageMut<'a> = &'a mut (dyn Any + 'static + Send + Sync);
 
-pub type AnyMessage = Box<dyn Any + 'static + Send + Sync>;
+pub type AnyMessageBox = Box<dyn Any + 'static + Send + Sync>;
 
 #[derive(ThisError, Debug)]
 #[error("failed to convert a message")]
 pub struct AnyMessageError {
     /// The original value provided
-    pub value: AnyMessage,
+    pub value: AnyMessageBox,
     /// The ID of the type expected by the buffer
     pub type_id: TypeId,
     /// The name of the type expected by the buffer
     pub type_name: &'static str,
 }
 
-pub type AnyMessagePushResult = Result<Option<AnyMessage>, AnyMessageError>;
+pub type AnyMessagePushResult = Result<Option<AnyMessageBox>, AnyMessageError>;
 
 impl<T: 'static + Send + Sync + Any> AnyBufferManagement for Mut<'_, BufferStorage<T>> {
-    fn any_push(&mut self, session: Entity, value: AnyMessage) -> AnyMessagePushResult {
+    fn any_push(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult {
         let value = from_any_message::<T>(value)?;
         Ok(self.push(session, value).map(to_any_message))
     }
 
-    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessage) -> AnyMessagePushResult {
+    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult {
         let value = from_any_message::<T>(value)?;
         Ok(self.push_as_oldest(session, value).map(to_any_message))
     }
 
-    fn any_pull(&mut self, session: Entity) -> Option<AnyMessage> {
+    fn any_pull(&mut self, session: Entity) -> Option<AnyMessageBox> {
         self.pull(session).map(to_any_message)
     }
 
-    fn any_pull_newest(&mut self, session: Entity) -> Option<AnyMessage> {
+    fn any_pull_newest(&mut self, session: Entity) -> Option<AnyMessageBox> {
         self.pull_newest(session).map(to_any_message)
     }
 
@@ -713,11 +717,11 @@ fn to_any_mut<'a, T: 'static + Send + Sync + Any>(x: &'a mut T) -> AnyMessageMut
     x
 }
 
-fn to_any_message<T: 'static + Send + Sync + Any>(x: T) -> AnyMessage {
+fn to_any_message<T: 'static + Send + Sync + Any>(x: T) -> AnyMessageBox {
     Box::new(x)
 }
 
-fn from_any_message<T: 'static + Send + Sync + Any>(value: AnyMessage) -> Result<T, AnyMessageError>
+fn from_any_message<T: 'static + Send + Sync + Any>(value: AnyMessageBox) -> Result<T, AnyMessageError>
 where
     T: 'static,
 {
@@ -799,7 +803,7 @@ pub trait AnyBufferAccessInterface {
         &self,
         entity_mut: &mut EntityWorldMut,
         session: Entity,
-    ) -> Result<AnyMessage, OperationError>;
+    ) -> Result<AnyMessageBox, OperationError>;
 
     fn create_any_buffer_view<'a>(
         &self,
@@ -915,7 +919,7 @@ impl<T: 'static + Send + Sync + Any> AnyBufferAccessInterface for AnyBufferAcces
         &self,
         entity_mut: &mut EntityWorldMut,
         session: Entity,
-    ) -> Result<AnyMessage, OperationError> {
+    ) -> Result<AnyMessageBox, OperationError> {
         entity_mut
             .pull_from_buffer::<T>(session)
             .map(to_any_message)
@@ -955,7 +959,7 @@ pub struct DrainAnyBuffer<'a> {
 }
 
 impl<'a> Iterator for DrainAnyBuffer<'a> {
-    type Item = AnyMessage;
+    type Item = AnyMessageBox;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.interface.any_next()
@@ -963,11 +967,11 @@ impl<'a> Iterator for DrainAnyBuffer<'a> {
 }
 
 trait DrainAnyBufferInterface {
-    fn any_next(&mut self) -> Option<AnyMessage>;
+    fn any_next(&mut self) -> Option<AnyMessageBox>;
 }
 
 impl<T: 'static + Send + Sync + Any> DrainAnyBufferInterface for DrainBuffer<'_, T> {
-    fn any_next(&mut self) -> Option<AnyMessage> {
+    fn any_next(&mut self) -> Option<AnyMessageBox> {
         self.next().map(to_any_message)
     }
 }
@@ -1015,7 +1019,7 @@ impl Buffered for AnyBuffer {
 }
 
 impl Joined for AnyBuffer {
-    type Item = AnyMessage;
+    type Item = AnyMessageBox;
     fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
         let mut buffer_mut = world.get_entity_mut(self.id()).or_broken()?;
         self.interface.pull(&mut buffer_mut, session)

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -49,6 +49,18 @@ pub struct AnyBuffer {
     pub(crate) interface: &'static (dyn AnyBufferAccessInterface + Send + Sync)
 }
 
+impl AnyBuffer {
+    /// The buffer ID for this key.
+    pub fn id(&self) -> Entity {
+        self.source
+    }
+
+    /// Get the type ID of the messages that this buffer supports.
+    pub fn message_type_id(&self) -> TypeId {
+        self.interface.message_type_id()
+    }
+}
+
 impl std::fmt::Debug for AnyBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AnyBuffer")

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -41,7 +41,7 @@ use crate::{
 };
 
 /// A [`Buffer`] whose message type has been anonymized. Joining with this buffer
-/// type will yield an [`AnyMessage`].
+/// type will yield an [`AnyMessageBox`].
 #[derive(Clone, Copy)]
 pub struct AnyBuffer {
     pub(crate) location: BufferLocation,

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -35,9 +35,9 @@ use smallvec::SmallVec;
 
 use crate::{
     add_listener_to_source, Accessed, Buffer, BufferAccessMut, BufferAccessors, BufferError,
-    BufferKey, BufferKeyTag, BufferLocation, BufferStorage, Bufferable, Buffered, Builder,
-    DrainBuffer, Gate, GateState, InspectBuffer, Joined, ManageBuffer, NotifyBufferUpdate,
-    OperationError, OperationResult, OperationRoster, OrBroken,
+    BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferStorage,
+    Bufferable, Buffered, Builder, DrainBuffer, Gate, GateState, InspectBuffer, Joined,
+    ManageBuffer, NotifyBufferUpdate, OperationError, OperationResult, OperationRoster, OrBroken,
 };
 
 /// A [`Buffer`] whose message type has been anonymized. Joining with this buffer
@@ -198,12 +198,23 @@ impl AnyBufferKey {
     pub fn session(&self) -> Entity {
         self.tag.session
     }
+}
 
-    pub(crate) fn is_in_use(&self) -> bool {
+impl BufferKeyLifecycle for AnyBufferKey {
+    type TargetBuffer = AnyBuffer;
+
+    fn create_key(buffer: &AnyBuffer, builder: &BufferKeyBuilder) -> Self {
+        AnyBufferKey {
+            tag: builder.make_tag(buffer.id()),
+            interface: buffer.interface,
+        }
+    }
+
+    fn is_in_use(&self) -> bool {
         self.tag.is_in_use()
     }
 
-    pub(crate) fn deep_clone(&self) -> Self {
+    fn deep_clone(&self) -> Self {
         Self {
             tag: self.tag.deep_clone(),
             interface: self.interface,

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -81,6 +81,8 @@ impl AnyBuffer {
         > = OnceLock::new();
         let interfaces = INTERFACE_MAP.get_or_init(|| Mutex::default());
 
+        // SAFETY: This will leak memory exactly once per type, so the leakage is bounded.
+        // Leaking this allows the interface to be shared freely across all instances.
         let mut interfaces_mut = interfaces.lock().unwrap();
         *interfaces_mut
             .entry(TypeId::of::<T>())
@@ -940,7 +942,7 @@ impl<T: 'static + Send + Sync + Any> AnyBufferAccessInterface for AnyBufferAcces
         let mut downcasts = self.buffer_downcasts.lock().unwrap();
 
         if let Entry::Vacant(entry) = downcasts.entry(buffer_type) {
-            // We should only leak this into the register once per type
+            // SAFETY: We only leak this into the register once per type
             entry.insert(Box::leak(f));
         }
     }
@@ -957,7 +959,7 @@ impl<T: 'static + Send + Sync + Any> AnyBufferAccessInterface for AnyBufferAcces
         let mut downcasts = self.key_downcasts.lock().unwrap();
 
         if let Entry::Vacant(entry) = downcasts.entry(key_type) {
-            // We should only leak this in to the register once per type
+            // SAFTY: We only leak this in to the register once per type
             entry.insert(Box::leak(f));
         }
     }

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -121,6 +121,10 @@ impl AnyBuffer {
             .ok()
             .map(|x| *x)
     }
+
+    pub fn as_any_buffer(&self) -> Self {
+        self.clone().into()
+    }
 }
 
 impl<T: 'static + Send + Sync + Any> From<Buffer<T>> for AnyBuffer {
@@ -853,6 +857,17 @@ impl<T: 'static + Send + Sync> AnyBufferAccessImpl<T> {
                 Box::new(AnyBuffer {
                     location,
                     interface: AnyBuffer::interface_for::<T>(),
+                })
+            })),
+        );
+
+        // Allow downcasting back to the original Buffer<T>
+        buffer_downcasts.insert(
+            TypeId::of::<Buffer<T>>(),
+            Box::leak(Box::new(|location| -> Box<dyn Any> {
+                Box::new(Buffer::<T> {
+                    location,
+                    _ignore: Default::default(),
                 })
             })),
         );

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use std::any::Any;
+
+use bevy_ecs::{
+    prelude::{Entity, Commands, Mut, World, Query},
+    system::SystemState,
+};
+
+use crate::{
+    AnyMessageRef, AnyMessageMut, BoxedMessage, BoxedMessageError, BufferAccessMut,
+    DynBufferViewer, DynBufferKey, DynBufferManagement, GateState, BufferStorage,
+};
+
+use thiserror::Error as ThisError;
+
+/// Similar to [`BufferMut`][crate::BufferMut], but this can be unlocked with a
+/// [`DynBufferKey`], so it can work for any buffer regardless of the data type
+/// inside.
+pub struct AnyBufferMut<'w, 's, 'a> {
+    storage: Box<dyn DynBufferManagement<'a, AnyMessageRef<'a>, AnyMessageMut<'a>, BoxedMessage, BoxedMessageError> + 'a>,
+    gate: Mut<'a, GateState>,
+    buffer: Entity,
+    session: Entity,
+    accessor: Option<Entity>,
+    commands: Commands<'w, 's>,
+    modified: bool,
+}
+
+#[derive(ThisError, Debug, Clone)]
+pub enum AnyBufferError {
+    #[error("The key was unable to identify a buffer")]
+    BufferMissing,
+}
+
+pub(crate) fn access_any_buffer_mut<T: 'static + Send + Sync + Any>(
+    key: DynBufferKey,
+    f: Box<dyn FnOnce(AnyBufferMut) + '_>,
+    world: &mut World,
+) -> Result<(), AnyBufferError> {
+    let mut state: SystemState<BufferAccessMut<T>> = SystemState::new(world);
+    let BufferAccessMut { mut query, commands } = state.get_mut(world);
+    let (storage, gate) = query.get_mut(key.buffer).map_err(|_| AnyBufferError::BufferMissing)?;
+    let buffer_mut = AnyBufferMut {
+        storage: Box::new(storage),
+        gate,
+        buffer: key.buffer,
+        session: key.session,
+        accessor: Some(key.accessor),
+        commands,
+        modified: false,
+    };
+
+    f(buffer_mut);
+    Ok(())
+}

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -517,7 +517,7 @@ pub trait AnyBufferWorldAccess {
     /// For technical reasons this requires direct [`World`] access, but you can
     /// do other read-only queries on the world while holding onto the
     /// [`AnyBufferView`].
-    fn any_buffer_view<'a>(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError>;
+    fn any_buffer_view(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError>;
 
     /// Call this to get mutable access to any buffer.
     ///
@@ -531,7 +531,7 @@ pub trait AnyBufferWorldAccess {
 }
 
 impl AnyBufferWorldAccess for World {
-    fn any_buffer_view<'a>(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError> {
+    fn any_buffer_view(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError> {
         key.interface.create_any_buffer_view(key, self)
     }
 

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -389,7 +389,10 @@ impl<'w, 's, 'a> AnyBufferMut<'w, 's, 'a> {
     /// If the input value does not match the message type of the buffer, this
     /// will return [`Err`] and give back an error with the message that you
     /// tried to push and the type information for the expected message type.
-    pub fn push_any(&mut self, value: AnyMessageBox) -> Result<Option<AnyMessageBox>, AnyMessageError> {
+    pub fn push_any(
+        &mut self,
+        value: AnyMessageBox,
+    ) -> Result<Option<AnyMessageBox>, AnyMessageError> {
         self.storage.any_push(self.session, value)
     }
 
@@ -525,7 +528,8 @@ trait AnyBufferViewing {
 
 trait AnyBufferManagement: AnyBufferViewing {
     fn any_push(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult;
-    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult;
+    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessageBox)
+        -> AnyMessagePushResult;
     fn any_pull(&mut self, session: Entity) -> Option<AnyMessageBox>;
     fn any_pull_newest(&mut self, session: Entity) -> Option<AnyMessageBox>;
     fn any_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<AnyMessageMut<'a>>;
@@ -675,7 +679,11 @@ impl<T: 'static + Send + Sync + Any> AnyBufferManagement for Mut<'_, BufferStora
         Ok(self.push(session, value).map(to_any_message))
     }
 
-    fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult {
+    fn any_push_as_oldest(
+        &mut self,
+        session: Entity,
+        value: AnyMessageBox,
+    ) -> AnyMessagePushResult {
         let value = from_any_message::<T>(value)?;
         Ok(self.push_as_oldest(session, value).map(to_any_message))
     }
@@ -721,7 +729,9 @@ fn to_any_message<T: 'static + Send + Sync + Any>(x: T) -> AnyMessageBox {
     Box::new(x)
 }
 
-fn from_any_message<T: 'static + Send + Sync + Any>(value: AnyMessageBox) -> Result<T, AnyMessageError>
+fn from_any_message<T: 'static + Send + Sync + Any>(
+    value: AnyMessageBox,
+) -> Result<T, AnyMessageError>
 where
     T: 'static,
 {

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -381,6 +381,11 @@ impl<'w, 's, 'a> Drop for AnyBufferMut<'w, 's, 'a> {
 /// This trait allows [`World`] to give you access to any buffer using an
 /// [`AnyBufferKey`].
 pub trait AnyBufferWorldAccess {
+
+    /// Call this to get mutable access to any buffer.
+    ///
+    /// Pass in a callback that will receive a [`AnyBufferMut`], allowing it to
+    /// view and modify the contents of the buffer.
     fn any_buffer_mut<U>(
         &mut self,
         key: &AnyBufferKey,

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -34,9 +34,9 @@ use thiserror::Error as ThisError;
 use smallvec::SmallVec;
 
 use crate::{
-    add_listener_to_source, Accessed, Buffer, BufferAccessMut, BufferAccessors, BufferError,
+    add_listener_to_source, Accessing, Buffer, BufferAccessMut, BufferAccessors, BufferError,
     BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferStorage,
-    Bufferable, Buffered, Builder, DrainBuffer, Gate, GateState, InspectBuffer, Joined,
+    Bufferable, Buffering, Builder, DrainBuffer, Gate, GateState, InspectBuffer, Joining,
     ManageBuffer, NotifyBufferUpdate, OperationError, OperationResult, OperationRoster, OrBroken,
 };
 
@@ -1035,7 +1035,7 @@ impl Bufferable for AnyBuffer {
     }
 }
 
-impl Buffered for AnyBuffer {
+impl Buffering for AnyBuffer {
     fn verify_scope(&self, scope: Entity) {
         assert_eq!(scope, self.scope());
     }
@@ -1069,7 +1069,7 @@ impl Buffered for AnyBuffer {
     }
 }
 
-impl Joined for AnyBuffer {
+impl Joining for AnyBuffer {
     type Item = AnyMessageBox;
     fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
         let mut buffer_mut = world.get_entity_mut(self.id()).or_broken()?;
@@ -1077,7 +1077,7 @@ impl Joined for AnyBuffer {
     }
 }
 
-impl Accessed for AnyBuffer {
+impl Accessing for AnyBuffer {
     type Key = AnyBufferKey;
     fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
         world

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -514,9 +514,17 @@ pub(crate) struct AnyRange {
 impl AnyRange {
     pub(crate) fn new<T: std::ops::RangeBounds<usize>>(range: T) -> Self {
         AnyRange {
-            start_bound: range.start_bound().map(|x| *x),
-            end_bound: range.end_bound().map(|x| *x),
+            start_bound: deref_bound(range.start_bound()),
+            end_bound: deref_bound(range.end_bound()),
         }
+    }
+}
+
+fn deref_bound(bound: std::ops::Bound<&usize>) -> std::ops::Bound<usize> {
+    match bound {
+        std::ops::Bound::Included(v) => std::ops::Bound::Included(*v),
+        std::ops::Bound::Excluded(v) => std::ops::Bound::Excluded(*v),
+        std::ops::Bound::Unbounded => std::ops::Bound::Unbounded,
     }
 }
 

--- a/src/buffer/buffer_access_lifecycle.rs
+++ b/src/buffer/buffer_access_lifecycle.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender as TokioSender;
 
 use std::sync::Arc;
 
-use crate::{emit_disposal, ChannelItem, Disposal, OperationRoster};
+use crate::{emit_disposal, BufferKeyBuilder, ChannelItem, Disposal, OperationRoster};
 
 /// This is used as a field inside of [`crate::BufferKey`] which keeps track of
 /// when a key that was sent out into the world gets fully dropped from use. We
@@ -86,4 +86,30 @@ impl Drop for BufferAccessLifecycle {
             }
         }
     }
+}
+
+/// This trait is implemented by [`crate::BufferKey`]-like structs so their
+/// lifecycles can be managed.
+pub trait BufferKeyLifecycle {
+    /// What kind of buffer this key can unlock.
+    type TargetBuffer;
+
+    /// Create a new key of this type.
+    fn create_key(buffer: &Self::TargetBuffer, builder: &BufferKeyBuilder) -> Self;
+
+    /// Check if the key is currently in use.
+    fn is_in_use(&self) -> bool;
+
+    /// Create a deep clone of the key. The usage tracking of the clone will
+    /// be unrelated to the usage tracking of the original.
+    ///
+    /// We do a deep clone of the key when distributing it to decouple the
+    /// lifecycle of the keys that we send out from the key that's held by the
+    /// accessor node.
+    //
+    /// The key instance held by the accessor node will never be dropped until
+    /// the session is cleaned up, so the keys that we send out into the workflow
+    /// need to have their own independent lifecycles or else we won't detect
+    /// when the workflow has dropped them.
+    fn deep_clone(&self) -> Self;
 }

--- a/src/buffer/buffer_access_lifecycle.rs
+++ b/src/buffer/buffer_access_lifecycle.rs
@@ -29,7 +29,7 @@ use crate::{emit_disposal, ChannelItem, Disposal, OperationRoster};
 /// we would be needlessly doing a reachability check every time the key gets
 /// cloned.
 #[derive(Clone)]
-pub(crate) struct BufferAccessLifecycle {
+pub struct BufferAccessLifecycle {
     scope: Entity,
     accessor: Entity,
     session: Entity,

--- a/src/buffer/buffer_key_builder.rs
+++ b/src/buffer/buffer_key_builder.rs
@@ -28,6 +28,13 @@ pub struct BufferKeyBuilder {
     lifecycle: Option<(ChannelSender, Arc<()>)>,
 }
 
+pub struct BufferKeyComponents {
+    pub buffer: Entity,
+    pub session: Entity,
+    pub accessor: Entity,
+    pub lifecycle: Option<Arc<BufferAccessLifecycle>>,
+}
+
 impl BufferKeyBuilder {
     pub(crate) fn build<T>(&self, buffer: Entity) -> BufferKey<T> {
         BufferKey {
@@ -45,6 +52,26 @@ impl BufferKeyBuilder {
                 ))
             }),
             _ignore: Default::default(),
+        }
+    }
+
+    // TODO(@mxgrey): Consider refactoring all the buffer key structs to use a
+    // single inner struct like BufferKeyComponents
+    pub(crate) fn as_components(&self, buffer: Entity) -> BufferKeyComponents {
+        BufferKeyComponents {
+            buffer,
+            session: self.session,
+            accessor: self.accessor,
+            lifecycle: self.lifecycle.as_ref().map(|(sender, tracker)| {
+                Arc::new(BufferAccessLifecycle::new(
+                    self.scope,
+                    buffer,
+                    self.session,
+                    self.accessor,
+                    sender.clone(),
+                    tracker.clone(),
+                ))
+            }),
         }
     }
 

--- a/src/buffer/buffer_key_builder.rs
+++ b/src/buffer/buffer_key_builder.rs
@@ -19,7 +19,7 @@ use bevy_ecs::prelude::Entity;
 
 use std::sync::Arc;
 
-use crate::{BufferAccessLifecycle, BufferKey, BufferKeyTag, ChannelSender};
+use crate::{BufferAccessLifecycle, BufferKeyTag, ChannelSender};
 
 pub struct BufferKeyBuilder {
     scope: Entity,
@@ -29,16 +29,8 @@ pub struct BufferKeyBuilder {
 }
 
 impl BufferKeyBuilder {
-    pub(crate) fn build<T>(&self, buffer: Entity) -> BufferKey<T> {
-        BufferKey {
-            tag: self.make_tag(buffer),
-            _ignore: Default::default(),
-        }
-    }
-
-    // TODO(@mxgrey): Consider refactoring all the buffer key structs to use a
-    // single inner struct like BufferKeyComponents
-    pub(crate) fn make_tag(&self, buffer: Entity) -> BufferKeyTag {
+    /// Make a [`BufferKeyTag`] that can be given to a [`crate::BufferKey`]-like struct.
+    pub fn make_tag(&self, buffer: Entity) -> BufferKeyTag {
         BufferKeyTag {
             buffer,
             session: self.session,

--- a/src/buffer/buffer_key_builder.rs
+++ b/src/buffer/buffer_key_builder.rs
@@ -19,7 +19,7 @@ use bevy_ecs::prelude::Entity;
 
 use std::sync::Arc;
 
-use crate::{BufferAccessLifecycle, BufferKey, ChannelSender};
+use crate::{BufferAccessLifecycle, BufferKey, BufferKeyTag, ChannelSender};
 
 pub struct BufferKeyBuilder {
     scope: Entity,
@@ -28,37 +28,18 @@ pub struct BufferKeyBuilder {
     lifecycle: Option<(ChannelSender, Arc<()>)>,
 }
 
-pub struct BufferKeyComponents {
-    pub buffer: Entity,
-    pub session: Entity,
-    pub accessor: Entity,
-    pub lifecycle: Option<Arc<BufferAccessLifecycle>>,
-}
-
 impl BufferKeyBuilder {
     pub(crate) fn build<T>(&self, buffer: Entity) -> BufferKey<T> {
         BufferKey {
-            buffer,
-            session: self.session,
-            accessor: self.accessor,
-            lifecycle: self.lifecycle.as_ref().map(|(sender, tracker)| {
-                Arc::new(BufferAccessLifecycle::new(
-                    self.scope,
-                    buffer,
-                    self.session,
-                    self.accessor,
-                    sender.clone(),
-                    tracker.clone(),
-                ))
-            }),
+            tag: self.make_tag(buffer),
             _ignore: Default::default(),
         }
     }
 
     // TODO(@mxgrey): Consider refactoring all the buffer key structs to use a
     // single inner struct like BufferKeyComponents
-    pub(crate) fn as_components(&self, buffer: Entity) -> BufferKeyComponents {
-        BufferKeyComponents {
+    pub(crate) fn make_tag(&self, buffer: Entity) -> BufferKeyTag {
+        BufferKeyTag {
             buffer,
             session: self.session,
             accessor: self.accessor,

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use std::{any::TypeId, borrow::Cow, collections::HashMap};
+use std::{borrow::Cow, collections::HashMap};
 
 use thiserror::Error as ThisError;
 
@@ -24,9 +24,9 @@ use smallvec::SmallVec;
 use bevy_ecs::prelude::{Entity, World};
 
 use crate::{
-    add_listener_to_source, Accessed, AddOperation, AnyBuffer, AnyBufferKey, BufferKeyBuilder,
-    Buffered, Builder, Chain, Gate, GateState, Join, Joined, OperationError, OperationResult,
-    OperationRoster, Output, UnusedTarget,
+    add_listener_to_source, Accessed, AddOperation, AnyBuffer, AnyBufferKey, AnyMessageBox,
+    Buffer, BufferKeyBuilder, Buffered, Builder, Chain, Gate, GateState, Join, Joined,
+    OperationError, OperationResult, OperationRoster, Output, UnusedTarget,
 };
 
 #[derive(Clone, Default)]
@@ -36,8 +36,8 @@ pub struct BufferMap {
 
 impl BufferMap {
     /// Insert a named buffer into the map.
-    pub fn insert(&mut self, name: Cow<'static, str>, buffer: impl Into<AnyBuffer>) {
-        self.inner.insert(name, buffer.into());
+    pub fn insert(&mut self, name: impl Into<Cow<'static, str>>, buffer: impl Into<AnyBuffer>) {
+        self.inner.insert(name.into(), buffer.into());
     }
 
     /// Get one of the buffers from the map by its name.
@@ -58,31 +58,45 @@ pub struct IncompatibleLayout {
 }
 
 impl IncompatibleLayout {
-    /// Check whether a named buffer is compatible with a specific type.
-    pub fn require_buffer<T: 'static>(&mut self, expected_name: &str, buffers: &BufferMap) {
+    /// Check whether a named buffer is compatible with a specific concrete message type.
+    pub fn require_message_type<Message: 'static>(&mut self, expected_name: &str, buffers: &BufferMap) -> Result<Buffer<Message>, ()> {
         if let Some((name, buffer)) = buffers.inner.get_key_value(expected_name) {
-            if buffer.message_type_id() != TypeId::of::<T>() {
+            if let Some(buffer) = buffer.downcast_for_message::<Message>() {
+                return Ok(buffer);
+            } else {
                 self.incompatible_buffers.push(BufferIncompatibility {
                     name: name.clone(),
-                    expected: TypeId::of::<T>(),
-                    received: buffer.message_type_id(),
+                    expected: std::any::type_name::<Buffer<Message>>(),
+                    received: buffer.message_type_name(),
                 });
             }
         } else {
             self.missing_buffers
                 .push(Cow::Owned(expected_name.to_owned()));
         }
+
+        Err(())
     }
 
-    /// Convert the instance into a result. If any field has content in it, then
-    /// this will produce an [`Err`]. Otherwise if no incompatibilities are
-    /// present, this will produce an [`Ok`].
-    pub fn into_result(self) -> Result<(), IncompatibleLayout> {
-        if self.missing_buffers.is_empty() && self.incompatible_buffers.is_empty() {
-            Ok(())
+    /// Check whether a named buffer is compatible with a specialized buffer type,
+    /// such as `JsonBuffer`.
+    pub fn require_buffer_type<BufferType: 'static>(&mut self, expected_name: &str, buffers: &BufferMap) -> Result<BufferType, ()> {
+        if let Some((name, buffer)) = buffers.inner.get_key_value(expected_name) {
+            if let Some(buffer) = buffer.downcast_buffer::<BufferType>() {
+                return Ok(buffer);
+            } else {
+                self.incompatible_buffers.push(BufferIncompatibility {
+                    name: name.clone(),
+                    expected: std::any::type_name::<BufferType>(),
+                    received: buffer.message_type_name(),
+                });
+            }
         } else {
-            Err(self)
+            self.missing_buffers
+                .push(Cow::Owned(expected_name.to_owned()));
         }
+
+        Err(())
     }
 }
 
@@ -92,213 +106,40 @@ pub struct BufferIncompatibility {
     /// Name of the expected buffer
     pub name: Cow<'static, str>,
     /// The type that was expected for this buffer
-    pub expected: TypeId,
+    pub expected: &'static str,
     /// The type that was received for this buffer
-    pub received: TypeId,
+    pub received: &'static str,
     // TODO(@mxgrey): Replace TypeId with TypeInfo
 }
 
-pub trait BufferMapLayout: Sized {
-    fn is_compatible(buffers: &BufferMap) -> Result<(), IncompatibleLayout>;
+/// This trait can be implemented on structs that represent a layout of buffers.
+/// You do not normally have to implement this yourself. Instead you should
+/// `#[derive(JoinedValue)]` on a struct that you want a join operation to
+/// produce.
+pub trait BufferMapLayout: Sized + Clone {
+    /// Produce a list of the buffers that exist in this layout.
+    fn buffer_list(&self) -> SmallVec<[AnyBuffer; 8]>;
 
-    fn buffered_count(
-        buffers: &BufferMap,
-        session: Entity,
-        world: &World,
-    ) -> Result<usize, OperationError>;
-
-    fn ensure_active_session(
-        buffers: &BufferMap,
-        session: Entity,
-        world: &mut World,
-    ) -> OperationResult;
-
-    fn add_listener(buffers: &BufferMap, listener: Entity, world: &mut World) -> OperationResult {
-        for buffer in buffers.inner.values() {
-            add_listener_to_source(buffer.id(), listener, world)?;
-        }
-        Ok(())
-    }
-
-    fn gate_action(
-        buffers: &BufferMap,
-        session: Entity,
-        action: Gate,
-        world: &mut World,
-        roster: &mut OperationRoster,
-    ) -> OperationResult {
-        for buffer in buffers.inner.values() {
-            GateState::apply(buffer.id(), session, action, world, roster)?;
-        }
-        Ok(())
-    }
-
-    fn as_input(buffers: &BufferMap) -> SmallVec<[Entity; 8]> {
-        let mut inputs = SmallVec::new();
-        for buffer in buffers.inner.values() {
-            inputs.push(buffer.id());
-        }
-        inputs
-    }
+    /// Try to convert a generic [`BufferMap`] into this specific layout.
+    fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout>;
 }
 
-pub trait JoinedValue: 'static + BufferMapLayout + Send + Sync {
-    /// This associated type must represent a buffer map layout that is
-    /// guaranteed to be compatible for this JoinedValue. Failure to implement
-    /// this trait accordingly will result in panics.
-    type Buffers: Into<BufferMap>;
-
-    fn pull(
-        buffers: &BufferMap,
-        session: Entity,
-        world: &mut World,
-    ) -> Result<Self, OperationError>;
-
-    fn join_into<'w, 's, 'a, 'b>(
-        buffers: Self::Buffers,
-        builder: &'b mut Builder<'w, 's, 'a>,
-    ) -> Chain<'w, 's, 'a, 'b, Self> {
-        Self::try_join_into(buffers.into(), builder).unwrap()
-    }
-
-    fn try_join_into<'w, 's, 'a, 'b>(
-        buffers: BufferMap,
-        builder: &'b mut Builder<'w, 's, 'a>,
-    ) -> Result<Chain<'w, 's, 'a, 'b, Self>, IncompatibleLayout> {
-        let scope = builder.scope();
-        let buffers = BufferedMap::<Self>::new(buffers)?;
-        buffers.verify_scope(scope);
-
-        let join = builder.commands.spawn(()).id();
-        let target = builder.commands.spawn(UnusedTarget).id();
-        builder.commands.add(AddOperation::new(
-            Some(scope),
-            join,
-            Join::new(buffers, target),
-        ));
-
-        Ok(Output::new(scope, target).chain(builder))
-    }
-}
-
-/// Trait to describe a layout of buffer keys
-pub trait BufferKeyMap: BufferMapLayout + Clone {
-    fn add_accessor(buffers: &BufferMap, accessor: Entity, world: &mut World) -> OperationResult;
-
-    fn create_key(buffers: &BufferMap, builder: &BufferKeyBuilder) -> Self;
-
-    fn deep_clone_key(&self) -> Self;
-
-    fn is_key_in_use(&self) -> bool;
-}
-
-struct BufferedMap<K> {
-    map: BufferMap,
-    _ignore: std::marker::PhantomData<fn(K)>,
-}
-
-impl<K: BufferMapLayout> BufferedMap<K> {
-    fn new(map: BufferMap) -> Result<Self, IncompatibleLayout> {
-        K::is_compatible(&map)?;
-        Ok(Self {
-            map,
-            _ignore: Default::default(),
-        })
-    }
-}
-
-impl<K> Clone for BufferedMap<K> {
-    fn clone(&self) -> Self {
-        Self {
-            map: self.map.clone(),
-            _ignore: Default::default(),
-        }
-    }
-}
-
-impl<L: BufferMapLayout> Buffered for BufferedMap<L> {
+impl<T: BufferMapLayout> Buffered for T {
     fn verify_scope(&self, scope: Entity) {
-        for buffer in self.map.inner.values() {
-            assert_eq!(scope, buffer.scope());
+        for buffer in self.buffer_list() {
+            assert_eq!(buffer.scope(), scope);
         }
     }
 
-    fn buffered_count(&self, session: Entity, world: &World) -> Result<usize, OperationError> {
-        L::buffered_count(&self.map, session, world)
-    }
-
-    fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
-        L::add_listener(&self.map, listener, world)
-    }
-
-    fn gate_action(
-        &self,
-        session: Entity,
-        action: Gate,
-        world: &mut World,
-        roster: &mut OperationRoster,
-    ) -> OperationResult {
-        L::gate_action(&self.map, session, action, world, roster)
-    }
-
-    fn as_input(&self) -> SmallVec<[Entity; 8]> {
-        L::as_input(&self.map)
-    }
-
-    fn ensure_active_session(&self, session: Entity, world: &mut World) -> OperationResult {
-        L::ensure_active_session(&self.map, session, world)
-    }
-}
-
-impl<V: JoinedValue> Joined for BufferedMap<V> {
-    type Item = V;
-
-    fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
-        V::pull(&self.map, session, world)
-    }
-}
-
-impl<K: BufferKeyMap> Accessed for BufferedMap<K> {
-    type Key = K;
-
-    fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
-        K::add_accessor(&self.map, accessor, world)
-    }
-
-    fn create_key(&self, builder: &BufferKeyBuilder) -> Self::Key {
-        K::create_key(&self.map, builder)
-    }
-
-    fn deep_clone_key(key: &Self::Key) -> Self::Key {
-        K::deep_clone_key(key)
-    }
-
-    fn is_key_in_use(key: &Self::Key) -> bool {
-        K::is_key_in_use(key)
-    }
-}
-
-/// Container to represent any layout of buffer keys.
-#[derive(Clone, Debug)]
-pub struct AnyBufferKeyMap {
-    pub keys: HashMap<Cow<'static, str>, AnyBufferKey>,
-}
-
-impl BufferMapLayout for AnyBufferKeyMap {
-    fn is_compatible(_: &BufferMap) -> Result<(), IncompatibleLayout> {
-        // AnyBufferKeyMap is always compatible with BufferMap
-        Ok(())
-    }
-
     fn buffered_count(
-        buffers: &BufferMap,
+        &self,
         session: Entity,
         world: &World,
     ) -> Result<usize, OperationError> {
         let mut min_count = None;
-        for buffer in buffers.inner.values() {
-            let count = buffer.buffered_count(session, world)?;
 
+        for buffer in self.buffer_list() {
+            let count = buffer.buffered_count(session, world)?;
             min_count = if min_count.is_some_and(|m| m < count) {
                 min_count
             } else {
@@ -309,60 +150,167 @@ impl BufferMapLayout for AnyBufferKeyMap {
         Ok(min_count.unwrap_or(0))
     }
 
-    fn add_listener(buffers: &BufferMap, listener: Entity, world: &mut World) -> OperationResult {
-        for buffer in buffers.inner.values() {
-            buffer.add_listener(listener, world)?;
-        }
-
-        Ok(())
-    }
-
-    fn gate_action(
-        buffers: &BufferMap,
-        session: Entity,
-        action: Gate,
-        world: &mut World,
-        roster: &mut OperationRoster,
-    ) -> OperationResult {
-        for buffer in buffers.inner.values() {
-            buffer.gate_action(session, action, world, roster)?;
-        }
-
-        Ok(())
-    }
-
-    fn as_input(buffers: &BufferMap) -> SmallVec<[Entity; 8]> {
-        let mut input = SmallVec::new();
-        input.reserve(buffers.inner.len());
-
-        for buffer in buffers.inner.values() {
-            input.extend(buffer.as_input());
-        }
-
-        input
-    }
-
     fn ensure_active_session(
-        buffers: &BufferMap,
+        &self,
         session: Entity,
         world: &mut World,
     ) -> OperationResult {
-        for buffer in buffers.inner.values() {
+        for buffer in self.buffer_list() {
             buffer.ensure_active_session(session, world)?;
         }
 
         Ok(())
     }
+
+    fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
+        for buffer in self.buffer_list() {
+            add_listener_to_source(buffer.id(), listener, world)?;
+        }
+        Ok(())
+    }
+
+    fn gate_action(
+        &self,
+        session: Entity,
+        action: Gate,
+        world: &mut World,
+        roster: &mut OperationRoster,
+    ) -> OperationResult {
+        for buffer in self.buffer_list() {
+            GateState::apply(buffer.id(), session, action, world, roster)?;
+        }
+        Ok(())
+    }
+
+    fn as_input(&self) -> SmallVec<[Entity; 8]> {
+        let mut inputs = SmallVec::new();
+        for buffer in self.buffer_list() {
+            inputs.push(buffer.id());
+        }
+        inputs
+    }
+}
+
+/// This trait can be implemented for structs that are created by joining a
+/// collection of buffers. Usually this
+pub trait JoinedValue: 'static + Send + Sync + Sized {
+    /// This associated type must represent a buffer map layout that implements
+    /// the [`Joined`] trait. The message type yielded by [`Joined`] for this
+    /// associated type must match the [`JoinedValue`] type.
+    type Buffers: 'static + BufferMapLayout + Joined<Item = Self> + Send + Sync;
+
+    /// Used by [`Builder::join_into`]
+    fn join_into<'w, 's, 'a, 'b>(
+        buffers: Self::Buffers,
+        builder: &'b mut Builder<'w, 's, 'a>,
+    ) -> Chain<'w, 's, 'a, 'b, Self> {
+        let scope = builder.scope();
+        buffers.verify_scope(scope);
+
+        let join = builder.commands.spawn(()).id();
+        let target = builder.commands.spawn(UnusedTarget).id();
+        builder.commands.add(AddOperation::new(
+            Some(scope),
+            join,
+            Join::new(buffers, target),
+        ));
+
+        Output::new(scope, target).chain(builder)
+    }
+
+    /// Used by [`Builder::try_join_into`]
+    fn try_join_into<'w, 's, 'a, 'b>(
+        buffers: &BufferMap,
+        builder: &'b mut Builder<'w, 's, 'a>,
+    ) -> Result<Chain<'w, 's, 'a, 'b, Self>, IncompatibleLayout> {
+        let buffers: Self::Buffers = Self::Buffers::try_from_buffer_map(buffers)?;
+        Ok(Self::join_into(buffers, builder))
+    }
+}
+
+/// Trait to describe a layout of buffer keys
+pub trait BufferKeyMap: 'static + Send + Sync + Sized + Clone {
+    type Buffers: 'static + BufferMapLayout + Accessed<Key=Self> + Send + Sync;
+
+    fn add_accessor(buffers: &BufferMap, accessor: Entity, world: &mut World) -> OperationResult;
+
+    fn create_key(buffers: &BufferMap, builder: &BufferKeyBuilder) -> Self;
+
+    fn deep_clone_key(&self) -> Self;
+
+    fn is_key_in_use(&self) -> bool;
+}
+
+impl BufferMapLayout for BufferMap {
+    fn buffer_list(&self) -> SmallVec<[AnyBuffer; 8]> {
+        self.inner.values().cloned().collect()
+    }
+    fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
+        Ok(buffers.clone())
+    }
+}
+
+impl Joined for BufferMap {
+    type Item = HashMap<Cow<'static, str>, AnyMessageBox>;
+
+    fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
+        let mut value = HashMap::new();
+        for (name, buffer) in &self.inner {
+            value.insert(name.clone(), buffer.pull(session, world)?);
+        }
+
+        Ok(value)
+    }
+}
+
+impl JoinedValue for HashMap<Cow<'static, str>, AnyMessageBox> {
+    type Buffers = BufferMap;
+}
+
+impl Accessed for BufferMap {
+    type Key = HashMap<Cow<'static, str>, AnyBufferKey>;
+
+    fn create_key(&self, builder: &BufferKeyBuilder) -> Self::Key {
+        let mut keys = HashMap::new();
+        for (name, buffer) in &self.inner {
+            let key = AnyBufferKey {
+                tag: builder.make_tag(buffer.id()),
+                interface: buffer.interface,
+            };
+            keys.insert(name.clone(), key);
+        }
+        keys
+    }
+
+    fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
+        for buffer in self.inner.values() {
+            buffer.add_accessor(accessor, world)?;
+        }
+        Ok(())
+    }
+
+    fn deep_clone_key(key: &Self::Key) -> Self::Key {
+        let mut cloned_key = HashMap::new();
+        for (name, key) in key.iter() {
+            cloned_key.insert(name.clone(), key.deep_clone());
+        }
+        cloned_key
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        for k in key.values() {
+            if k.is_in_use() {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
-
-    use crate::{
-        prelude::*, testing::*, BufferMap, InspectBuffer, ManageBuffer, OperationError,
-        OperationResult, OrBroken,
-    };
+    use crate::{prelude::*, testing::*, BufferMap, OperationError};
 
     use bevy_ecs::prelude::World;
 
@@ -373,88 +321,38 @@ mod tests {
         string: String,
     }
 
-    impl BufferMapLayout for TestJoinedValue {
-        fn is_compatible(buffers: &BufferMap) -> Result<(), IncompatibleLayout> {
-            let mut compatibility = IncompatibleLayout::default();
-            compatibility.require_buffer::<i64>("integer", buffers);
-            compatibility.require_buffer::<f64>("float", buffers);
-            compatibility.require_buffer::<String>("string", buffers);
-            compatibility.into_result()
-        }
-
-        fn buffered_count(
-            buffers: &BufferMap,
-            session: Entity,
-            world: &World,
-        ) -> Result<usize, OperationError> {
-            let integer_count = world
-                .get_entity(buffers.get("integer").unwrap().id())
-                .or_broken()?
-                .buffered_count::<i64>(session)?;
-
-            let float_count = world
-                .get_entity(buffers.get("float").unwrap().id())
-                .or_broken()?
-                .buffered_count::<f64>(session)?;
-
-            let string_count = world
-                .get_entity(buffers.get("string").unwrap().id())
-                .or_broken()?
-                .buffered_count::<String>(session)?;
-
-            Ok([integer_count, float_count, string_count]
-                .iter()
-                .min()
-                .copied()
-                .unwrap_or(0))
-        }
-
-        fn ensure_active_session(
-            buffers: &BufferMap,
-            session: Entity,
-            world: &mut World,
-        ) -> OperationResult {
-            world
-                .get_entity_mut(buffers.get("integer").unwrap().id())
-                .or_broken()?
-                .ensure_session::<i64>(session)?;
-
-            world
-                .get_entity_mut(buffers.get("float").unwrap().id())
-                .or_broken()?
-                .ensure_session::<f64>(session)?;
-
-            world
-                .get_entity_mut(buffers.get("string").unwrap().id())
-                .or_broken()?
-                .ensure_session::<String>(session)?;
-
-            Ok(())
-        }
+    #[derive(Clone)]
+    struct TestJoinedValueBuffers {
+        integer: Buffer<i64>,
+        float: Buffer<f64>,
+        string: Buffer<String>,
     }
 
-    impl JoinedValue for TestJoinedValue {
-        type Buffers = TestJoinedValueBuffers;
+    impl BufferMapLayout for TestJoinedValueBuffers {
+        fn buffer_list(&self) -> smallvec::SmallVec<[AnyBuffer; 8]> {
+            use smallvec::smallvec;
+            smallvec![
+                self.integer.as_any_buffer(),
+                self.float.as_any_buffer(),
+                self.string.as_any_buffer(),
+            ]
+        }
 
-        fn pull(
-            buffers: &BufferMap,
-            session: Entity,
-            world: &mut World,
-        ) -> Result<Self, OperationError> {
-            let integer = world
-                .get_entity_mut(buffers.get("integer").unwrap().id())
-                .or_broken()?
-                .pull_from_buffer::<i64>(session)?;
+        fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
+            let mut compatibility = IncompatibleLayout::default();
+            let integer = compatibility.require_message_type::<i64>("integer", buffers);
+            let float = compatibility.require_message_type::<f64>("float", buffers);
+            let string = compatibility.require_message_type::<String>("string", buffers);
 
-            let float = world
-                .get_entity_mut(buffers.get("float").unwrap().id())
-                .or_broken()?
-                .pull_from_buffer::<f64>(session)?;
-
-            let string = world
-                .get_entity_mut(buffers.get("string").unwrap().id())
-                .or_broken()?
-                .pull_from_buffer::<String>(session)?;
+            let Ok(integer) = integer else {
+                return Err(compatibility);
+            };
+            let Ok(float) = float else {
+                return Err(compatibility);
+            };
+            let Ok(string) = string else {
+                return Err(compatibility);
+            };
 
             Ok(Self {
                 integer,
@@ -464,20 +362,24 @@ mod tests {
         }
     }
 
-    struct TestJoinedValueBuffers {
-        integer: Buffer<i64>,
-        float: Buffer<f64>,
-        string: Buffer<String>,
+    impl crate::Joined for TestJoinedValueBuffers {
+        type Item = TestJoinedValue;
+
+        fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
+            let integer = self.integer.pull(session, world)?;
+            let float = self.float.pull(session, world)?;
+            let string = self.string.pull(session, world)?;
+
+            Ok(TestJoinedValue {
+                integer,
+                float,
+                string,
+            })
+        }
     }
 
-    impl From<TestJoinedValueBuffers> for BufferMap {
-        fn from(value: TestJoinedValueBuffers) -> Self {
-            let mut buffers = BufferMap::default();
-            buffers.insert(Cow::Borrowed("integer"), value.integer);
-            buffers.insert(Cow::Borrowed("float"), value.float);
-            buffers.insert(Cow::Borrowed("string"), value.string);
-            buffers
-        }
+    impl JoinedValue for TestJoinedValue {
+        type Buffers = TestJoinedValueBuffers;
     }
 
     #[test]
@@ -490,9 +392,9 @@ mod tests {
             let buffer_string = builder.create_buffer(BufferSettings::default());
 
             let mut buffers = BufferMap::default();
-            buffers.insert(Cow::Borrowed("integer"), buffer_i64);
-            buffers.insert(Cow::Borrowed("float"), buffer_f64);
-            buffers.insert(Cow::Borrowed("string"), buffer_string);
+            buffers.insert("integer", buffer_i64);
+            buffers.insert("float", buffer_f64);
+            buffers.insert("string", buffer_string);
 
             scope.input.chain(builder).fork_unzip((
                 |chain: Chain<_>| chain.connect(buffer_i64.input_slot()),
@@ -501,7 +403,7 @@ mod tests {
             ));
 
             builder
-                .try_join_into(buffers)
+                .try_join_into(&buffers)
                 .unwrap()
                 .connect(scope.terminate);
         });

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use std::{
+    collections::HashMap,
+    borrow::Cow,
+};
+
+use bevy_ecs::prelude::{Entity, World};
+
+use crate::{DynBuffer, OperationError, OperationResult, OperationRoster, Buffered, Gate};
+
+#[derive(Clone)]
+pub struct BufferMap {
+    inner: HashMap<Cow<'static, str>, DynBuffer>,
+}
+
+pub trait BufferKeyMap: Sized {
+
+    fn buffered_count(
+        buffers: &BufferMap,
+        session: Entity,
+        world: &World
+    ) -> Result<usize, OperationError>;
+
+    fn pull(
+        buffers: &BufferMap,
+        session: Entity,
+        world: &mut World,
+    ) -> Result<Self, OperationError>;
+
+    fn add_listener(
+        buffers: &BufferMap,
+        listener: Entity,
+        world: &mut World,
+    ) -> OperationResult;
+
+    fn gate_action(
+        buffers: &BufferMap,
+        session: Entity,
+        action: Gate,
+        world: &mut World,
+        roster: &mut OperationRoster,
+    ) -> OperationResult;
+}
+
+struct BufferedMap<K> {
+    map: BufferMap,
+    _ignore: std::marker::PhantomData<fn(K)>,
+}
+
+impl<K: BufferKeyMap> Buffered for BufferedMap<K> {
+
+    type Item = K;
+
+    fn verify_scope(&self, scope: Entity) {
+        for buffer in self.map.inner.values() {
+            assert_eq!(scope, buffer.scope);
+        }
+    }
+
+    fn buffered_count(&self, session: Entity, world: &World) -> Result<usize, OperationError> {
+        K::buffered_count(&self.map, session, world)
+    }
+
+    fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
+        K::pull(&self.map, session, world)
+    }
+
+    fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
+
+    }
+}

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -24,9 +24,9 @@ use smallvec::SmallVec;
 use bevy_ecs::prelude::{Entity, World};
 
 use crate::{
-    add_listener_to_source, Accessed, AddOperation, AnyBuffer, AnyBufferKey, AnyMessageBox,
-    Buffer, BufferKeyBuilder, Buffered, Builder, Chain, Gate, GateState, Join, Joined,
-    OperationError, OperationResult, OperationRoster, Output, UnusedTarget, Bufferable,
+    add_listener_to_source, Accessed, AddOperation, AnyBuffer, AnyBufferKey, AnyMessageBox, Buffer,
+    BufferKeyBuilder, Bufferable, Buffered, Builder, Chain, Gate, GateState, Join, Joined,
+    OperationError, OperationResult, OperationRoster, Output, UnusedTarget,
 };
 
 #[derive(Clone, Default)]
@@ -59,7 +59,11 @@ pub struct IncompatibleLayout {
 
 impl IncompatibleLayout {
     /// Check whether a named buffer is compatible with a specific concrete message type.
-    pub fn require_message_type<Message: 'static>(&mut self, expected_name: &str, buffers: &BufferMap) -> Result<Buffer<Message>, ()> {
+    pub fn require_message_type<Message: 'static>(
+        &mut self,
+        expected_name: &str,
+        buffers: &BufferMap,
+    ) -> Result<Buffer<Message>, ()> {
         if let Some((name, buffer)) = buffers.inner.get_key_value(expected_name) {
             if let Some(buffer) = buffer.downcast_for_message::<Message>() {
                 return Ok(buffer);
@@ -80,7 +84,11 @@ impl IncompatibleLayout {
 
     /// Check whether a named buffer is compatible with a specialized buffer type,
     /// such as `JsonBuffer`.
-    pub fn require_buffer_type<BufferType: 'static>(&mut self, expected_name: &str, buffers: &BufferMap) -> Result<BufferType, ()> {
+    pub fn require_buffer_type<BufferType: 'static>(
+        &mut self,
+        expected_name: &str,
+        buffers: &BufferMap,
+    ) -> Result<BufferType, ()> {
         if let Some((name, buffer)) = buffers.inner.get_key_value(expected_name) {
             if let Some(buffer) = buffer.downcast_buffer::<BufferType>() {
                 return Ok(buffer);
@@ -139,11 +147,7 @@ impl<T: BufferMapLayout> Buffered for T {
         }
     }
 
-    fn buffered_count(
-        &self,
-        session: Entity,
-        world: &World,
-    ) -> Result<usize, OperationError> {
+    fn buffered_count(&self, session: Entity, world: &World) -> Result<usize, OperationError> {
         let mut min_count = None;
 
         for buffer in self.buffer_list() {
@@ -158,11 +162,7 @@ impl<T: BufferMapLayout> Buffered for T {
         Ok(min_count.unwrap_or(0))
     }
 
-    fn ensure_active_session(
-        &self,
-        session: Entity,
-        world: &mut World,
-    ) -> OperationResult {
+    fn ensure_active_session(&self, session: Entity, world: &mut World) -> OperationResult {
         for buffer in self.buffer_list() {
             buffer.ensure_active_session(session, world)?;
         }
@@ -238,7 +238,7 @@ pub trait JoinedValue: 'static + Send + Sync + Sized {
 
 /// Trait to describe a layout of buffer keys
 pub trait BufferKeyMap: 'static + Send + Sync + Sized + Clone {
-    type Buffers: 'static + BufferMapLayout + Accessed<Key=Self> + Send + Sync;
+    type Buffers: 'static + BufferMapLayout + Accessed<Key = Self> + Send + Sync;
 }
 
 impl BufferMapLayout for BufferMap {
@@ -402,10 +402,7 @@ mod tests {
                 |chain: Chain<_>| chain.connect(buffer_string.input_slot()),
             ));
 
-            builder
-                .try_join(&buffers)
-                .unwrap()
-                .connect(scope.terminate);
+            builder.try_join(&buffers).unwrap().connect(scope.terminate);
         });
 
         let mut promise = context.command(|commands| {
@@ -439,9 +436,7 @@ mod tests {
                 |chain: Chain<_>| chain.connect(buffers.string.input_slot()),
             ));
 
-            builder
-                .join(buffers)
-                .connect(scope.terminate);
+            builder.join(buffers).connect(scope.terminate);
         });
 
         let mut promise = context.command(|commands| {

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -28,13 +28,13 @@ use smallvec::SmallVec;
 use bevy_ecs::prelude::{Entity, World};
 
 use crate::{
-    DynBuffer, OperationError, OperationResult, OperationRoster, Buffered, Gate,
+    AnyBuffer, OperationError, OperationResult, OperationRoster, Buffered, Gate,
     Joined, Accessed, BufferKeyBuilder, AnyBufferKey,
 };
 
 #[derive(Clone)]
 pub struct BufferMap {
-    inner: HashMap<Cow<'static, str>, DynBuffer>,
+    inner: HashMap<Cow<'static, str>, AnyBuffer>,
 }
 
 /// This error is used when the buffers provided for an input are not compatible

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -29,7 +29,7 @@ use crate::{
     Joined, Node, OperationError, OperationResult, OperationRoster,
 };
 
-pub use bevy_impulse_derive::JoinedValue;
+pub use bevy_impulse_derive::{BufferKeyMap, JoinedValue};
 
 /// Uniquely identify a buffer within a buffer map, either by name or by an
 /// index value.
@@ -282,8 +282,66 @@ impl<T: BufferMapStruct> Buffered for T {
 }
 
 /// This trait can be implemented for structs that are created by joining together
-/// values from a collection of buffers. Usually you do not need to implement this
-/// yourself. Instead you can use `#[derive(JoinedValue)]`.
+/// values from a collection of buffers. This allows [`join`][1] to produce arbitrary
+/// structs. Structs with this trait can be produced by [`try_join`][2].
+///
+/// Each field in this struct needs to have the trait bounds `'static + Send + Sync`.
+///
+/// This does not generally need to be implemented explicitly. Instead you should
+/// use `#[derive(JoinedValue)]`:
+///
+/// ```
+/// use bevy_impulse::prelude::*;
+///
+/// #[derive(JoinedValue)]
+/// struct SomeValues {
+///     integer: i64,
+///     string: String,
+/// }
+/// ```
+///
+/// The above example would allow you to join a value from an `i64` buffer with
+/// a value from a `String` buffer. You can have as many fields in the struct
+/// as you'd like.
+///
+/// This macro will generate a struct of buffers to match the fields of the
+/// struct that it's applied to. The name of that struct is anonymous by default
+/// since you don't generally need to use it directly, but if you want to give
+/// it a name you can use #[joined(buffers_struct_name = ...)]`:
+///
+/// ```
+/// # use bevy_impulse::prelude::*;
+///
+/// #[derive(JoinedValue)]
+/// #[joined(buffers_struct_name = SomeBuffers)]
+/// struct SomeValues {
+///     integer: i64,
+///     string: String,
+/// }
+/// ```
+///
+/// By default each field of the generated buffers struct will have a type of
+/// [`Buffer<T>`], but you can override this using `#[joined(buffer = ...)]`
+/// to specify a special buffer type. For example if your `JoinedValue` struct
+/// contains an [`AnyMessageBox`] then by default the macro will use `Buffer<AnyMessageBox>`,
+/// but you probably really want it to have an [`AnyBuffer`]:
+///
+/// ```
+/// # use bevy_impulse::prelude::*;
+///
+/// #[derive(JoinedValue)]
+/// struct SomeValues {
+///     integer: i64,
+///     string: String,
+///     #[joined(buffer = AnyBuffer)]
+///     any: AnyMessageBox,
+/// }
+/// ```
+///
+/// The above method also works for joining a `JsonMessage` field from a `JsonBuffer`.
+///
+/// [1]: crate::Builder::join
+/// [2]: crate::Builder::try_join
 pub trait JoinedValue: 'static + Send + Sync + Sized {
     /// This associated type must represent a buffer map layout that implements
     /// the [`Joined`] trait. The message type yielded by [`Joined`] for this
@@ -300,7 +358,47 @@ pub trait JoinedValue: 'static + Send + Sync + Sized {
     }
 }
 
-/// Trait to describe a set of buffer keys.
+/// Trait to describe a set of buffer keys. This allows [listen][1] and [access][2]
+/// to work for arbitrary structs of buffer keys. Structs with this trait can be
+/// produced by [`try_listen`][3] and [`try_create_buffer_access`][4].
+///
+/// Each field in the struct must be some kind of buffer key.
+///
+/// This does not generally need to be implemented explicitly. Instead you should
+/// define a struct where all fields are buffer keys and then apply
+/// `#[derive(BufferKeyMap)]` to it, e.g.:
+///
+/// ```
+/// use bevy_impulse::prelude::*;
+///
+/// #[derive(Clone, BufferKeyMap)]
+/// struct SomeKeys {
+///     integer: BufferKey<i64>,
+///     string: BufferKey<String>,
+///     any: AnyBufferKey,
+/// }
+/// ```
+///
+/// The macro will generate a struct of buffers to match the keys. The name of
+/// that struct is anonymous by default since you don't generally need to use it
+/// directly, but if you want to give it a name you can use `#[key(buffers_struct_name = ...)]`:
+///
+/// ```
+/// # use bevy_impulse::prelude::*;
+///
+/// #[derive(Clone, BufferKeyMap)]
+/// #[key(buffers_struct_name = SomeBuffers)]
+/// struct SomeKeys {
+///     integer: BufferKey<i64>,
+///     string: BufferKey<String>,
+///     any: AnyBufferKey,
+/// }
+/// ```
+///
+/// [1]: crate::Builder::listen
+/// [2]: crate::Builder::create_buffer_access
+/// [3]: crate::Builder::try_listen
+/// [4]: crate::Builder::try_create_buffer_access
 pub trait BufferKeyMap: 'static + Send + Sync + Sized + Clone {
     type Buffers: 'static + BufferMapLayout + Accessed<Key = Self> + Send + Sync;
 
@@ -433,7 +531,7 @@ impl<B: 'static + Send + Sync + AsAnyBuffer + Clone, const N: usize> BufferMapLa
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, Accessed, AddBufferToMap, BufferMap};
+    use crate::{prelude::*, testing::*, AddBufferToMap, BufferMap};
 
     #[derive(JoinedValue)]
     struct TestJoinedValue<T: Send + Sync + 'static + Clone> {
@@ -624,7 +722,8 @@ mod tests {
         _b: u32,
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, BufferKeyMap)]
+    #[key(buffers_struct_name = TestKeysBuffers)]
     struct TestKeys<T: 'static + Send + Sync + Clone> {
         integer: BufferKey<i64>,
         float: BufferKey<f64>,
@@ -632,106 +731,159 @@ mod tests {
         generic: BufferKey<T>,
         any: AnyBufferKey,
     }
+    #[test]
+    fn test_listen() {
+        let mut context = TestingContext::minimal_plugins();
 
-    impl<T: 'static + Send + Sync + Clone> BufferKeyMap for TestKeys<T> {
-        type Buffers = TestKeysBuffers<T>;
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let buffer_any = builder.create_buffer::<i64>(BufferSettings::default());
+
+            let buffers = TestKeys::select_buffers(
+                builder.create_buffer(BufferSettings::default()),
+                builder.create_buffer(BufferSettings::default()),
+                builder.create_buffer(BufferSettings::default()),
+                builder.create_buffer(BufferSettings::default()),
+                buffer_any.as_any_buffer(),
+            );
+
+            scope.input.chain(builder).fork_unzip((
+                |chain: Chain<_>| chain.connect(buffers.integer.input_slot()),
+                |chain: Chain<_>| chain.connect(buffers.float.input_slot()),
+                |chain: Chain<_>| chain.connect(buffers.string.input_slot()),
+                |chain: Chain<_>| chain.connect(buffers.generic.input_slot()),
+                |chain: Chain<_>| chain.connect(buffer_any.input_slot()),
+            ));
+
+            builder
+                .listen(buffers)
+                .then(join_via_listen.into_blocking_callback())
+                .dispose_on_none()
+                .connect(scope.terminate);
+        });
+
+        let mut promise = context.command(|commands| {
+            commands
+                .request(
+                    (5_i64, 3.14_f64, "hello".to_string(), "world", 42_i64),
+                    workflow,
+                )
+                .take_response()
+        });
+
+        context.run_with_conditions(&mut promise, Duration::from_secs(2));
+        let value: TestJoinedValue<&'static str> = promise.take().available().unwrap();
+        assert_eq!(value.integer, 5);
+        assert_eq!(value.float, 3.14);
+        assert_eq!(value.string, "hello");
+        assert_eq!(value.generic, "world");
+        assert_eq!(*value.any.downcast::<i64>().unwrap(), 42);
+        assert!(context.no_unhandled_errors());
     }
 
-    #[derive(Clone)]
-    struct TestKeysBuffers<T: 'static + Send + Sync + Clone> {
-        integer: <BufferKey<i64> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer,
-        float: <BufferKey<f64> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer,
-        string: <BufferKey<String> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer,
-        generic: <BufferKey<T> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer,
-        any: <AnyBufferKey as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer,
+    #[test]
+    fn test_try_listen() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let buffer_i64 = builder.create_buffer::<i64>(BufferSettings::default());
+            let buffer_f64 = builder.create_buffer::<f64>(BufferSettings::default());
+            let buffer_string = builder.create_buffer::<String>(BufferSettings::default());
+            let buffer_generic = builder.create_buffer::<&'static str>(BufferSettings::default());
+            let buffer_any = builder.create_buffer::<i64>(BufferSettings::default());
+
+            scope.input.chain(builder).fork_unzip((
+                |chain: Chain<_>| chain.connect(buffer_i64.input_slot()),
+                |chain: Chain<_>| chain.connect(buffer_f64.input_slot()),
+                |chain: Chain<_>| chain.connect(buffer_string.input_slot()),
+                |chain: Chain<_>| chain.connect(buffer_generic.input_slot()),
+                |chain: Chain<_>| chain.connect(buffer_any.input_slot()),
+            ));
+
+            let mut buffer_map = BufferMap::new();
+            buffer_map.insert_buffer("integer", buffer_i64);
+            buffer_map.insert_buffer("float", buffer_f64);
+            buffer_map.insert_buffer("string", buffer_string);
+            buffer_map.insert_buffer("generic", buffer_generic);
+            buffer_map.insert_buffer("any", buffer_any);
+
+            builder
+                .try_listen(&buffer_map)
+                .unwrap()
+                .then(join_via_listen.into_blocking_callback())
+                .dispose_on_none()
+                .connect(scope.terminate);
+        });
+
+        let mut promise = context.command(|commands| {
+            commands
+                .request(
+                    (5_i64, 3.14_f64, "hello".to_string(), "world", 42_i64),
+                    workflow,
+                )
+                .take_response()
+        });
+
+        context.run_with_conditions(&mut promise, Duration::from_secs(2));
+        let value: TestJoinedValue<&'static str> = promise.take().available().unwrap();
+        assert_eq!(value.integer, 5);
+        assert_eq!(value.float, 3.14);
+        assert_eq!(value.string, "hello");
+        assert_eq!(value.generic, "world");
+        assert_eq!(*value.any.downcast::<i64>().unwrap(), 42);
+        assert!(context.no_unhandled_errors());
     }
 
-    impl<T: 'static + Send + Sync + Clone> BufferMapLayout for TestKeysBuffers<T> {
-        fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
-            let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
-            let integer = compatibility.require_buffer_by_literal::<<BufferKey<i64> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer>("integer", buffers);
-            let float = compatibility.require_buffer_by_literal::<<BufferKey<f64> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer>("float", buffers);
-            let string = compatibility.require_buffer_by_literal::<<BufferKey<String> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer>("string", buffers);
-            let generic = compatibility.require_buffer_by_literal::<<BufferKey<T> as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer>("generic", buffers);
-            let any = compatibility.require_buffer_by_literal::<<AnyBufferKey as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer>("any", buffers);
-
-            let Ok(integer) = integer else {
-                return Err(compatibility);
-            };
-            let Ok(float) = float else {
-                return Err(compatibility);
-            };
-            let Ok(string) = string else {
-                return Err(compatibility);
-            };
-            let Ok(generic) = generic else {
-                return Err(compatibility);
-            };
-            let Ok(any) = any else {
-                return Err(compatibility);
-            };
-
-            Ok(Self {
-                integer,
-                float,
-                string,
-                generic,
-                any,
-            })
+    /// This macro is a manual implementation of the join operation that uses
+    /// the buffer listening mechanism. There isn't any reason to reimplement
+    /// join here except so we can test that listening is working correctly for
+    /// BufferKeyMap.
+    fn join_via_listen(
+        In(keys): In<TestKeys<&'static str>>,
+        world: &mut World,
+    ) -> Option<TestJoinedValue<&'static str>> {
+        if world.buffer_view(&keys.integer).ok()?.is_empty() {
+            return None;
         }
-    }
-
-    impl<T: 'static + Send + Sync + Clone> ::bevy_impulse::BufferMapStruct for TestKeysBuffers<T> {
-        fn buffer_list(&self) -> smallvec::SmallVec<[AnyBuffer; 8]> {
-            smallvec::smallvec![
-                ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.integer),
-                ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.float),
-                ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.string),
-                ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.generic),
-                ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.any),
-            ]
+        if world.buffer_view(&keys.float).ok()?.is_empty() {
+            return None;
         }
-    }
-
-    impl<T: 'static + Send + Sync + Clone> Accessed for TestKeysBuffers<T> {
-        type Key = TestKeys<T>;
-
-        fn add_accessor(&self, accessor: Entity, world: &mut World) -> crate::OperationResult {
-            ::bevy_impulse::Accessed::add_accessor(&self.integer, accessor, world)?;
-            ::bevy_impulse::Accessed::add_accessor(&self.float, accessor, world)?;
-            ::bevy_impulse::Accessed::add_accessor(&self.string, accessor, world)?;
-            ::bevy_impulse::Accessed::add_accessor(&self.generic, accessor, world)?;
-            ::bevy_impulse::Accessed::add_accessor(&self.any, accessor, world)?;
-            Ok(())
+        if world.buffer_view(&keys.string).ok()?.is_empty() {
+            return None;
+        }
+        if world.buffer_view(&keys.generic).ok()?.is_empty() {
+            return None;
+        }
+        if world.any_buffer_view(&keys.any).ok()?.is_empty() {
+            return None;
         }
 
-        fn create_key(&self, builder: &crate::BufferKeyBuilder) -> Self::Key {
-            TestKeys {
-                integer: ::bevy_impulse::BufferKeyLifecycle::create_key(&self.integer, builder),
-                float: ::bevy_impulse::BufferKeyLifecycle::create_key(&self.float, builder),
-                string: ::bevy_impulse::BufferKeyLifecycle::create_key(&self.string, builder),
-                generic: ::bevy_impulse::BufferKeyLifecycle::create_key(&self.generic, builder),
-                any: ::bevy_impulse::BufferKeyLifecycle::create_key(&self.any, builder),
-            }
-        }
+        let integer = world
+            .buffer_mut(&keys.integer, |mut buffer| buffer.pull())
+            .unwrap()
+            .unwrap();
+        let float = world
+            .buffer_mut(&keys.float, |mut buffer| buffer.pull())
+            .unwrap()
+            .unwrap();
+        let string = world
+            .buffer_mut(&keys.string, |mut buffer| buffer.pull())
+            .unwrap()
+            .unwrap();
+        let generic = world
+            .buffer_mut(&keys.generic, |mut buffer| buffer.pull())
+            .unwrap()
+            .unwrap();
+        let any = world
+            .any_buffer_mut(&keys.any, |mut buffer| buffer.pull())
+            .unwrap()
+            .unwrap();
 
-        fn deep_clone_key(key: &Self::Key) -> Self::Key {
-            TestKeys {
-                integer: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.integer),
-                float: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.float),
-                string: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.string),
-                generic: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.generic),
-                any: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.any),
-            }
-        }
-
-        fn is_key_in_use(key: &Self::Key) -> bool {
-            false
-                || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.integer)
-                || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.float)
-                || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.string)
-                || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.generic)
-                || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.any)
-        }
+        Some(TestJoinedValue {
+            integer,
+            float,
+            string,
+            generic,
+            any,
+        })
     }
 }

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -219,7 +219,7 @@ impl<K> Clone for BufferedMap<K> {
 impl<L: BufferMapLayout> Buffered for BufferedMap<L> {
     fn verify_scope(&self, scope: Entity) {
         for buffer in self.map.inner.values() {
-            assert_eq!(scope, buffer.scope);
+            assert_eq!(scope, buffer.scope());
         }
     }
 

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -29,7 +29,7 @@ use bevy_ecs::prelude::{Entity, World};
 
 use crate::{
     DynBuffer, OperationError, OperationResult, OperationRoster, Buffered, Gate,
-    Joined, Accessed, BufferKeyBuilder, DynBufferKey,
+    Joined, Accessed, BufferKeyBuilder, AnyBufferKey,
 };
 
 #[derive(Clone)]
@@ -197,7 +197,7 @@ impl<K: BufferKeyMap> Accessed for BufferedMap<K> {
 /// Container to represent any layout of buffer keys.
 #[derive(Clone, Debug)]
 pub struct AnyBufferKeyMap {
-    pub keys: HashMap<Cow<'static, str>, DynBufferKey>,
+    pub keys: HashMap<Cow<'static, str>, AnyBufferKey>,
 }
 
 impl BufferMapLayout for AnyBufferKeyMap {

--- a/src/buffer/buffer_storage.rs
+++ b/src/buffer/buffer_storage.rs
@@ -44,7 +44,7 @@ pub(crate) struct BufferStorage<T> {
 }
 
 impl<T> BufferStorage<T> {
-    pub(crate) fn count(&self, session: Entity) -> usize  {
+    pub(crate) fn count(&self, session: Entity) -> usize {
         self.reverse_queues
             .get(&session)
             .map(|q| q.len())

--- a/src/buffer/buffer_storage.rs
+++ b/src/buffer/buffer_storage.rs
@@ -15,19 +15,56 @@
  *
 */
 
-use bevy_ecs::prelude::{Component, Entity};
+use bevy_ecs::prelude::{Component, Entity, EntityRef, EntityWorldMut, World, Mut};
 
 use smallvec::{Drain, SmallVec};
 
 use std::collections::HashMap;
 
 use std::{
+    any::{Any, TypeId},
     iter::Rev,
     ops::RangeBounds,
     slice::{Iter, IterMut},
 };
 
-use crate::{BufferSettings, RetentionPolicy};
+use thiserror::Error as ThisError;
+
+use crate::{
+    AnyBufferMut, BufferSettings, DynBufferKey, InspectBuffer, ManageBuffer,
+    RetentionPolicy, OperationError, OperationResult,
+};
+
+pub(crate) trait BufferInspection {
+    fn count(&self, session: Entity) -> usize;
+    fn active_sessions(&self) -> SmallVec<[Entity; 16]>;
+}
+
+pub(crate) trait DynBufferViewer<'a, R> {
+    fn dyn_oldest(&'a self, session: Entity) -> Option<R>;
+    fn dyn_newest(&'a self, session: Entity) -> Option<R>;
+    fn dyn_get(&'a self, session: Entity, index: usize) -> Option<R>;
+}
+
+pub(crate) trait DynBufferMutator<'a, R, M>: DynBufferViewer<'a, R> {
+    fn dyn_oldest_mut(&'a mut self, session: Entity) -> Option<M>;
+    fn dyn_newest_mut(&'a mut self, session: Entity) -> Option<M>;
+    fn dyn_get_mut(&'a mut self, session: Entity, index: usize) -> Option<M>;
+}
+
+pub(crate) trait DynBufferManagement<'a, R, M, T, E>: DynBufferMutator<'a, R, M> {
+    fn dyn_force_push(&mut self, session: Entity, value: T) -> Result<Option<T>, E>;
+    fn dyn_push(&mut self, session: Entity, value: T) -> Result<Option<T>, E>;
+    fn dyn_push_as_oldest(&mut self, session: Entity, value: T) -> Result<Option<T>, E>;
+    fn dyn_pull(&mut self, session: Entity) -> Option<T>;
+    fn dyn_pull_newest(&mut self, session: Entity) -> Option<T>;
+    fn dyn_consume(&mut self, session: Entity) -> SmallVec<[T; 16]>;
+}
+
+pub(crate) trait BufferSessionManagement {
+    fn clear_session(&mut self, session: Entity);
+    fn ensure_session(&mut self, session: Entity);
+}
 
 #[derive(Component)]
 pub(crate) struct BufferStorage<T> {
@@ -44,23 +81,7 @@ pub(crate) struct BufferStorage<T> {
 }
 
 impl<T> BufferStorage<T> {
-    pub(crate) fn force_push(&mut self, session: Entity, value: T) -> Option<T> {
-        Self::impl_push(
-            self.reverse_queues.entry(session).or_default(),
-            self.settings.retention(),
-            value,
-        )
-    }
-
-    pub(crate) fn push(&mut self, session: Entity, value: T) -> Option<T> {
-        let Some(reverse_queue) = self.reverse_queues.get_mut(&session) else {
-            return Some(value);
-        };
-
-        Self::impl_push(reverse_queue, self.settings.retention(), value)
-    }
-
-    pub(crate) fn impl_push(
+    fn impl_push(
         reverse_queue: &mut SmallVec<[T; 16]>,
         retention: RetentionPolicy,
         value: T,
@@ -90,6 +111,22 @@ impl<T> BufferStorage<T> {
 
         reverse_queue.insert(0, value);
         replaced
+    }
+
+    pub(crate) fn force_push(&mut self, session: Entity, value: T) -> Option<T> {
+        Self::impl_push(
+            self.reverse_queues.entry(session).or_default(),
+            self.settings.retention(),
+            value,
+        )
+    }
+
+    pub(crate) fn push(&mut self, session: Entity, value: T) -> Option<T> {
+        let Some(reverse_queue) = self.reverse_queues.get_mut(&session) else {
+            return Some(value);
+        };
+
+        Self::impl_push(reverse_queue, self.settings.retention(), value)
     }
 
     pub(crate) fn push_as_oldest(&mut self, session: Entity, value: T) -> Option<T> {
@@ -147,20 +184,8 @@ impl<T> BufferStorage<T> {
         self.reverse_queues.remove(&session);
     }
 
-    pub(crate) fn count(&self, session: Entity) -> usize {
-        self.reverse_queues
-            .get(&session)
-            .map(|q| q.len())
-            .unwrap_or(0)
-    }
-
-    pub(crate) fn iter(&self, session: Entity) -> IterBufferView<'_, T>
-    where
-        T: 'static + Send + Sync,
-    {
-        IterBufferView {
-            iter: self.reverse_queues.get(&session).map(|q| q.iter().rev()),
-        }
+    pub(crate) fn ensure_session(&mut self, session: Entity) {
+        self.reverse_queues.entry(session).or_default();
     }
 
     pub(crate) fn iter_mut(&mut self, session: Entity) -> IterBufferMut<'_, T>
@@ -173,37 +198,6 @@ impl<T> BufferStorage<T> {
                 .get_mut(&session)
                 .map(|q| q.iter_mut().rev()),
         }
-    }
-
-    pub(crate) fn drain<R>(&mut self, session: Entity, range: R) -> DrainBuffer<'_, T>
-    where
-        T: 'static + Send + Sync,
-        R: RangeBounds<usize>,
-    {
-        DrainBuffer {
-            drain: self
-                .reverse_queues
-                .get_mut(&session)
-                .map(|q| q.drain(range).rev()),
-        }
-    }
-
-    pub(crate) fn oldest(&self, session: Entity) -> Option<&T> {
-        self.reverse_queues.get(&session).and_then(|q| q.last())
-    }
-
-    pub(crate) fn newest(&self, session: Entity) -> Option<&T> {
-        self.reverse_queues.get(&session).and_then(|q| q.first())
-    }
-
-    pub(crate) fn get(&self, session: Entity, index: usize) -> Option<&T> {
-        let reverse_queue = self.reverse_queues.get(&session)?;
-        let len = reverse_queue.len();
-        if len >= index {
-            return None;
-        }
-
-        reverse_queue.get(len - index - 1)
     }
 
     pub(crate) fn oldest_mut(&mut self, session: Entity) -> Option<&mut T> {
@@ -228,12 +222,44 @@ impl<T> BufferStorage<T> {
         reverse_queue.get_mut(len - index - 1)
     }
 
-    pub(crate) fn active_sessions(&self) -> SmallVec<[Entity; 16]> {
-        self.reverse_queues.keys().copied().collect()
+    pub(crate) fn drain<R>(&mut self, session: Entity, range: R) -> DrainBuffer<'_, T>
+    where
+        T: 'static + Send + Sync,
+        R: RangeBounds<usize>,
+    {
+        DrainBuffer {
+            drain: self
+                .reverse_queues
+                .get_mut(&session)
+                .map(|q| q.drain(range).rev()),
+        }
     }
 
-    pub(crate) fn ensure_session(&mut self, session: Entity) {
-        self.reverse_queues.entry(session).or_default();
+    pub(crate) fn iter(&self, session: Entity) -> IterBufferView<'_, T>
+    where
+        T: 'static + Send + Sync,
+    {
+        IterBufferView {
+            iter: self.reverse_queues.get(&session).map(|q| q.iter().rev()),
+        }
+    }
+
+    pub(crate) fn oldest(&self, session: Entity) -> Option<&T> {
+        self.reverse_queues.get(&session).and_then(|q| q.last())
+    }
+
+    pub(crate) fn newest(&self, session: Entity) -> Option<&T> {
+        self.reverse_queues.get(&session).and_then(|q| q.first())
+    }
+
+    pub(crate) fn get(&self, session: Entity, index: usize) -> Option<&T> {
+        let reverse_queue = self.reverse_queues.get(&session)?;
+        let len = reverse_queue.len();
+        if len >= index {
+            return None;
+        }
+
+        reverse_queue.get(len - index - 1)
     }
 
     pub(crate) fn new(settings: BufferSettings) -> Self {
@@ -242,6 +268,117 @@ impl<T> BufferStorage<T> {
             reverse_queues: Default::default(),
         }
     }
+}
+
+impl<T: 'static + Send + Sync> BufferInspection for BufferStorage<T> {
+    fn count(&self, session: Entity) -> usize  {
+        self.reverse_queues
+            .get(&session)
+            .map(|q| q.len())
+            .unwrap_or(0)
+    }
+
+    fn active_sessions(&self) -> SmallVec<[Entity; 16]> {
+        self.reverse_queues.keys().copied().collect()
+    }
+}
+
+pub type AnyMessageRef<'a> = &'a (dyn Any + 'static + Send + Sync);
+
+impl<'a, T: 'static + Send + Sync + Any> DynBufferViewer<'a, AnyMessageRef<'a>> for Mut<'a, BufferStorage<T>> {
+    fn dyn_oldest(&'a self, session: Entity) -> Option<AnyMessageRef<'a>> {
+        self.oldest(session).map(to_any_ref)
+    }
+
+    fn dyn_newest(&'a self, session: Entity) -> Option<AnyMessageRef<'a>> {
+        self.newest(session).map(to_any_ref)
+    }
+
+    fn dyn_get(&'a self, session: Entity, index: usize) -> Option<AnyMessageRef<'a>> {
+        self.get(session, index).map(to_any_ref)
+    }
+}
+
+pub type AnyMessageMut<'a> = &'a mut (dyn Any + 'static + Send + Sync);
+
+impl<'a, T: 'static + Send + Sync + Any> DynBufferMutator<'a, AnyMessageRef<'a>, AnyMessageMut<'a>> for Mut<'a, BufferStorage<T>> {
+    fn dyn_oldest_mut(&'a mut self, session: Entity) -> Option<AnyMessageMut<'a>> {
+        self.oldest_mut(session).map(to_any_mut)
+    }
+
+    fn dyn_newest_mut(&'a mut self, session: Entity) -> Option<AnyMessageMut<'a>> {
+        self.newest_mut(session).map(to_any_mut)
+    }
+
+    fn dyn_get_mut(&'a mut self, session: Entity, index: usize) -> Option<AnyMessageMut<'a>> {
+        self.get_mut(session, index).map(to_any_mut)
+    }
+}
+
+pub type BoxedMessage = Box<dyn Any + 'static + Send + Sync>;
+
+#[derive(ThisError, Debug)]
+#[error("failed to convert a message")]
+pub struct BoxedMessageError {
+    /// The original value provided
+    pub value: BoxedMessage,
+    /// The type expected by the buffer
+    pub type_id: TypeId,
+}
+
+impl<'a, T: 'static + Send + Sync + Any> DynBufferManagement<'a, AnyMessageRef<'a>, AnyMessageMut<'a>, BoxedMessage, BoxedMessageError> for Mut<'a, BufferStorage<T>> {
+    fn dyn_force_push(&mut self, session: Entity, value: BoxedMessage) -> Result<Option<BoxedMessage>, BoxedMessageError> {
+        let value = from_boxed_message::<T>(value)?;
+        Ok(self.force_push(session, value).map(to_boxed_message))
+    }
+
+    fn dyn_push(&mut self, session: Entity, value: BoxedMessage) -> Result<Option<BoxedMessage>, BoxedMessageError> {
+        let value = from_boxed_message::<T>(value)?;
+        Ok(self.push(session, value).map(to_boxed_message))
+    }
+
+    fn dyn_push_as_oldest(&mut self, session: Entity, value: BoxedMessage) -> Result<Option<BoxedMessage>, BoxedMessageError> {
+        let value = from_boxed_message::<T>(value)?;
+        Ok(self.push_as_oldest(session, value).map(to_boxed_message))
+    }
+
+    fn dyn_pull(&mut self, session: Entity) -> Option<BoxedMessage> {
+        self.pull(session).map(to_boxed_message)
+    }
+
+    fn dyn_pull_newest(&mut self, session: Entity) -> Option<BoxedMessage> {
+        self.pull_newest(session).map(to_boxed_message)
+    }
+
+    fn dyn_consume(&mut self, session: Entity) -> SmallVec<[BoxedMessage; 16]> {
+        self.consume(session).into_iter().map(to_boxed_message).collect()
+    }
+}
+
+fn to_any_ref<'a, T: 'static + Send + Sync + Any>(x: &'a T) -> AnyMessageRef<'a> {
+    x
+}
+
+fn to_any_mut<'a, T: 'static + Send + Sync + Any>(x: &'a mut T) -> AnyMessageMut<'a> {
+    x
+}
+
+fn to_boxed_message<T: 'static + Send + Sync + Any>(x: T) -> BoxedMessage {
+    Box::new(x)
+}
+
+fn from_boxed_message<T: 'static + Send + Sync + Any>(value: BoxedMessage) -> Result<T, BoxedMessageError>
+where
+    T: 'static,
+{
+    let value = value.downcast::<T>().map_err(|value| {
+        BoxedMessageError {
+            value,
+            type_id: TypeId::of::<T>(),
+        }
+    })?;
+
+    Ok(*value)
 }
 
 pub struct IterBufferView<'b, T>
@@ -308,4 +445,33 @@ where
             None
         }
     }
+}
+
+/// A component that lets us inspect buffer properties without knowing the
+/// message type of the buffer.
+#[derive(Component, Clone, Copy)]
+pub(crate) struct DynBufferStorage {
+    access_any_buffer_mut: fn(DynBufferKey, Box<dyn FnOnce(AnyBufferMut) + '_>, &mut World),
+}
+
+impl DynBufferStorage {
+    pub(crate) fn new<T: 'static + Send + Sync>() -> Self {
+        Self {
+            access_any_buffer_mut: crate::access_any_buffer_mut::<T>,
+        }
+    }
+}
+
+fn buffered_count<T: 'static + Send + Sync>(
+    entity: &EntityRef,
+    session: Entity,
+) -> Result<usize, OperationError> {
+    entity.buffered_count::<T>(session)
+}
+
+fn ensure_session<T: 'static + Send + Sync>(
+    entity_mut: &mut EntityWorldMut,
+    session: Entity,
+) -> OperationResult {
+    entity_mut.ensure_session::<T>(session)
 }

--- a/src/buffer/buffer_storage.rs
+++ b/src/buffer/buffer_storage.rs
@@ -15,32 +15,19 @@
  *
 */
 
-use bevy_ecs::{
-    prelude::{Component, Entity, EntityRef, EntityWorldMut, World, Mut},
-    system::SystemState,
-};
+use bevy_ecs::prelude::{Component, Entity};
 
 use smallvec::{Drain, SmallVec};
 
 use std::collections::HashMap;
 
 use std::{
-    any::{Any, TypeId},
     iter::Rev,
     ops::RangeBounds,
     slice::{Iter, IterMut},
 };
 
-use crate::{
-    AnyBufferAccessMutState, BufferAccessMut, BufferSettings,
-    InspectBuffer, ManageBuffer, RetentionPolicy, OperationError, OperationResult,
-};
-
-
-pub(crate) trait BufferSessionManagement {
-    fn clear_session(&mut self, session: Entity);
-    fn ensure_session(&mut self, session: Entity);
-}
+use crate::{BufferSettings, RetentionPolicy};
 
 #[derive(Component)]
 pub(crate) struct BufferStorage<T> {

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -19,8 +19,8 @@ use bevy_utils::all_tuples;
 use smallvec::SmallVec;
 
 use crate::{
-    Accessed, AddOperation, Buffer, BufferSettings, Buffered, Builder, Chain,
-    CloneFromBuffer, Join, Joined, Output, UnusedTarget,
+    Accessed, AddOperation, Buffer, BufferSettings, Buffered, Builder, Chain, CloneFromBuffer,
+    Join, Joined, Output, UnusedTarget,
 };
 
 pub type BufferKeys<B> = <<B as Bufferable>::BufferType as Accessed>::Key;

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -20,8 +20,8 @@ use smallvec::SmallVec;
 
 use crate::{
     Accessed, AddOperation, Buffer, BufferSettings, Buffered, Builder, Chain,
-    CleanupWorkflowConditions, CloneFromBuffer, Join, Joined, Listen, Output, Scope,
-    ScopeSettings, UnusedTarget,
+    CleanupWorkflowConditions, CloneFromBuffer, Join, Joined, Listen, Output, Scope, ScopeSettings,
+    UnusedTarget,
 };
 
 pub type BufferKeys<B> = <<B as Bufferable>::BufferType as Accessed>::Key;

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -152,6 +152,13 @@ impl<T: Bufferable, const N: usize> Bufferable for [T; N] {
     }
 }
 
+impl<T: Bufferable> Bufferable for Vec<T> {
+    type BufferType = Vec<T::BufferType>;
+    fn into_buffer(self, builder: &mut Builder) -> Self::BufferType {
+        self.into_iter().map(|b| b.into_buffer(builder)).collect()
+    }
+}
+
 pub trait IterBufferable {
     type BufferElement: Buffered + Joined;
 

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -156,7 +156,7 @@ pub trait Bufferable {
 impl<T: 'static + Send + Sync> Bufferable for Buffer<T> {
     type BufferType = Self;
     fn into_buffer(self, builder: &mut Builder) -> Self::BufferType {
-        assert_eq!(self.scope, builder.scope());
+        assert_eq!(self.scope(), builder.scope());
         self
     }
 }
@@ -164,7 +164,7 @@ impl<T: 'static + Send + Sync> Bufferable for Buffer<T> {
 impl<T: 'static + Send + Sync + Clone> Bufferable for CloneFromBuffer<T> {
     type BufferType = Self;
     fn into_buffer(self, builder: &mut Builder) -> Self::BufferType {
-        assert_eq!(self.scope, builder.scope());
+        assert_eq!(self.scope(), builder.scope());
         self
     }
 }

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -540,9 +540,7 @@ pub(crate) fn add_listener_to_source(
     listener: Entity,
     world: &mut World,
 ) -> OperationResult {
-    let mut targets = world
-        .get_mut::<ForkTargetStorage>(source)
-        .or_broken()?;
+    let mut targets = world.get_mut::<ForkTargetStorage>(source).or_broken()?;
     if !targets.0.contains(&listener) {
         targets.0.push(listener);
     }

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -23,7 +23,7 @@ use smallvec::SmallVec;
 use crate::{
     Buffer, BufferAccessors, BufferKey, BufferKeyBuilder, BufferStorage, CloneFromBuffer,
     ForkTargetStorage, Gate, GateState, InspectBuffer, ManageBuffer, OperationError,
-    OperationResult, OperationRoster, OrBroken, SingleInputStorage, DynBuffer,
+    OperationResult, OperationRoster, OrBroken, SingleInputStorage, AnyBuffer,
 };
 
 pub trait Buffered: Clone {
@@ -205,7 +205,7 @@ impl<T: 'static + Send + Sync + Clone> Accessed for CloneFromBuffer<T> {
     }
 }
 
-impl Buffered for DynBuffer {
+impl Buffered for AnyBuffer {
     fn verify_scope(&self, scope: Entity) {
         assert_eq!(scope, self.scope);
     }

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -211,10 +211,8 @@ impl Buffered for AnyBuffer {
     }
 
     fn buffered_count(&self, session: Entity, world: &World) -> Result<usize, OperationError> {
-        world
-            .get_entity(self.source)
-            .or_broken()?
-            .dyn_buffered_count(session)
+        let entity_ref = world.get_entity(self.source).or_broken()?;
+        self.interface.buffered_count(&entity_ref, session)
     }
 
     fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
@@ -236,10 +234,8 @@ impl Buffered for AnyBuffer {
     }
 
     fn ensure_active_session(&self, session: Entity, world: &mut World) -> OperationResult {
-        world
-            .get_entity_mut(self.source)
-            .or_broken()?
-            .dyn_ensure_session(session)
+        let mut entity_mut = world.get_entity_mut(self.source).or_broken()?;
+        self.interface.ensure_session(&mut entity_mut, session)
     }
 }
 

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -57,7 +57,7 @@ pub trait Joined: Buffered {
     /// and join them into a tuple that gets sent to the target.
     ///
     /// If you need a more general way to get access to one or more buffers,
-    /// use [`listen`](Self::listen) instead.
+    /// use [`listen`](Accessed::listen) instead.
     fn join<'w, 's, 'a, 'b>(
         self,
         builder: &'b mut Builder<'w, 's, 'a>,
@@ -90,7 +90,7 @@ pub trait Accessed: Buffered {
     /// operates on those buffers.
     ///
     /// For an operation that simply joins the contents of two or more outputs
-    /// or buffers, use [`join`](Self::join) instead.
+    /// or buffers, use [`join`](Joined::join) instead.
     fn listen<'w, 's, 'a, 'b>(
         self,
         builder: &'b mut Builder<'w, 's, 'a>,

--- a/src/buffer/buffered.rs
+++ b/src/buffer/buffered.rs
@@ -22,11 +22,10 @@ use bevy_utils::all_tuples;
 use smallvec::SmallVec;
 
 use crate::{
-    Buffer, BufferAccessors, BufferKey, BufferKeyBuilder, BufferStorage, CloneFromBuffer,
-    ForkTargetStorage, Gate, GateState, InspectBuffer, ManageBuffer, OperationError,
-    OperationResult, OperationRoster, OrBroken, SingleInputStorage, Join, Output,
-    AddOperation, Chain, Builder, UnusedTarget, Listen, CleanupWorkflowConditions,
-    Scope, ScopeSettings, BeginCleanupWorkflow,
+    AddOperation, BeginCleanupWorkflow, Buffer, BufferAccessors, BufferKey, BufferKeyBuilder,
+    BufferStorage, Builder, Chain, CleanupWorkflowConditions, CloneFromBuffer, ForkTargetStorage,
+    Gate, GateState, InspectBuffer, Join, Listen, ManageBuffer, OperationError, OperationResult,
+    OperationRoster, OrBroken, Output, Scope, ScopeSettings, SingleInputStorage, UnusedTarget,
 };
 
 pub trait Buffered: 'static + Send + Sync + Clone {
@@ -109,7 +108,6 @@ pub trait Accessed: Buffered {
 
         Output::new(scope, target).chain(builder)
     }
-
 
     /// Alternative way to call [`Builder::on_cleanup`].
     fn on_cleanup<Settings>(

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -18,18 +18,24 @@
 use std::{
     any::TypeId,
     collections::HashMap,
-    sync::{Mutex, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
 };
 
-use bevy_ecs::prelude::Entity;
-
-use schemars::{
-    gen::SchemaGenerator,
-    schema::Schema,
-    JsonSchema,
+use bevy_ecs::{
+    prelude::{Commands, Entity, EntityRef, EntityWorldMut, Mut, World},
+    system::SystemState,
 };
 
 use serde::{de::DeserializeOwned, Serialize};
+
+use serde_json::Value as JsonMessage;
+
+use thiserror::Error as ThisError;
+
+use crate::{
+    AnyRange, BufferKey, BufferAccessLifecycle, BufferAccessMut, BufferError, BufferStorage,
+    DrainBuffer, OperationError, OperationResult, InspectBuffer, ManageBuffer, GateState,
+};
 
 #[derive(Clone, Copy, Debug)]
 pub struct JsonBuffer {
@@ -38,10 +44,220 @@ pub struct JsonBuffer {
     pub(crate) interface: &'static (dyn JsonBufferAccessInterface + Send + Sync),
 }
 
+/// Similar to a [`BufferKey`] except it can be used for any buffer that supports
+/// serialization and deserialization without knowing the buffer's specific
+/// message type at compile time.
+///
+/// Use this with [`JsonBufferAccess`] to directly view or manipulate the contents
+/// of a buffer.
+#[derive(Clone)]
+pub struct JsonBufferKey {
+    buffer: Entity,
+    session: Entity,
+    accessor: Entity,
+    lifecycle: Option<Arc<BufferAccessLifecycle>>,
+    interface: &'static (dyn JsonBufferAccessInterface + Send + Sync),
+}
+
+impl std::fmt::Debug for JsonBufferKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f
+            .debug_struct("JsonBufferKey")
+            .field("buffer", &self.buffer)
+            .field("session", &self.session)
+            .field("accessor", &self.accessor)
+            .field("in_use", &self.lifecycle.as_ref().is_some_and(|l| l.is_in_use()))
+            .field("message_type_name", &self.interface.message_type_name())
+            .finish()
+    }
+}
+
+pub struct JsonBufferMut<'w, 's, 'a> {
+    storage: Box<dyn JsonBufferManagement + 'a>,
+    gate: Mut<'a, GateState>,
+    buffer: Entity,
+    session: Entity,
+    accessor: Option<Entity>,
+    commands: &'a mut Commands<'w, 's>,
+    modified: bool,
+}
+
+///  View or modify a buffer message in terms of JSON values.
+pub struct JsonMut<'a> {
+    interface: &'a mut dyn JsonMutInterface,
+}
+
+impl<'a> JsonMut<'a> {
+    /// Serialize the message within the buffer into JSON.
+    ///
+    /// This new [`JsonMessage`] will be a duplicate of the data of the message
+    /// inside the buffer, effectively meaning this function clones the data.
+    pub fn serialize(&self) -> Result<JsonMessage, serde_json::Error> {
+        self.interface.serialize()
+    }
+
+    /// This will first serialize the message within the buffer into JSON and
+    /// then attempt to deserialize it into the target type.
+    ///
+    /// The target type does not need to match the message type inside the buffer,
+    /// as long as the target type can be deserialized from a serialized value
+    /// of the buffer's message type.
+    ///
+    /// The returned value will duplicate the data of the message inside the
+    /// buffer, effectively meaning this function clones the data.
+    pub fn deserialize_into<T: DeserializeOwned>(&self) -> Result<T, serde_json::Error> {
+        serde_json::from_value::<T>(self.serialize()?)
+    }
+
+    /// Replace the underlying message with new data, and receive its original
+    /// data as JSON.
+    #[must_use = "if you are going to discard the returned message, use insert instead"]
+    pub fn replace(&mut self, message: JsonMessage) -> JsonMessageReplaceResult {
+        self.interface.replace(message)
+    }
+
+    /// Insert new data into the underyling message. This is the same as replace
+    /// except it is more efficient if you don't care about the original data,
+    /// because it will discard the original data instead of serializing it.
+    pub fn insert(&mut self, message: JsonMessage) -> Result<(), serde_json::Error> {
+        self.interface.insert(message)
+    }
+}
+
+pub type JsonMessageFetchResult = Result<Option<JsonMessage>, serde_json::Error>;
+pub type JsonMessagePushResult = Result<Option<JsonMessage>, serde_json::Error>;
+pub type JsonMessageReplaceResult = Result<JsonMessage, serde_json::Error>;
+
+trait JsonBufferViewing {
+    fn json_count(&self, session: Entity) -> usize;
+    fn json_oldest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult;
+    fn json_newest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult;
+    fn json_get<'a>(&'a self, session: Entity, index: usize) ->JsonMessageFetchResult;
+}
+
+trait JsonBufferManagement: JsonBufferViewing {
+    fn json_push(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult;
+    fn json_push_as_oldest(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult;
+    fn json_pull(&mut self, session: Entity) -> JsonMessageFetchResult;
+    fn json_pull_newest(&mut self, session: Entity) -> JsonMessageFetchResult;
+    fn json_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>>;
+    fn json_newest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>>;
+    fn json_get_mut<'a>(&'a mut self, session: Entity, index: usize) -> Option<JsonMut<'a>>;
+    fn json_drain<'a>(&'a mut self, session: Entity, range: AnyRange) -> Box<dyn DrainJsonBufferInterface + 'a>;
+}
+
+impl<T> JsonBufferViewing for Mut<'_, BufferStorage<T>>
+where
+    T: 'static + Send + Sync + Serialize + DeserializeOwned,
+{
+    fn json_count(&self, session: Entity) -> usize {
+        self.count(session)
+    }
+
+    fn json_oldest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult {
+        self.oldest(session).map(serde_json::to_value).transpose()
+    }
+
+    fn json_newest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult {
+        self.newest(session).map(serde_json::to_value).transpose()
+    }
+
+    fn json_get<'a>(&'a self, session: Entity, index: usize) ->JsonMessageFetchResult {
+        self.get(session, index).map(serde_json::to_value).transpose()
+    }
+}
+
+impl<T> JsonBufferManagement for Mut<'_, BufferStorage<T>>
+where
+    T: 'static + Send + Sync + Serialize + DeserializeOwned,
+{
+    fn json_push(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult {
+        let value: T = serde_json::from_value(value)?;
+        self.push(session, value).map(serde_json::to_value).transpose()
+    }
+
+    fn json_push_as_oldest(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult {
+        let value: T = serde_json::from_value(value)?;
+        self.push(session, value).map(serde_json::to_value).transpose()
+    }
+
+    fn json_pull(&mut self, session: Entity) -> JsonMessageFetchResult {
+        self.pull(session).map(serde_json::to_value).transpose()
+    }
+
+    fn json_pull_newest(&mut self, session: Entity) -> JsonMessageFetchResult {
+        self.pull_newest(session).map(serde_json::to_value).transpose()
+    }
+
+    fn json_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>> {
+        self.oldest_mut(session).map(|interface| JsonMut { interface })
+    }
+
+    fn json_newest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>> {
+        self.newest_mut(session).map(|interface| JsonMut { interface })
+    }
+
+    fn json_get_mut<'a>(&'a mut self, session: Entity, index: usize) -> Option<JsonMut<'a>> {
+        self.get_mut(session, index).map(|interface| JsonMut { interface })
+    }
+
+    fn json_drain<'a>(&'a mut self, session: Entity, range: AnyRange) -> Box<dyn DrainJsonBufferInterface + 'a> {
+        Box::new(self.drain(session, range))
+    }
+}
+
+trait JsonMutInterface {
+    /// Serialize the underlying message into JSON
+    fn serialize(&self) -> Result<JsonMessage, serde_json::Error>;
+    /// Replace the underlying message with new data, and receive its original
+    /// data as JSON
+    fn replace(&mut self, message: JsonMessage) -> JsonMessageReplaceResult;
+    /// Insert new data into the underyling message. This is the same as replace
+    /// except it is more efficient if you don't care about the original data,
+    /// because it will discard the original data instead of serializing it.
+    fn insert(&mut self, message: JsonMessage) -> Result<(), serde_json::Error>;
+}
+
+impl<T: 'static + Send + Sync + Serialize + DeserializeOwned> JsonMutInterface for T {
+    fn serialize(&self) -> Result<JsonMessage, serde_json::Error> {
+        serde_json::to_value(self)
+    }
+
+    fn replace(&mut self, message: JsonMessage) -> JsonMessageReplaceResult {
+        let new_message: T = serde_json::from_value(message)?;
+        let old_message = serde_json::to_value(&self)?;
+        *self = new_message;
+        Ok(old_message)
+    }
+
+    fn insert(&mut self, message: JsonMessage) -> Result<(), serde_json::Error> {
+        let new_message: T = serde_json::from_value(message)?;
+        *self = new_message;
+        Ok(())
+    }
+}
+
 pub(crate) trait JsonBufferAccessInterface {
-    fn message_type_name(&self) -> &str;
     fn message_type_id(&self) -> TypeId;
-    fn schema(&self, generator: &mut SchemaGenerator) -> &'static Schema;
+
+    fn message_type_name(&self) -> &'static str;
+
+    fn buffered_count(
+        &self,
+        buffer_ref: &EntityRef,
+        session: Entity,
+    ) -> Result<usize, OperationError>;
+
+    fn ensure_session(
+        &self,
+        buffer_mut: &mut EntityWorldMut,
+        session: Entity,
+    ) -> OperationResult;
+
+    fn create_json_buffer_access_mut_state(
+        &self,
+        world: &mut World,
+    ) -> Box<dyn JsonBufferAccessMutState>;
 }
 
 impl<'a> std::fmt::Debug for &'a (dyn JsonBufferAccessInterface + Send + Sync) {
@@ -55,12 +271,12 @@ impl<'a> std::fmt::Debug for &'a (dyn JsonBufferAccessInterface + Send + Sync) {
 
 struct JsonBufferAccessImpl<T>(std::marker::PhantomData<T>);
 
-impl<T: 'static + Send + Sync + Serialize + DeserializeOwned + JsonSchema> JsonBufferAccessImpl<T> {
+impl<T: 'static + Send + Sync + Serialize + DeserializeOwned> JsonBufferAccessImpl<T> {
 
 }
 
-impl<T: 'static + Send + Sync + Serialize + DeserializeOwned + JsonSchema> JsonBufferAccessInterface for JsonBufferAccessImpl<T> {
-    fn message_type_name(&self) -> &str {
+impl<T: 'static + Send + Sync + Serialize + DeserializeOwned> JsonBufferAccessInterface for JsonBufferAccessImpl<T> {
+    fn message_type_name(&self) -> &'static str {
         std::any::type_name::<T>()
     }
 
@@ -68,17 +284,76 @@ impl<T: 'static + Send + Sync + Serialize + DeserializeOwned + JsonSchema> JsonB
         TypeId::of::<T>()
     }
 
-    fn schema(&self, generator: &mut SchemaGenerator) -> &'static Schema {
-        // We use a const map so that we only need to generate the schema once
-        // per message type.
-        const SCHEMA_MAP: OnceLock<Mutex<HashMap<TypeId, &'static Schema>>> = OnceLock::new();
-        let binding = SCHEMA_MAP;
+    fn buffered_count(
+        &self,
+        buffer_ref: &EntityRef,
+        session: Entity,
+    ) -> Result<usize, OperationError> {
+        buffer_ref.buffered_count::<T>(session)
+    }
 
-        let schemas = binding.get_or_init(|| Mutex::default());
+    fn ensure_session(
+        &self,
+        buffer_mut: &mut EntityWorldMut,
+        session: Entity,
+    ) -> OperationResult {
+        buffer_mut.ensure_session::<T>(session)
+    }
 
-        let mut schemas_mut = schemas.lock().unwrap();
-        *schemas_mut.entry(TypeId::of::<T>()).or_insert_with(|| {
-            Box::leak(Box::new(generator.subschema_for::<T>()))
+    fn create_json_buffer_access_mut_state(
+        &self,
+        world: &mut World,
+    ) -> Box<dyn JsonBufferAccessMutState> {
+        Box::new(SystemState::<BufferAccessMut<T>>::new(world))
+    }
+}
+
+trait JsonBufferAccessMutState {
+    fn get_json_buffer_access_mut<'s, 'w: 's>(&'s mut self, world: &'w mut World) -> Box<dyn JsonBufferAccessMut<'w, 's> + 's>;
+}
+
+impl<T> JsonBufferAccessMutState for SystemState<BufferAccessMut<'static, 'static, T>>
+where
+    T: 'static + Send + Sync + Serialize + DeserializeOwned,
+{
+    fn get_json_buffer_access_mut<'s, 'w: 's>(&'s mut self, world: &'w mut World) -> Box<dyn JsonBufferAccessMut<'w, 's> + 's> {
+        Box::new(self.get_mut(world))
+    }
+}
+
+trait JsonBufferAccessMut<'w, 's> {
+    fn as_json_buffer_mut<'a>(&'a mut self, key: &JsonBufferKey) -> Result<JsonBufferMut<'w, 's ,'a>, BufferError>;
+}
+
+impl<'w, 's, T> JsonBufferAccessMut<'w, 's> for BufferAccessMut<'w, 's, T>
+where
+    T: 'static + Send + Sync + Serialize + DeserializeOwned,
+{
+    fn as_json_buffer_mut<'a>(&'a mut self, key: &JsonBufferKey) -> Result<JsonBufferMut<'w, 's ,'a>, BufferError> {
+        let BufferAccessMut { query, commands } = self;
+        let (storage, gate) = query.get_mut(key.buffer).map_err(|_| BufferError::BufferMissing)?;
+        Ok(JsonBufferMut {
+            storage: Box::new(storage),
+            gate,
+            buffer: key.buffer,
+            session: key.session,
+            accessor: Some(key.accessor),
+            commands,
+            modified: false,
         })
+    }
+}
+
+pub struct DrainJsonBuffer<'a> {
+    interface: Box<dyn DrainJsonBufferInterface + 'a>,
+}
+
+trait DrainJsonBufferInterface {
+    fn json_next(&mut self) -> Option<Result<JsonMessage, serde_json::Error>>;
+}
+
+impl<T: 'static + Send + Sync + Serialize> DrainJsonBufferInterface for DrainBuffer<'_, T> {
+    fn json_next(&mut self) -> Option<Result<JsonMessage, serde_json::Error>> {
+        self.next().map(serde_json::to_value)
     }
 }

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -146,8 +146,6 @@ pub struct JsonBufferKey {
 
 impl JsonBufferKey {
     /// Downcast this into a concrete [`BufferKey`] for the specified message type.
-    ///
-    /// To downcast into a specialized kind of buffer key, use [`Self::downcast_buffer_key`] instead.
     pub fn downcast_for_message<T: 'static>(&self) -> Option<BufferKey<T>> {
         if TypeId::of::<T>() == self.interface.any_access_interface().message_type_id() {
             Some(BufferKey {
@@ -420,7 +418,7 @@ impl<'w, 's, 'a> JsonBufferMut<'w, 's, 'a> {
         self.storage.json_push_as_oldest(self.session, message)
     }
 
-    /// Same as [`Self:push_as_oldest`] but no serialization step is needed for
+    /// Same as [`Self::push_as_oldest`] but no serialization step is needed for
     /// the incoming message.
     pub fn push_json_as_oldest(
         &mut self,

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -18,6 +18,7 @@
 use std::{
     any::TypeId,
     collections::HashMap,
+    ops::RangeBounds,
     sync::{Arc, Mutex, OnceLock},
 };
 
@@ -34,7 +35,8 @@ use thiserror::Error as ThisError;
 
 use crate::{
     AnyRange, BufferKey, BufferAccessLifecycle, BufferAccessMut, BufferError, BufferStorage,
-    DrainBuffer, OperationError, OperationResult, InspectBuffer, ManageBuffer, GateState,
+    DrainBuffer, OperationError, OperationResult, InspectBuffer, ManageBuffer, Gate, GateState,
+    NotifyBufferUpdate,
 };
 
 #[derive(Clone, Copy, Debug)]
@@ -72,6 +74,9 @@ impl std::fmt::Debug for JsonBufferKey {
     }
 }
 
+/// Similar to [`BufferMut`][crate::BufferMut], but this can be unlocked with a
+/// [`JsonBufferKey`], so it can work for any buffer whose message types support
+/// serialization and deserialization.
 pub struct JsonBufferMut<'w, 's, 'a> {
     storage: Box<dyn JsonBufferManagement + 'a>,
     gate: Mut<'a, GateState>,
@@ -82,9 +87,210 @@ pub struct JsonBufferMut<'w, 's, 'a> {
     modified: bool,
 }
 
+impl<'w, 's, 'a> JsonBufferMut<'w, 's,  'a> {
+    /// Same as [BufferMut::allow_closed_loops][1].
+    ///
+    /// [1]: crate::BufferMut::allow_closed_loops
+    pub fn allow_closed_loops(mut self) -> Self {
+        self.accessor = None;
+        self
+    }
+
+    /// Get a serialized copy of the oldest message in the buffer.
+    pub fn oldest(&self) -> JsonMessageViewResult {
+        self.storage.json_oldest(self.session)
+    }
+
+    /// Get a serialized copy of the newest message in the buffer.
+    pub fn newest(&self) -> JsonMessageViewResult {
+        self.storage.json_newest(self.session)
+    }
+
+    /// Get a serialized copy of a message in the buffer.
+    pub fn get(&self, index: usize) -> JsonMessageViewResult {
+        self.storage.json_get(self.session, index)
+    }
+
+    /// Get how many messages are in this buffer.
+    pub fn len(&self) -> usize {
+        self.storage.json_count(self.session)
+    }
+
+    /// Check if the buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Check whether the gate of this buffer is open or closed.
+    pub fn gate(&self) -> Gate {
+        self.gate
+            .map
+            .get(&self.session)
+            .copied()
+            .unwrap_or(Gate::Open)
+    }
+
+    /// Modify the oldest message in the buffer.
+    pub fn oldest_mut(&mut self) -> Option<JsonMut<'_>> {
+        self.storage.json_oldest_mut(self.session, &mut self.modified)
+    }
+
+    /// Modify the newest message in the buffer.
+    pub fn newest_mut(&mut self) -> Option<JsonMut<'_>> {
+        self.storage.json_newest_mut(self.session, &mut self.modified)
+    }
+
+    /// Modify a message in the buffer.
+    pub fn get_mut(&mut self, index: usize) -> Option<JsonMut<'_>> {
+        self.storage.json_get_mut(self.session, index, &mut self.modified)
+    }
+
+    /// Drain a range of messages out of the buffer.
+    pub fn drain<R: RangeBounds<usize>>(&mut self, range: R) -> DrainJsonBuffer<'_> {
+        self.modified = true;
+        DrainJsonBuffer {
+            interface: self.storage.json_drain(self.session, AnyRange::new(range))
+        }
+    }
+
+    /// Pull the oldest message from the buffer as a JSON value. Unlike
+    /// [`Self::oldest`] this will remove the message from the buffer.
+    pub fn pull(&mut self) -> JsonMessageViewResult {
+        self.modified = true;
+        self.storage.json_pull(self.session)
+    }
+
+    /// Pull the oldest message from the buffer and attempt to deserialize it
+    /// into the target type.
+    pub fn pull_as<T: DeserializeOwned>(&mut self) -> Result<Option<T>, serde_json::Error> {
+        self.pull()?.map(|m| serde_json::from_value(m)).transpose()
+    }
+
+    /// Pull the newest message from the buffer as a JSON value. Unlike
+    /// [`Self::newest`] this will remove the message from the buffer.
+    pub fn pull_newest(&mut self) -> JsonMessageViewResult {
+        self.modified = true;
+        self.storage.json_pull_newest(self.session)
+    }
+
+    /// Pull the newest message from the buffer and attempt to deserialize it
+    /// into the target type.
+    pub fn pull_newest_as<T: DeserializeOwned>(&mut self) -> Result<Option<T>, serde_json::Error> {
+        self.pull_newest()?.map(|m| serde_json::from_value(m)).transpose()
+    }
+
+    /// Attempt to push a new value into the buffer.
+    ///
+    /// If the input value is compatible with the message type of the buffer,
+    /// this will return [`Ok`]. If the buffer is at its limit before a successful
+    /// push, this will return the value that needed to be removed.
+    ///
+    /// If the input value does not match the message type of the buffer, this
+    /// will return [`Err`]. This may also return [`Err`] if the message coming
+    /// out of the buffer failed to serialize.
+    // TODO(@mxgrey): Consider having an error type that differentiates the
+    // various possible error modes.
+    pub fn push<T: 'static + Serialize>(&mut self, value: T) -> Result<Option<JsonMessage>, serde_json::Error> {
+        let message = serde_json::to_value(&value)?;
+        self.modified = true;
+        self.storage.json_push(self.session, message)
+    }
+
+    /// Same as [`Self::push`] but no serialization step is needed for the incoming
+    /// message.
+    pub fn push_json(&mut self, message: JsonMessage) -> Result<Option<JsonMessage>, serde_json::Error> {
+        self.modified = true;
+        self.storage.json_push(self.session, message)
+    }
+
+    /// Same as [`Self::push`] but the message will be interpreted as the oldest
+    /// message in the buffer.
+    pub fn push_as_oldest<T: 'static + Serialize>(&mut self, value: T) -> Result<Option<JsonMessage>, serde_json::Error> {
+        let message = serde_json::to_value(&value)?;
+        self.modified = true;
+        self.storage.json_push_as_oldest(self.session, message)
+    }
+
+    /// Same as [`Self:push_as_oldest`] but no serialization step is needed for
+    /// the incoming message.
+    pub fn push_json_as_oldest(&mut self, message: JsonMessage) -> Result<Option<JsonMessage>, serde_json::Error> {
+        self.modified = true;
+        self.storage.json_push_as_oldest(self.session, message)
+    }
+
+    /// Tell the buffer [`Gate`] to open.
+    pub fn open_gate(&mut self) {
+        if let Some(gate) = self.gate.map.get_mut(&self.session) {
+            if *gate != Gate::Open {
+                *gate = Gate::Open;
+                self.modified = true;
+            }
+        }
+    }
+
+    /// Tell the buffer [`Gate`] to close.
+    pub fn close_gate(&mut self) {
+        if let Some(gate) = self.gate.map.get_mut(&self.session) {
+            *gate = Gate::Closed;
+            // There is no need to to indicate that a modification happened
+            // because listeners do not get notified about gates closing.
+        }
+    }
+
+    /// Perform an action on the gate of the buffer.
+    pub fn gate_action(&mut self, action: Gate) {
+        match action {
+            Gate::Open => self.open_gate(),
+            Gate::Closed => self.close_gate(),
+        }
+    }
+
+    /// Trigger the listeners for this buffer to wake up even if nothing in the
+    /// buffer has changed. This could be used for timers or timeout elements
+    /// in a workflow.
+    pub fn pulse(&mut self) {
+        self.modified = true;
+    }
+}
+
+impl<'w, 's, 'a> Drop for JsonBufferMut<'w, 's, 'a> {
+    fn drop(&mut self) {
+        if self.modified {
+            self.commands.add(NotifyBufferUpdate::new(
+                self.buffer,
+                self.session,
+                self.accessor,
+            ));
+        }
+    }
+}
+
+pub trait JsonBufferWorldAccess {
+    fn json_buffer_mut<U>(
+        &mut self,
+        key: &JsonBufferKey,
+        f: impl FnOnce(JsonBufferMut) -> U,
+    ) -> Result<U, BufferError>;
+}
+
+impl JsonBufferWorldAccess for World {
+    fn json_buffer_mut<U>(
+        &mut self,
+        key: &JsonBufferKey,
+        f: impl FnOnce(JsonBufferMut) -> U,
+    ) -> Result<U, BufferError> {
+        let interface = key.interface;
+        let mut state = interface.create_json_buffer_access_mut_state(self);
+        let mut access = state.get_json_buffer_access_mut(self);
+        let buffer_mut = access.as_json_buffer_mut(key)?;
+        Ok(f(buffer_mut))
+    }
+}
+
 ///  View or modify a buffer message in terms of JSON values.
 pub struct JsonMut<'a> {
     interface: &'a mut dyn JsonMutInterface,
+    modified: &'a mut bool,
 }
 
 impl<'a> JsonMut<'a> {
@@ -113,6 +319,7 @@ impl<'a> JsonMut<'a> {
     /// data as JSON.
     #[must_use = "if you are going to discard the returned message, use insert instead"]
     pub fn replace(&mut self, message: JsonMessage) -> JsonMessageReplaceResult {
+        *self.modified = true;
         self.interface.replace(message)
     }
 
@@ -120,29 +327,52 @@ impl<'a> JsonMut<'a> {
     /// except it is more efficient if you don't care about the original data,
     /// because it will discard the original data instead of serializing it.
     pub fn insert(&mut self, message: JsonMessage) -> Result<(), serde_json::Error> {
+        *self.modified = true;
         self.interface.insert(message)
     }
 }
 
-pub type JsonMessageFetchResult = Result<Option<JsonMessage>, serde_json::Error>;
+/// The return type for functions that give a JSON view of a message in a buffer.
+/// If an error occurs while attempting to serialize the message, this will return
+/// [`Err`].
+///
+/// If this returns [`Ok`] then [`None`] means there was no message available at
+/// the requested location while [`Some`] will contain a serialized copy of the
+/// message.
+pub type JsonMessageViewResult = Result<Option<JsonMessage>, serde_json::Error>;
+
+/// The return type for functions that push a new message into a buffer. If an
+/// error occurs while deserializing the message into the buffer's message type
+/// then this will return [`Err`].
+///
+/// If this returns [`Ok`] then [`None`] means the new message was added and all
+/// prior messages have been retained in the buffer. [`Some`] will contain an
+/// old message which has now been removed from the buffer.
 pub type JsonMessagePushResult = Result<Option<JsonMessage>, serde_json::Error>;
+
+/// The return type for functions that replace (swap out) one message with
+/// another. If an error occurs while serializing or deserializing either
+/// message to/from the buffer's message type then this will return [`Err`].
+///
+/// If this returns [`Ok`] then the message was successfully replaced, and the
+/// value inside [`Ok`] is the message that was previously in the buffer.
 pub type JsonMessageReplaceResult = Result<JsonMessage, serde_json::Error>;
 
 trait JsonBufferViewing {
     fn json_count(&self, session: Entity) -> usize;
-    fn json_oldest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult;
-    fn json_newest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult;
-    fn json_get<'a>(&'a self, session: Entity, index: usize) ->JsonMessageFetchResult;
+    fn json_oldest<'a>(&'a self, session: Entity) -> JsonMessageViewResult;
+    fn json_newest<'a>(&'a self, session: Entity) -> JsonMessageViewResult;
+    fn json_get<'a>(&'a self, session: Entity, index: usize) ->JsonMessageViewResult;
 }
 
 trait JsonBufferManagement: JsonBufferViewing {
     fn json_push(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult;
     fn json_push_as_oldest(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult;
-    fn json_pull(&mut self, session: Entity) -> JsonMessageFetchResult;
-    fn json_pull_newest(&mut self, session: Entity) -> JsonMessageFetchResult;
-    fn json_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>>;
-    fn json_newest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>>;
-    fn json_get_mut<'a>(&'a mut self, session: Entity, index: usize) -> Option<JsonMut<'a>>;
+    fn json_pull(&mut self, session: Entity) -> JsonMessageViewResult;
+    fn json_pull_newest(&mut self, session: Entity) -> JsonMessageViewResult;
+    fn json_oldest_mut<'a>(&'a mut self, session: Entity, modified: &'a mut bool) -> Option<JsonMut<'a>>;
+    fn json_newest_mut<'a>(&'a mut self, session: Entity, modified: &'a mut bool) -> Option<JsonMut<'a>>;
+    fn json_get_mut<'a>(&'a mut self, session: Entity, index: usize, modified: &'a mut bool) -> Option<JsonMut<'a>>;
     fn json_drain<'a>(&'a mut self, session: Entity, range: AnyRange) -> Box<dyn DrainJsonBufferInterface + 'a>;
 }
 
@@ -154,15 +384,15 @@ where
         self.count(session)
     }
 
-    fn json_oldest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult {
+    fn json_oldest<'a>(&'a self, session: Entity) -> JsonMessageViewResult {
         self.oldest(session).map(serde_json::to_value).transpose()
     }
 
-    fn json_newest<'a>(&'a self, session: Entity) -> JsonMessageFetchResult {
+    fn json_newest<'a>(&'a self, session: Entity) -> JsonMessageViewResult {
         self.newest(session).map(serde_json::to_value).transpose()
     }
 
-    fn json_get<'a>(&'a self, session: Entity, index: usize) ->JsonMessageFetchResult {
+    fn json_get<'a>(&'a self, session: Entity, index: usize) ->JsonMessageViewResult {
         self.get(session, index).map(serde_json::to_value).transpose()
     }
 }
@@ -181,24 +411,24 @@ where
         self.push(session, value).map(serde_json::to_value).transpose()
     }
 
-    fn json_pull(&mut self, session: Entity) -> JsonMessageFetchResult {
+    fn json_pull(&mut self, session: Entity) -> JsonMessageViewResult {
         self.pull(session).map(serde_json::to_value).transpose()
     }
 
-    fn json_pull_newest(&mut self, session: Entity) -> JsonMessageFetchResult {
+    fn json_pull_newest(&mut self, session: Entity) -> JsonMessageViewResult {
         self.pull_newest(session).map(serde_json::to_value).transpose()
     }
 
-    fn json_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>> {
-        self.oldest_mut(session).map(|interface| JsonMut { interface })
+    fn json_oldest_mut<'a>(&'a mut self, session: Entity, modified: &'a mut bool) -> Option<JsonMut<'a>> {
+        self.oldest_mut(session).map(|interface| JsonMut { interface, modified })
     }
 
-    fn json_newest_mut<'a>(&'a mut self, session: Entity) -> Option<JsonMut<'a>> {
-        self.newest_mut(session).map(|interface| JsonMut { interface })
+    fn json_newest_mut<'a>(&'a mut self, session: Entity, modified: &'a mut bool) -> Option<JsonMut<'a>> {
+        self.newest_mut(session).map(|interface| JsonMut { interface, modified })
     }
 
-    fn json_get_mut<'a>(&'a mut self, session: Entity, index: usize) -> Option<JsonMut<'a>> {
-        self.get_mut(session, index).map(|interface| JsonMut { interface })
+    fn json_get_mut<'a>(&'a mut self, session: Entity, index: usize, modified: &'a mut bool) -> Option<JsonMut<'a>> {
+        self.get_mut(session, index).map(|interface| JsonMut { interface, modified })
     }
 
     fn json_drain<'a>(&'a mut self, session: Entity, range: AnyRange) -> Box<dyn DrainJsonBufferInterface + 'a> {

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1404,7 +1404,11 @@ mod tests {
     impl crate::Joined for TestJoinedValueJsonBuffers {
         type Item = TestJoinedValueJson;
 
-        fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, crate::OperationError> {
+        fn pull(
+            &self,
+            session: Entity,
+            world: &mut World,
+        ) -> Result<Self::Item, crate::OperationError> {
             let integer = self.integer.pull(session, world)?;
             let float = self.float.pull(session, world)?;
             let json = self.json.pull(session, world)?;
@@ -1443,10 +1447,7 @@ mod tests {
                 |chain: Chain<_>| chain.connect(buffer_json.input_slot()),
             ));
 
-            builder
-                .try_join(&buffers)
-                .unwrap()
-                .connect(scope.terminate);
+            builder.try_join(&buffers).unwrap().connect(scope.terminate);
         });
 
         let mut promise = context.command(|commands| {
@@ -1484,9 +1485,7 @@ mod tests {
                 |chain: Chain<_>| chain.connect(json_buffer.input_slot()),
             ));
 
-            builder
-                .join(buffers)
-                .connect(scope.terminate);
+            builder.join(buffers).connect(scope.terminate);
         });
 
         let mut promise = context.command(|commands| {

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -823,36 +823,34 @@ impl<T: 'static + Send + Sync + Serialize + DeserializeOwned> JsonBufferAccessIm
         let interfaces = INTERFACE_MAP.get_or_init(|| Mutex::default());
 
         let mut interfaces_mut = interfaces.lock().unwrap();
-        *interfaces_mut
-            .entry(TypeId::of::<T>())
-            .or_insert_with(|| {
-                // Register downcasting for JsonBuffer and JsonBufferKey the
-                // first time that we retrieve an interface for this type.
-                let any_interface = AnyBuffer::interface_for::<T>();
-                any_interface.register_buffer_downcast(
-                    TypeId::of::<JsonBuffer>(),
-                    Box::new(|location| {
-                        Box::new(JsonBuffer {
-                            location,
-                            interface: Self::get_interface(),
-                        })
-                    }),
-                );
+        *interfaces_mut.entry(TypeId::of::<T>()).or_insert_with(|| {
+            // Register downcasting for JsonBuffer and JsonBufferKey the
+            // first time that we retrieve an interface for this type.
+            let any_interface = AnyBuffer::interface_for::<T>();
+            any_interface.register_buffer_downcast(
+                TypeId::of::<JsonBuffer>(),
+                Box::new(|location| {
+                    Box::new(JsonBuffer {
+                        location,
+                        interface: Self::get_interface(),
+                    })
+                }),
+            );
 
-                any_interface.register_key_downcast(
-                    TypeId::of::<JsonBufferKey>(),
-                    Box::new(|tag| {
-                        Box::new(JsonBufferKey {
-                            tag,
-                            interface: Self::get_interface(),
-                        })
-                    }),
-                );
+            any_interface.register_key_downcast(
+                TypeId::of::<JsonBufferKey>(),
+                Box::new(|tag| {
+                    Box::new(JsonBufferKey {
+                        tag,
+                        interface: Self::get_interface(),
+                    })
+                }),
+            );
 
-                // SAFETY: This will leak memory exactly once per type, so the leakage is bounded.
-                // Leaking this allows the interface to be shared freely across all instances.
-                Box::leak(Box::new(JsonBufferAccessImpl::<T>(Default::default())))
-            })
+            // SAFETY: This will leak memory exactly once per type, so the leakage is bounded.
+            // Leaking this allows the interface to be shared freely across all instances.
+            Box::leak(Box::new(JsonBufferAccessImpl::<T>(Default::default())))
+        })
     }
 }
 

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1071,7 +1071,7 @@ impl BufferMapLayout for HashMap<String, JsonBuffer> {
             match name {
                 BufferIdentifier::Name(name) => {
                     if let Ok(downcast) =
-                        compatibility.require_buffer_by_name::<JsonBuffer>(&name, buffers)
+                        compatibility.require_buffer_for_borrowed_name::<JsonBuffer>(&name, buffers)
                     {
                         downcast_buffers.insert(name.clone().into_owned(), downcast);
                     }

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1581,4 +1581,15 @@ mod tests {
         assert_eq!(values[2], serde_json::Value::String("hello".to_string()));
         assert_eq!(values[3], serde_json::to_value(TestMessage::new()).unwrap());
     }
+
+    // We define this struct just to make sure the BufferKeyMap macro successfully
+    // compiles with JsonBufferKey.
+    #[derive(Clone, BufferKeyMap)]
+    #[allow(unused)]
+    struct TestJsonKeyMap {
+        integer: BufferKey<i64>,
+        string: BufferKey<String>,
+        json: JsonBufferKey,
+        any: AnyBufferKey,
+    }
 }

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -38,10 +38,10 @@ use smallvec::SmallVec;
 use crate::{
     add_listener_to_source, Accessed, AnyBuffer, AnyBufferAccessInterface, AnyBufferKey, AnyRange,
     AsAnyBuffer, Buffer, BufferAccessMut, BufferAccessors, BufferError, BufferIdentifier,
-    BufferKey, BufferKeyBuilder, BufferKeyTag, BufferLocation, BufferMap, BufferMapLayout,
-    BufferMapStruct, BufferStorage, Bufferable, Buffered, Builder, DrainBuffer, Gate, GateState,
-    IncompatibleLayout, InspectBuffer, Joined, JoinedValue, ManageBuffer, NotifyBufferUpdate,
-    OperationError, OperationResult, OrBroken,
+    BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferMap,
+    BufferMapLayout, BufferMapStruct, BufferStorage, Bufferable, Buffered, Builder, DrainBuffer,
+    Gate, GateState, IncompatibleLayout, InspectBuffer, Joined, JoinedValue, ManageBuffer,
+    NotifyBufferUpdate, OperationError, OperationResult, OrBroken,
 };
 
 /// A [`Buffer`] whose message type has been anonymized, but which is known to
@@ -159,16 +159,27 @@ impl JsonBufferKey {
     pub fn as_any_buffer_key(self) -> AnyBufferKey {
         self.into()
     }
+}
+
+impl BufferKeyLifecycle for JsonBufferKey {
+    type TargetBuffer = JsonBuffer;
+
+    fn create_key(buffer: &Self::TargetBuffer, builder: &BufferKeyBuilder) -> Self {
+        Self {
+            tag: builder.make_tag(buffer.id()),
+            interface: buffer.interface,
+        }
+    }
+
+    fn is_in_use(&self) -> bool {
+        self.tag.is_in_use()
+    }
 
     fn deep_clone(&self) -> Self {
         Self {
             tag: self.tag.deep_clone(),
             interface: self.interface,
         }
-    }
-
-    fn is_in_use(&self) -> bool {
-        self.tag.is_in_use()
     }
 }
 

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -36,11 +36,11 @@ pub use serde_json::Value as JsonMessage;
 use smallvec::SmallVec;
 
 use crate::{
-    add_listener_to_source, Accessed, AnyBuffer, AnyBufferAccessInterface, AnyBufferKey, AnyRange,
+    add_listener_to_source, Accessing, AnyBuffer, AnyBufferAccessInterface, AnyBufferKey, AnyRange,
     AsAnyBuffer, Buffer, BufferAccessMut, BufferAccessors, BufferError, BufferIdentifier,
     BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferMap,
-    BufferMapLayout, BufferMapStruct, BufferStorage, Bufferable, Buffered, Builder, DrainBuffer,
-    Gate, GateState, IncompatibleLayout, InspectBuffer, Joined, JoinedValue, ManageBuffer,
+    BufferMapLayout, BufferMapStruct, BufferStorage, Bufferable, Buffering, Builder, DrainBuffer,
+    Gate, GateState, IncompatibleLayout, InspectBuffer, Joined, Joining, ManageBuffer,
     NotifyBufferUpdate, OperationError, OperationResult, OrBroken,
 };
 
@@ -988,7 +988,7 @@ impl Bufferable for JsonBuffer {
     }
 }
 
-impl Buffered for JsonBuffer {
+impl Buffering for JsonBuffer {
     fn verify_scope(&self, scope: Entity) {
         assert_eq!(scope, self.scope());
     }
@@ -1022,7 +1022,7 @@ impl Buffered for JsonBuffer {
     }
 }
 
-impl Joined for JsonBuffer {
+impl Joining for JsonBuffer {
     type Item = JsonMessage;
     fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
         let mut buffer_mut = world.get_entity_mut(self.id()).or_broken()?;
@@ -1030,7 +1030,7 @@ impl Joined for JsonBuffer {
     }
 }
 
-impl Accessed for JsonBuffer {
+impl Accessing for JsonBuffer {
     type Key = JsonBufferKey;
     fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
         world
@@ -1056,7 +1056,7 @@ impl Accessed for JsonBuffer {
     }
 }
 
-impl JoinedValue for serde_json::Map<String, JsonMessage> {
+impl Joined for serde_json::Map<String, JsonMessage> {
     type Buffers = HashMap<String, JsonBuffer>;
 }
 
@@ -1092,7 +1092,7 @@ impl BufferMapStruct for HashMap<String, JsonBuffer> {
     }
 }
 
-impl Joined for HashMap<String, JsonBuffer> {
+impl Joining for HashMap<String, JsonBuffer> {
     type Item = serde_json::Map<String, JsonMessage>;
     fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
         self.iter()
@@ -1411,7 +1411,7 @@ mod tests {
         assert!(context.no_unhandled_errors());
     }
 
-    #[derive(Clone, JoinedValue)]
+    #[derive(Clone, Joined)]
     #[joined(buffers_struct_name = TestJoinedValueJsonBuffers)]
     struct TestJoinedValueJson {
         integer: i64,
@@ -1582,9 +1582,9 @@ mod tests {
         assert_eq!(values[3], serde_json::to_value(TestMessage::new()).unwrap());
     }
 
-    // We define this struct just to make sure the BufferKeyMap macro successfully
+    // We define this struct just to make sure the Accessor macro successfully
     // compiles with JsonBufferKey.
-    #[derive(Clone, BufferKeyMap)]
+    #[derive(Clone, Accessor)]
     #[allow(unused)]
     struct TestJsonKeyMap {
         integer: BufferKey<i64>,

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_ecs::prelude::Entity;
+
+use schemars::schema::Schema;
+
+#[derive(Clone, Copy, Debug)]
+pub struct JsonBuffer {
+    pub(crate) scope: Entity,
+    pub(crate) source: Entity,
+    pub(crate) interface: &'static dyn JsonInterface,
+}
+
+pub(crate) trait JsonInterface {
+    fn message_type(&self) -> &str;
+    fn schema(&self) -> &Schema;
+}
+
+impl<'a> std::fmt::Debug for &'a dyn JsonInterface {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f
+            .debug_struct("Message Properties")
+            .field("type", &self.message_type())
+            .field("schema", self.schema())
+            .finish()
+    }
+}

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1367,6 +1367,10 @@ mod tests {
         json: JsonBuffer,
     }
 
+    impl JoinedValue for TestJoinedValueJson {
+        type Buffers = TestJoinedValueJsonBuffers;
+    }
+
     impl BufferMapLayout for TestJoinedValueJsonBuffers {
         fn buffer_list(&self) -> smallvec::SmallVec<[AnyBuffer; 8]> {
             use smallvec::smallvec;
@@ -1419,10 +1423,6 @@ mod tests {
                 json,
             })
         }
-    }
-
-    impl JoinedValue for TestJoinedValueJson {
-        type Buffers = TestJoinedValueJsonBuffers;
     }
 
     #[test]

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1353,76 +1353,13 @@ mod tests {
         assert!(context.no_unhandled_errors());
     }
 
-    #[derive(Clone)]
+    #[derive(Clone, JoinedValue)]
+    #[joined(buffers_struct_name = TestJoinedValueJsonBuffers)]
     struct TestJoinedValueJson {
         integer: i64,
         float: f64,
+        #[joined(buffer = JsonBuffer)]
         json: JsonMessage,
-    }
-
-    #[derive(Clone)]
-    struct TestJoinedValueJsonBuffers {
-        integer: Buffer<i64>,
-        float: Buffer<f64>,
-        json: JsonBuffer,
-    }
-
-    impl JoinedValue for TestJoinedValueJson {
-        type Buffers = TestJoinedValueJsonBuffers;
-    }
-
-    impl BufferMapLayout for TestJoinedValueJsonBuffers {
-        fn buffer_list(&self) -> smallvec::SmallVec<[AnyBuffer; 8]> {
-            use smallvec::smallvec;
-            smallvec![
-                self.integer.as_any_buffer(),
-                self.float.as_any_buffer(),
-                self.json.as_any_buffer(),
-            ]
-        }
-
-        fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
-            let mut compatibility = IncompatibleLayout::default();
-            let integer = compatibility.require_message_type::<i64>("integer", buffers);
-            let float = compatibility.require_message_type::<f64>("float", buffers);
-            let json = compatibility.require_buffer_type::<JsonBuffer>("json", buffers);
-
-            let Ok(integer) = integer else {
-                return Err(compatibility);
-            };
-            let Ok(float) = float else {
-                return Err(compatibility);
-            };
-            let Ok(json) = json else {
-                return Err(compatibility);
-            };
-
-            Ok(Self {
-                integer,
-                float,
-                json,
-            })
-        }
-    }
-
-    impl crate::Joined for TestJoinedValueJsonBuffers {
-        type Item = TestJoinedValueJson;
-
-        fn pull(
-            &self,
-            session: Entity,
-            world: &mut World,
-        ) -> Result<Self::Item, crate::OperationError> {
-            let integer = self.integer.pull(session, world)?;
-            let float = self.float.pull(session, world)?;
-            let json = self.json.pull(session, world)?;
-
-            Ok(TestJoinedValueJson {
-                integer,
-                float,
-                json,
-            })
-        }
     }
 
     #[test]
@@ -1483,6 +1420,45 @@ mod tests {
                 |chain: Chain<_>| chain.connect(buffers.integer.input_slot()),
                 |chain: Chain<_>| chain.connect(buffers.float.input_slot()),
                 |chain: Chain<_>| chain.connect(json_buffer.input_slot()),
+            ));
+
+            builder.join(buffers).connect(scope.terminate);
+        });
+
+        let mut promise = context.command(|commands| {
+            commands
+                .request((5_i64, 3.14_f64, TestMessage::new()), workflow)
+                .take_response()
+        });
+
+        context.run_with_conditions(&mut promise, Duration::from_secs(2));
+        let value: TestJoinedValueJson = promise.take().available().unwrap();
+        assert_eq!(value.integer, 5);
+        assert_eq!(value.float, 3.14);
+        let deserialized_json: TestMessage = serde_json::from_value(value.json).unwrap();
+        let expected_json = TestMessage::new();
+        assert_eq!(deserialized_json, expected_json);
+    }
+
+    #[test]
+    fn test_select_buffers_json() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let buffer_integer = builder.create_buffer::<i64>(BufferSettings::default());
+            let buffer_float = builder.create_buffer::<f64>(BufferSettings::default());
+            let buffer_json =
+                JsonBuffer::from(builder.create_buffer::<TestMessage>(BufferSettings::default()));
+
+            let buffers =
+                TestJoinedValueJson::select_buffers(buffer_integer, buffer_float, buffer_json);
+
+            scope.input.chain(builder).fork_unzip((
+                |chain: Chain<_>| chain.connect(buffers.integer.input_slot()),
+                |chain: Chain<_>| chain.connect(buffers.float.input_slot()),
+                |chain: Chain<_>| {
+                    chain.connect(buffers.json.downcast_for_message().unwrap().input_slot())
+                },
             ));
 
             builder.join(buffers).connect(scope.terminate);

--- a/src/buffer/manage_buffer.rs
+++ b/src/buffer/manage_buffer.rs
@@ -54,8 +54,8 @@ impl<'w> InspectBuffer for EntityRef<'w> {
     }
 
     fn dyn_buffered_count(&self, session: Entity) -> Result<usize, OperationError> {
-        let count = self.get::<AnyBufferStorageAccess>().or_broken()?.buffered_count;
-        count(self, session)
+        let interface = self.get::<AnyBufferStorageAccess>().or_broken()?.interface;
+        interface.buffered_count(self, session)
     }
 
     fn try_clone_from_buffer<T: 'static + Send + Sync + Clone>(
@@ -137,11 +137,11 @@ impl<'w> ManageBuffer for EntityWorldMut<'w> {
     }
 
     fn dyn_ensure_session(&mut self, session: Entity) -> OperationResult {
-        let ensure_session = self
+        let interface = self
             .get_mut::<AnyBufferStorageAccess>()
             .or_broken()?
-            .ensure_session;
+            .interface;
 
-        ensure_session(self, session)
+        interface.ensure_session(self, session)
     }
 }

--- a/src/buffer/manage_buffer.rs
+++ b/src/buffer/manage_buffer.rs
@@ -22,9 +22,7 @@ use bevy_ecs::{
 
 use smallvec::SmallVec;
 
-use crate::{
-    BufferStorage, OperationError, OperationResult, OrBroken,
-};
+use crate::{BufferStorage, OperationError, OperationResult, OrBroken};
 
 pub trait InspectBuffer {
     fn buffered_count<T: 'static + Send + Sync>(
@@ -120,8 +118,7 @@ impl<'w> ManageBuffer for EntityWorldMut<'w> {
     }
 
     fn ensure_session<T: 'static + Send + Sync>(&mut self, session: Entity) -> OperationResult {
-        self
-            .get_mut::<BufferStorage<T>>()
+        self.get_mut::<BufferStorage<T>>()
             .or_broken()?
             .ensure_session(session);
         Ok(())

--- a/src/buffer/manage_buffer.rs
+++ b/src/buffer/manage_buffer.rs
@@ -23,8 +23,7 @@ use bevy_ecs::{
 use smallvec::SmallVec;
 
 use crate::{
-    BufferStorage, DynBufferStorage, OperationError, OperationResult, OrBroken,
-    BufferInspection,
+    BufferStorage, AnyBufferStorageAccess, OperationError, OperationResult, OrBroken,
 };
 
 pub trait InspectBuffer {
@@ -55,7 +54,7 @@ impl<'w> InspectBuffer for EntityRef<'w> {
     }
 
     fn dyn_buffered_count(&self, session: Entity) -> Result<usize, OperationError> {
-        let count = self.get::<DynBufferStorage>().or_broken()?.count;
+        let count = self.get::<AnyBufferStorageAccess>().or_broken()?.buffered_count;
         count(self, session)
     }
 
@@ -139,7 +138,7 @@ impl<'w> ManageBuffer for EntityWorldMut<'w> {
 
     fn dyn_ensure_session(&mut self, session: Entity) -> OperationResult {
         let ensure_session = self
-            .get_mut::<DynBufferStorage>()
+            .get_mut::<AnyBufferStorageAccess>()
             .or_broken()?
             .ensure_session;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,13 +22,14 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    Accessed, Accessible, AddOperation, AsMap, Buffer, BufferKeys, BufferLocation, BufferMap, BufferSettings,
-    Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
-    GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Joinable,
-    JoinedValue, Node, OperateBuffer, OperateBufferAccess, OperateDynamicGate,
-    OperateScope, OperateSplit, OperateStaticGate, Output, Provider, RequestOfMap, ResponseOfMap,
-    Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage, Sendish, Service, SplitOutputs,
-    Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
+    Accessed, Accessible, AddOperation, AsMap, Buffer, BufferKeys, BufferLocation, BufferMap,
+    BufferSettings, Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput,
+    ForkTargetStorage, Gate, GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap,
+    IntoBlockingMap, Joinable, JoinedValue, Node, OperateBuffer, OperateBufferAccess,
+    OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output, Provider,
+    RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage,
+    Sendish, Service, SplitOutputs, Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim,
+    TrimBranch, UnusedTarget,
 };
 
 pub(crate) mod connect;
@@ -232,10 +233,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     }
 
     /// Alternative way of calling [`Joinable::join`]
-    pub fn join<'b, B: Joinable>(
-        &'b mut self,
-        buffers: B,
-    ) -> Chain<'w, 's, 'a, 'b, B::Item> {
+    pub fn join<'b, B: Joinable>(&'b mut self, buffers: B) -> Chain<'w, 's, 'a, 'b, B::Item> {
         buffers.join(self)
     }
 
@@ -248,10 +246,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     }
 
     /// Alternative way of calling [`Accessible::listen`].
-    pub fn listen<'b, B: Accessible>(
-        &'b mut self,
-        buffers: B,
-    ) -> Chain<'w, 's, 'a, 'b, B::Keys> {
+    pub fn listen<'b, B: Accessible>(&'b mut self, buffers: B) -> Chain<'w, 's, 'a, 'b, B::Keys> {
         buffers.listen(self)
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -245,9 +245,9 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     /// Try joining a map of buffers into a single value.
     pub fn try_join_into<'b, Joined: JoinedValue>(
         &'b mut self,
-        buffers: impl Into<BufferMap>,
+        buffers: &BufferMap,
     ) -> Result<Chain<'w, 's, 'a, 'b, Joined>, IncompatibleLayout> {
-        Joined::try_join_into(buffers.into(), self)
+        Joined::try_join_into(buffers, self)
     }
 
     /// Join an appropriate layout of buffers into a single value.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,7 +23,7 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    AddOperation, AsMap, BeginCleanupWorkflow, Buffer, BufferItem, BufferKeys, BufferSettings,
+    AddOperation, AsMap, BeginCleanupWorkflow, Buffer, JoinedItem, BufferKeys, BufferSettings,
     Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
     GateRequest, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Node, OperateBuffer,
     OperateBufferAccess, OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output,
@@ -231,10 +231,10 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     }
 
     /// Alternative way of calling [`Bufferable::join`]
-    pub fn join<'b, B: Bufferable>(&'b mut self, buffers: B) -> Chain<'w, 's, 'a, 'b, BufferItem<B>>
+    pub fn join<'b, B: Bufferable>(&'b mut self, buffers: B) -> Chain<'w, 's, 'a, 'b, JoinedItem<B>>
     where
         B::BufferType: 'static + Send + Sync,
-        BufferItem<B>: 'static + Send + Sync,
+        JoinedItem<B>: 'static + Send + Sync,
     {
         buffers.join(self)
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,14 +22,13 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    AddOperation, AsMap, Buffer, BufferKeys, BufferLocation, BufferMap,
-    BufferSettings, Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput,
-    ForkTargetStorage, Gate, GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap,
-    IntoBlockingMap, JoinedItem, JoinedValue, Node, OperateBuffer, OperateBufferAccess,
-    OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output, Provider,
-    RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage,
-    Sendish, Service, SplitOutputs, Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim,
-    TrimBranch, UnusedTarget, Joined, Accessed,
+    Accessed, AddOperation, AsMap, Buffer, BufferKeys, BufferLocation, BufferMap, BufferSettings,
+    Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
+    GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Joined,
+    JoinedItem, JoinedValue, Node, OperateBuffer, OperateBufferAccess, OperateDynamicGate,
+    OperateScope, OperateSplit, OperateStaticGate, Output, Provider, RequestOfMap, ResponseOfMap,
+    Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage, Sendish, Service, SplitOutputs,
+    Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
 };
 
 pub(crate) mod connect;
@@ -456,7 +455,9 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         B::BufferType: Accessed,
         Settings: Into<ScopeSettings>,
     {
-        from_buffers.into_buffer(self).on_cleanup_if(self, conditions, build);
+        from_buffers
+            .into_buffer(self)
+            .on_cleanup_if(self, conditions, build);
     }
 
     /// Create a node that trims (cancels) other nodes in the workflow when it

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,13 +23,14 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    AddOperation, AsMap, BeginCleanupWorkflow, Buffer, BufferKeys, BufferMap, BufferSettings,
-    Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
-    GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap,
-    JoinedItem, JoinedValue, Node, OperateBuffer, OperateBufferAccess, OperateDynamicGate,
-    OperateScope, OperateSplit, OperateStaticGate, Output, Provider, RequestOfMap, ResponseOfMap,
-    Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage, Sendish, Service, SplitOutputs,
-    Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
+    AddOperation, AsMap, BeginCleanupWorkflow, Buffer, BufferKeys, BufferLocation, BufferMap,
+    BufferSettings, Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput,
+    ForkTargetStorage, Gate, GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap,
+    IntoBlockingMap, JoinedItem, JoinedValue, Node, OperateBuffer, OperateBufferAccess,
+    OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output, Provider,
+    RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage,
+    Sendish, Service, SplitOutputs, Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim,
+    TrimBranch, UnusedTarget,
 };
 
 pub(crate) mod connect;
@@ -165,8 +166,10 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         ));
 
         Buffer {
-            scope: self.scope,
-            source,
+            location: BufferLocation {
+                scope: self.scope(),
+                source,
+            },
             _ignore: Default::default(),
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -23,13 +23,13 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    AddOperation, AsMap, BeginCleanupWorkflow, Buffer, JoinedItem, BufferKeys, BufferSettings,
+    AddOperation, AsMap, BeginCleanupWorkflow, Buffer, BufferKeys, BufferMap, BufferSettings,
     Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput, ForkTargetStorage, Gate,
-    GateRequest, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Node, OperateBuffer,
-    OperateBufferAccess, OperateDynamicGate, OperateScope, OperateSplit, OperateStaticGate, Output,
-    Provider, RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings,
-    ScopeSettingsStorage, Sendish, Service, SplitOutputs, Splittable, StreamPack, StreamTargetMap,
-    StreamsOfMap, Trim, TrimBranch, UnusedTarget, JoinedValue, BufferMap, IncompatibleLayout,
+    GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap, IntoBlockingMap,
+    JoinedItem, JoinedValue, Node, OperateBuffer, OperateBufferAccess, OperateDynamicGate,
+    OperateScope, OperateSplit, OperateStaticGate, Output, Provider, RequestOfMap, ResponseOfMap,
+    Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage, Sendish, Service, SplitOutputs,
+    Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
 };
 
 pub(crate) mod connect;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,10 +22,10 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    Accessed, Accessible, AddOperation, AsMap, Buffer, BufferKeyMap, BufferKeys, BufferLocation,
-    BufferMap, BufferSettings, Bufferable, Buffered, Chain, Collect, ForkClone, ForkCloneOutput,
+    Accessible, Accessing, Accessor, AddOperation, AsMap, Buffer, BufferKeys, BufferLocation,
+    BufferMap, BufferSettings, Bufferable, Buffering, Chain, Collect, ForkClone, ForkCloneOutput,
     ForkTargetStorage, Gate, GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap,
-    IntoBlockingMap, Joinable, JoinedValue, Node, OperateBuffer, OperateDynamicGate, OperateScope,
+    IntoBlockingMap, Joinable, Joined, Node, OperateBuffer, OperateDynamicGate, OperateScope,
     OperateSplit, OperateStaticGate, Output, Provider, RequestOfMap, ResponseOfMap, Scope,
     ScopeEndpoints, ScopeSettings, ScopeSettingsStorage, Sendish, Service, SplitOutputs,
     Splittable, StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget,
@@ -237,11 +237,11 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     }
 
     /// Try joining a map of buffers into a single value.
-    pub fn try_join<'b, Joined: JoinedValue>(
+    pub fn try_join<'b, J: Joined>(
         &'b mut self,
         buffers: &BufferMap,
-    ) -> Result<Chain<'w, 's, 'a, 'b, Joined>, IncompatibleLayout> {
-        Joined::try_join_from(buffers, self)
+    ) -> Result<Chain<'w, 's, 'a, 'b, J>, IncompatibleLayout> {
+        J::try_join_from(buffers, self)
     }
 
     /// Alternative way of calling [`Accessible::listen`].
@@ -250,7 +250,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     }
 
     /// Try listening to a map of buffers.
-    pub fn try_listen<'b, Keys: BufferKeyMap>(
+    pub fn try_listen<'b, Keys: Accessor>(
         &'b mut self,
         buffers: &BufferMap,
     ) -> Result<Chain<'w, 's, 'a, 'b, Keys>, IncompatibleLayout> {
@@ -269,7 +269,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         buffers: B,
     ) -> Node<T, (T, BufferKeys<B>)>
     where
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
         T: 'static + Send + Sync,
     {
         let buffers = buffers.into_buffer(self);
@@ -279,7 +279,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     /// Try to create access to some buffers. Same as [`Self::create_buffer_access`]
     /// except it will return an error if the buffers in the [`BufferMap`] are not
     /// compatible with the keys that are being asked for.
-    pub fn try_create_buffer_access<T, Keys: BufferKeyMap>(
+    pub fn try_create_buffer_access<T, Keys: Accessor>(
         &mut self,
         buffers: &BufferMap,
     ) -> Result<Node<T, (T, Keys)>, IncompatibleLayout>
@@ -393,7 +393,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
     ) where
         B: Bufferable,
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
         Settings: Into<ScopeSettings>,
     {
         from_buffers.into_buffer(self).on_cleanup(self, build);
@@ -418,7 +418,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
     ) where
         B: Bufferable,
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
         Settings: Into<ScopeSettings>,
     {
         from_buffers.into_buffer(self).on_cancel(self, build);
@@ -437,7 +437,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
     ) where
         B: Bufferable,
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
         Settings: Into<ScopeSettings>,
     {
         from_buffers.into_buffer(self).on_terminate(self, build);
@@ -453,7 +453,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         build: impl FnOnce(Scope<BufferKeys<B>, (), ()>, &mut Builder) -> Settings,
     ) where
         B: Bufferable,
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
         Settings: Into<ScopeSettings>,
     {
         from_buffers

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -24,12 +24,12 @@ use smallvec::SmallVec;
 use std::error::Error;
 
 use crate::{
-    make_option_branching, make_result_branching, Accessed, AddOperation, AsMap, Buffer, BufferKey,
-    BufferKeys, Bufferable, Buffered, Builder, Collect, CreateCancelFilter, CreateDisposalFilter,
-    ForkTargetStorage, Gate, GateRequest, InputSlot, IntoAsyncMap, IntoBlockingCallback,
-    IntoBlockingMap, Node, Noop, OperateBufferAccess, OperateDynamicGate, OperateSplit,
-    OperateStaticGate, Output, ProvideOnce, Provider, Scope, ScopeSettings, Sendish, Service,
-    Spread, StreamOf, StreamPack, StreamTargetMap, Trim, TrimBranch, UnusedTarget,
+    make_option_branching, make_result_branching, Accessing, AddOperation, AsMap, Buffer,
+    BufferKey, BufferKeys, Bufferable, Buffering, Builder, Collect, CreateCancelFilter,
+    CreateDisposalFilter, ForkTargetStorage, Gate, GateRequest, InputSlot, IntoAsyncMap,
+    IntoBlockingCallback, IntoBlockingMap, Node, Noop, OperateBufferAccess, OperateDynamicGate,
+    OperateSplit, OperateStaticGate, Output, ProvideOnce, Provider, Scope, ScopeSettings, Sendish,
+    Service, Spread, StreamOf, StreamPack, StreamTargetMap, Trim, TrimBranch, UnusedTarget,
 };
 
 pub mod fork_clone_builder;
@@ -302,7 +302,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn with_access<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, (T, BufferKeys<B>)>
     where
         B: Bufferable,
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
     {
         let buffers = buffers.into_buffer(self.builder);
         buffers.verify_scope(self.builder.scope);
@@ -323,7 +323,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn then_access<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, BufferKeys<B>>
     where
         B: Bufferable,
-        B::BufferType: Accessed,
+        B::BufferType: Accessing,
     {
         self.with_access(buffers).map_block(|(_, key)| key)
     }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -546,7 +546,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// If the buffer is broken (e.g. its operation has been despawned) the
     /// workflow will be cancelled.
     pub fn then_push(self, buffer: Buffer<T>) -> Chain<'w, 's, 'a, 'b, ()> {
-        assert_eq!(self.scope(), buffer.scope);
+        assert_eq!(self.scope(), buffer.scope());
         self.with_access(buffer)
             .then(push_into_buffer.into_blocking_callback())
             .cancel_on_err()

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -298,7 +298,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// will be transformed into a buffer with default buffer settings.
     ///
     /// To obtain a set of buffer keys each time a buffer is modified, use
-    /// [`listen`](crate::Bufferable::listen).
+    /// [`listen`](crate::Accessible::listen).
     pub fn with_access<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, (T, BufferKeys<B>)>
     where
         B: Bufferable,
@@ -391,7 +391,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// The return values of the individual chain builders will be zipped into
     /// one tuple return value by this function. If all of the builders return
     /// [`Output`] then you can easily continue chaining more operations using
-    /// [`join`](crate::Bufferable::join), or destructure them into individual
+    /// [`join`](crate::Joinable::join), or destructure them into individual
     /// outputs that you can continue to build with.
     pub fn fork_clone<Build: ForkCloneBuilder<T>>(self, build: Build) -> Build::Outputs
     where

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -24,7 +24,7 @@ use smallvec::SmallVec;
 use std::error::Error;
 
 use crate::{
-    make_option_branching, make_result_branching, AddOperation, AsMap, Buffer, BufferKey,
+    make_option_branching, make_result_branching, Accessed, AddOperation, AsMap, Buffer, BufferKey,
     BufferKeys, Bufferable, Buffered, Builder, Collect, CreateCancelFilter, CreateDisposalFilter,
     ForkTargetStorage, Gate, GateRequest, InputSlot, IntoAsyncMap, IntoBlockingCallback,
     IntoBlockingMap, Node, Noop, OperateBufferAccess, OperateDynamicGate, OperateSplit,
@@ -302,8 +302,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn with_access<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, (T, BufferKeys<B>)>
     where
         B: Bufferable,
-        B::BufferType: 'static + Send + Sync,
-        BufferKeys<B>: 'static + Send + Sync,
+        B::BufferType: Accessed,
     {
         let buffers = buffers.into_buffer(self.builder);
         buffers.verify_scope(self.builder.scope);
@@ -324,8 +323,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn then_access<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, BufferKeys<B>>
     where
         B: Bufferable,
-        B::BufferType: 'static + Send + Sync,
-        BufferKeys<B>: 'static + Send + Sync,
+        B::BufferType: Accessed,
     {
         self.with_access(buffers).map_block(|(_, key)| key)
     }
@@ -557,7 +555,6 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn then_gate_action<B>(self, action: Gate, buffers: B) -> Chain<'w, 's, 'a, 'b, T>
     where
         B: Bufferable,
-        B::BufferType: 'static + Send + Sync,
     {
         let buffers = buffers.into_buffer(self.builder);
         buffers.verify_scope(self.builder.scope);
@@ -578,7 +575,6 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn then_gate_open<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, T>
     where
         B: Bufferable,
-        B::BufferType: 'static + Send + Sync,
     {
         self.then_gate_action(Gate::Open, buffers)
     }
@@ -588,7 +584,6 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     pub fn then_gate_close<B>(self, buffers: B) -> Chain<'w, 's, 'a, 'b, T>
     where
         B: Bufferable,
-        B::BufferType: 'static + Send + Sync,
     {
         self.then_gate_action(Gate::Closed, buffers)
     }

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -375,37 +375,7 @@ pub struct Diagram {
 }
 
 impl Diagram {
-    /// Spawns a workflow from this diagram.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use bevy_impulse::{Diagram, DiagramError, NodeBuilderOptions, DiagramElementRegistry, RunCommandsOnWorldExt};
-    ///
-    /// let mut app = bevy_app::App::new();
-    /// let mut registry = DiagramElementRegistry::new();
-    /// registry.register_node_builder(NodeBuilderOptions::new("echo".to_string()), |builder, _config: ()| {
-    ///     builder.create_map_block(|msg: String| msg)
-    /// });
-    ///
-    /// let json_str = r#"
-    /// {
-    ///     "version": "0.1.0",
-    ///     "start": "echo",
-    ///     "ops": {
-    ///         "echo": {
-    ///             "type": "node",
-    ///             "builder": "echo",
-    ///             "next": { "builtin": "terminate" }
-    ///         }
-    ///     }
-    /// }
-    /// "#;
-    ///
-    /// let diagram = Diagram::from_json_str(json_str)?;
-    /// let workflow = app.world.command(|cmds| diagram.spawn_io_workflow(cmds, &registry))?;
-    /// # Ok::<_, DiagramError>(())
-    /// ```
+    /// Implementation for [Self::spawn_io_workflow].
     // TODO(koonpeng): Support streams other than `()` #43.
     /* pub */
     fn spawn_workflow<Streams>(
@@ -447,7 +417,37 @@ impl Diagram {
         Ok(w)
     }
 
-    /// Wrapper to [spawn_workflow::<()>](Self::spawn_workflow).
+    /// Spawns a workflow from this diagram.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_impulse::{Diagram, DiagramError, NodeBuilderOptions, DiagramElementRegistry, RunCommandsOnWorldExt};
+    ///
+    /// let mut app = bevy_app::App::new();
+    /// let mut registry = DiagramElementRegistry::new();
+    /// registry.register_node_builder(NodeBuilderOptions::new("echo".to_string()), |builder, _config: ()| {
+    ///     builder.create_map_block(|msg: String| msg)
+    /// });
+    ///
+    /// let json_str = r#"
+    /// {
+    ///     "version": "0.1.0",
+    ///     "start": "echo",
+    ///     "ops": {
+    ///         "echo": {
+    ///             "type": "node",
+    ///             "builder": "echo",
+    ///             "next": { "builtin": "terminate" }
+    ///         }
+    ///     }
+    /// }
+    /// "#;
+    ///
+    /// let diagram = Diagram::from_json_str(json_str)?;
+    /// let workflow = app.world.command(|cmds| diagram.spawn_io_workflow(cmds, &registry))?;
+    /// # Ok::<_, DiagramError>(())
+    /// ```
     pub fn spawn_io_workflow(
         &self,
         cmds: &mut Commands,

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -985,7 +985,7 @@ impl DiagramElementRegistry {
     /// Register a node builder with all the common operations (deserialize the
     /// request, serialize the response, and clone the response) enabled.
     ///
-    /// You will receive a [`RegistrationBuilder`] which you can then use to
+    /// You will receive a [`NodeRegistrationBuilder`] which you can then use to
     /// enable more operations around your node, such as fork result, split,
     /// or unzip. The data types of your node need to be suitable for those
     /// operations or else the compiler will not allow you to enable them.

--- a/src/gate.rs
+++ b/src/gate.rs
@@ -23,14 +23,14 @@ pub enum Gate {
     /// receive a wakeup immediately when a gate switches from closed to open,
     /// even if none of the data inside the buffer has changed.
     ///
-    /// [1]: crate::Bufferable::join
+    /// [1]: crate::Joinable::join
     Open,
     /// Close the buffer gate so that listeners (including [join][1] operations)
     /// will not be woken up when the data in the buffer gets modified. This
     /// effectively blocks the workflow nodes that are downstream of the buffer.
     /// Data will build up in the buffer according to its [`BufferSettings`][2].
     ///
-    /// [1]: crate::Bufferable::join
+    /// [1]: crate::Joinable::join
     /// [2]: crate::BufferSettings
     Closed,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,9 +336,9 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox, Buffer,
+            Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox, Buffer,
             BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap, BufferMapLayout,
-            BufferSettings, Bufferable, Buffered, IncompatibleLayout, IterBufferable, JoinedValue,
+            BufferSettings, Bufferable, Buffered, IncompatibleLayout, IterBufferable, Joinable, JoinedValue,
             RetentionPolicy,
         },
         builder::Builder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub use async_execution::Sendish;
 pub mod buffer;
 pub use buffer::*;
 
+pub mod re_exports;
+
 pub mod builder;
 pub use builder::*;
 
@@ -340,8 +342,8 @@ pub mod prelude {
         buffer::{
             Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox,
             AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
-            BufferMapLayout, BufferSettings, Bufferable, Buffered, IncompatibleLayout,
-            IterBufferable, Joinable, JoinedValue, RetentionPolicy,
+            BufferMapLayout, BufferSettings, BufferWorldAccess, Bufferable, Buffered,
+            IncompatibleLayout, IterBufferable, Joinable, JoinedValue, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,7 +339,7 @@ pub mod prelude {
     pub use crate::{
         buffer::{
             Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox,
-            Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
+            AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
             BufferMapLayout, BufferSettings, Bufferable, Buffered, IncompatibleLayout,
             IterBufferable, Joinable, JoinedValue, RetentionPolicy,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,10 +336,10 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessage,
-            Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferSettings, Bufferable,
-            Buffered, IterBufferable, RetentionPolicy, BufferMapLayout, JoinedValue, BufferKeyMap,
-            IncompatibleLayout,
+            AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessage, Buffer,
+            BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMapLayout,
+            BufferSettings, Bufferable, Buffered, IncompatibleLayout, IterBufferable, JoinedValue,
+            RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,9 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            AnyBuffer, AnyBufferKey, AnyBufferWorldAccess, Buffer, BufferAccess, BufferAccessMut,
-            BufferKey, BufferSettings, Bufferable, Buffered, IterBufferable, RetentionPolicy,
+            AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessage,
+            Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferSettings, Bufferable,
+            Buffered, IterBufferable, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},
@@ -361,5 +362,10 @@ pub mod prelude {
         AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
         BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
         BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
+    };
+
+    #[cfg(feature = "diagram")]
+    pub use crate::buffer::{
+        JsonBuffer, JsonBufferKey, JsonBufferMut, JsonBufferWorldAccess, JsonMessage,
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,10 +336,10 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox, Buffer,
-            BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap, BufferMapLayout,
-            BufferSettings, Bufferable, Buffered, IncompatibleLayout, IterBufferable, Joinable, JoinedValue,
-            RetentionPolicy,
+            Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox,
+            Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
+            BufferMapLayout, BufferSettings, Bufferable, Buffered, IncompatibleLayout,
+            IterBufferable, Joinable, JoinedValue, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,8 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessage, Buffer,
-            BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMapLayout,
+            AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox, Buffer,
+            BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap, BufferMapLayout,
             BufferSettings, Bufferable, Buffered, IncompatibleLayout, IterBufferable, JoinedValue,
             RetentionPolicy,
         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,10 +340,10 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox,
-            AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
-            BufferMapLayout, BufferSettings, BufferWorldAccess, Bufferable, Buffered,
-            IncompatibleLayout, IterBufferable, Joinable, JoinedValue, RetentionPolicy,
+            Accessible, Accessor, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess,
+            AnyMessageBox, AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey,
+            BufferMap, BufferMapLayout, BufferSettings, BufferWorldAccess, Bufferable, Buffering,
+            IncompatibleLayout, IterBufferable, Joinable, Joined, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,8 +336,8 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferSettings, Bufferable, Buffered,
-            IterBufferable, RetentionPolicy,
+            AnyBufferKey, AnyBufferWorldAccess, Buffer, BufferAccess, BufferAccessMut,
+            BufferKey, BufferSettings, Bufferable, Buffered, IterBufferable, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ impl Plugin for ImpulsePlugin {
 pub mod prelude {
     pub use crate::{
         buffer::{
-            AnyBufferKey, AnyBufferWorldAccess, Buffer, BufferAccess, BufferAccessMut,
+            AnyBuffer, AnyBufferKey, AnyBufferWorldAccess, Buffer, BufferAccess, BufferAccessMut,
             BufferKey, BufferSettings, Bufferable, Buffered, IterBufferable, RetentionPolicy,
         },
         builder::Builder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,8 @@ pub use trim::*;
 use bevy_app::prelude::{App, Plugin, Update};
 use bevy_ecs::prelude::{Entity, In};
 
+extern crate self as bevy_impulse;
+
 /// Use `BlockingService` to indicate that your system is a blocking [`Service`].
 ///
 /// A blocking service will have exclusive world access while it runs, which

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,8 @@ pub mod prelude {
         buffer::{
             AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessage,
             Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferSettings, Bufferable,
-            Buffered, IterBufferable, RetentionPolicy,
+            Buffered, IterBufferable, RetentionPolicy, BufferMapLayout, JoinedValue, BufferKeyMap,
+            IncompatibleLayout,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/operation/cleanup.rs
+++ b/src/operation/cleanup.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    Accessed, BufferAccessStorage, ManageDisposal, ManageInput, MiscellaneousFailure,
+    Accessing, BufferAccessStorage, ManageDisposal, ManageInput, MiscellaneousFailure,
     OperationError, OperationResult, OperationRoster, OrBroken, ScopeStorage, UnhandledErrors,
 };
 
@@ -98,7 +98,7 @@ impl<'a> OperationCleanup<'a> {
 
     pub fn cleanup_buffer_access<B>(&mut self) -> OperationResult
     where
-        B: Accessed + 'static + Send + Sync,
+        B: Accessing + 'static + Send + Sync,
         B::Key: 'static + Send + Sync,
     {
         let scope = self

--- a/src/operation/cleanup.rs
+++ b/src/operation/cleanup.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    BufferAccessStorage, Buffered, ManageDisposal, ManageInput, MiscellaneousFailure,
+    Accessed, BufferAccessStorage, ManageDisposal, ManageInput, MiscellaneousFailure,
     OperationError, OperationResult, OperationRoster, OrBroken, ScopeStorage, UnhandledErrors,
 };
 
@@ -98,7 +98,7 @@ impl<'a> OperationCleanup<'a> {
 
     pub fn cleanup_buffer_access<B>(&mut self) -> OperationResult
     where
-        B: Buffered + 'static + Send + Sync,
+        B: Accessed + 'static + Send + Sync,
         B::Key: 'static + Send + Sync,
     {
         let scope = self

--- a/src/operation/join.rs
+++ b/src/operation/join.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    Buffered, FunnelInputStorage, Input, InputBundle, ManageInput, Operation, OperationCleanup,
+    FunnelInputStorage, Input, InputBundle, Joined, ManageInput, Operation, OperationCleanup,
     OperationError, OperationReachability, OperationRequest, OperationResult, OperationSetup,
     OrBroken, ReachabilityResult, SingleInputStorage, SingleTargetStorage,
 };
@@ -37,7 +37,7 @@ impl<Buffers> Join<Buffers> {
 #[derive(Component)]
 struct BufferStorage<Buffers>(Buffers);
 
-impl<Buffers: Buffered + 'static + Send + Sync> Operation for Join<Buffers>
+impl<Buffers: Joined + 'static + Send + Sync> Operation for Join<Buffers>
 where
     Buffers::Item: 'static + Send + Sync,
 {

--- a/src/operation/join.rs
+++ b/src/operation/join.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    FunnelInputStorage, Input, InputBundle, Joined, ManageInput, Operation, OperationCleanup,
+    FunnelInputStorage, Input, InputBundle, Joining, ManageInput, Operation, OperationCleanup,
     OperationError, OperationReachability, OperationRequest, OperationResult, OperationSetup,
     OrBroken, ReachabilityResult, SingleInputStorage, SingleTargetStorage,
 };
@@ -37,7 +37,7 @@ impl<Buffers> Join<Buffers> {
 #[derive(Component)]
 struct BufferStorage<Buffers>(Buffers);
 
-impl<Buffers: Joined + 'static + Send + Sync> Operation for Join<Buffers>
+impl<Buffers: Joining + 'static + Send + Sync> Operation for Join<Buffers>
 where
     Buffers::Item: 'static + Send + Sync,
 {

--- a/src/operation/listen.rs
+++ b/src/operation/listen.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::Entity;
 
 use crate::{
-    buffer_key_usage, get_access_keys, BufferAccessStorage, BufferKeyUsage, Buffered,
+    Accessed, buffer_key_usage, get_access_keys, BufferAccessStorage, BufferKeyUsage,
     FunnelInputStorage, Input, InputBundle, ManageInput, Operation, OperationCleanup,
     OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
     ReachabilityResult, SingleInputStorage, SingleTargetStorage,
@@ -37,7 +37,7 @@ impl<B> Listen<B> {
 
 impl<B> Operation for Listen<B>
 where
-    B: Buffered + 'static + Send + Sync,
+    B: Accessed + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {

--- a/src/operation/listen.rs
+++ b/src/operation/listen.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::Entity;
 
 use crate::{
-    buffer_key_usage, get_access_keys, Accessed, BufferAccessStorage, BufferKeyUsage,
+    buffer_key_usage, get_access_keys, Accessing, BufferAccessStorage, BufferKeyUsage,
     FunnelInputStorage, Input, InputBundle, ManageInput, Operation, OperationCleanup,
     OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
     ReachabilityResult, SingleInputStorage, SingleTargetStorage,
@@ -37,7 +37,7 @@ impl<B> Listen<B> {
 
 impl<B> Operation for Listen<B>
 where
-    B: Accessed + 'static + Send + Sync,
+    B: Accessing + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {

--- a/src/operation/listen.rs
+++ b/src/operation/listen.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::Entity;
 
 use crate::{
-    Accessed, buffer_key_usage, get_access_keys, BufferAccessStorage, BufferKeyUsage,
+    buffer_key_usage, get_access_keys, Accessed, BufferAccessStorage, BufferKeyUsage,
     FunnelInputStorage, Input, InputBundle, ManageInput, Operation, OperationCleanup,
     OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
     ReachabilityResult, SingleInputStorage, SingleTargetStorage,

--- a/src/operation/operate_buffer.rs
+++ b/src/operation/operate_buffer.rs
@@ -29,7 +29,7 @@ use backtrace::Backtrace;
 use smallvec::SmallVec;
 
 use crate::{
-    Broken, BufferAccessors, BufferSettings, BufferStorage, AnyBufferStorageAccess, DeferredRoster, ForkTargetStorage,
+    Broken, BufferAccessors, BufferSettings, BufferStorage, DeferredRoster, ForkTargetStorage,
     Gate, GateActionStorage, Input, InputBundle, InspectBuffer, ManageBuffer, ManageInput,
     MiscellaneousFailure, Operation, OperationCleanup, OperationError, OperationReachability,
     OperationRequest, OperationResult, OperationRoster, OperationSetup, OrBroken,
@@ -39,14 +39,12 @@ use crate::{
 #[derive(Bundle)]
 pub(crate) struct OperateBuffer<T: 'static + Send + Sync> {
     storage: BufferStorage<T>,
-    inspector: AnyBufferStorageAccess,
 }
 
 impl<T: 'static + Send + Sync> OperateBuffer<T> {
     pub(crate) fn new(settings: BufferSettings) -> Self {
         Self {
             storage: BufferStorage::new(settings),
-            inspector: AnyBufferStorageAccess::new::<T>(),
         }
     }
 }

--- a/src/operation/operate_buffer.rs
+++ b/src/operation/operate_buffer.rs
@@ -29,7 +29,7 @@ use backtrace::Backtrace;
 use smallvec::SmallVec;
 
 use crate::{
-    Broken, BufferAccessors, BufferSettings, BufferStorage, DynBufferStorage, DeferredRoster, ForkTargetStorage,
+    Broken, BufferAccessors, BufferSettings, BufferStorage, AnyBufferStorageAccess, DeferredRoster, ForkTargetStorage,
     Gate, GateActionStorage, Input, InputBundle, InspectBuffer, ManageBuffer, ManageInput,
     MiscellaneousFailure, Operation, OperationCleanup, OperationError, OperationReachability,
     OperationRequest, OperationResult, OperationRoster, OperationSetup, OrBroken,
@@ -39,14 +39,14 @@ use crate::{
 #[derive(Bundle)]
 pub(crate) struct OperateBuffer<T: 'static + Send + Sync> {
     storage: BufferStorage<T>,
-    inspector: DynBufferStorage,
+    inspector: AnyBufferStorageAccess,
 }
 
 impl<T: 'static + Send + Sync> OperateBuffer<T> {
     pub(crate) fn new(settings: BufferSettings) -> Self {
         Self {
             storage: BufferStorage::new(settings),
-            inspector: DynBufferStorage::new::<T>(),
+            inspector: AnyBufferStorageAccess::new::<T>(),
         }
     }
 }

--- a/src/operation/operate_buffer.rs
+++ b/src/operation/operate_buffer.rs
@@ -29,7 +29,7 @@ use backtrace::Backtrace;
 use smallvec::SmallVec;
 
 use crate::{
-    Broken, BufferAccessors, BufferSettings, BufferStorage, DeferredRoster, ForkTargetStorage,
+    Broken, BufferAccessors, BufferSettings, BufferStorage, DynBufferStorage, DeferredRoster, ForkTargetStorage,
     Gate, GateActionStorage, Input, InputBundle, InspectBuffer, ManageBuffer, ManageInput,
     MiscellaneousFailure, Operation, OperationCleanup, OperationError, OperationReachability,
     OperationRequest, OperationResult, OperationRoster, OperationSetup, OrBroken,
@@ -39,12 +39,14 @@ use crate::{
 #[derive(Bundle)]
 pub(crate) struct OperateBuffer<T: 'static + Send + Sync> {
     storage: BufferStorage<T>,
+    inspector: DynBufferStorage,
 }
 
 impl<T: 'static + Send + Sync> OperateBuffer<T> {
     pub(crate) fn new(settings: BufferSettings) -> Self {
         Self {
             storage: BufferStorage::new(settings),
+            inspector: DynBufferStorage::new::<T>(),
         }
     }
 }

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -25,7 +25,7 @@ use std::{
 use smallvec::SmallVec;
 
 use crate::{
-    BufferKeyBuilder, Buffered, ChannelQueue, Input, InputBundle, ManageInput, Operation,
+    Accessed, BufferKeyBuilder, ChannelQueue, Input, InputBundle, ManageInput, Operation,
     OperationCleanup, OperationError, OperationReachability, OperationRequest, OperationResult,
     OperationSetup, OrBroken, ReachabilityResult, ScopeStorage, SingleInputStorage,
     SingleTargetStorage,
@@ -34,7 +34,7 @@ use crate::{
 pub(crate) struct OperateBufferAccess<T, B>
 where
     T: 'static + Send + Sync,
-    B: Buffered,
+    B: Accessed,
 {
     buffers: B,
     target: Entity,
@@ -44,7 +44,7 @@ where
 impl<T, B> OperateBufferAccess<T, B>
 where
     T: 'static + Send + Sync,
-    B: Buffered,
+    B: Accessed,
 {
     pub(crate) fn new(buffers: B, target: Entity) -> Self {
         Self {
@@ -59,12 +59,12 @@ where
 pub struct BufferKeyUsage(pub(crate) fn(Entity, Entity, &World) -> ReachabilityResult);
 
 #[derive(Component)]
-pub(crate) struct BufferAccessStorage<B: Buffered> {
+pub(crate) struct BufferAccessStorage<B: Accessed> {
     pub(crate) buffers: B,
     pub(crate) keys: HashMap<Entity, B::Key>,
 }
 
-impl<B: Buffered> BufferAccessStorage<B> {
+impl<B: Accessed> BufferAccessStorage<B> {
     pub(crate) fn new(buffers: B) -> Self {
         Self {
             buffers,
@@ -76,7 +76,7 @@ impl<B: Buffered> BufferAccessStorage<B> {
 impl<T, B> Operation for OperateBufferAccess<T, B>
 where
     T: 'static + Send + Sync,
-    B: Buffered + 'static + Send + Sync,
+    B: Accessed + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
@@ -138,7 +138,7 @@ pub(crate) fn get_access_keys<B>(
     world: &mut World,
 ) -> Result<B::Key, OperationError>
 where
-    B: Buffered + 'static + Send + Sync,
+    B: Accessed + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     let scope = world.get::<ScopeStorage>(source).or_broken()?.get();
@@ -180,7 +180,7 @@ pub(crate) fn buffer_key_usage<B>(
     world: &World,
 ) -> ReachabilityResult
 where
-    B: Buffered + 'static + Send + Sync,
+    B: Accessed + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     let key = world

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -206,6 +206,12 @@ where
 pub(crate) struct BufferAccessors(pub(crate) SmallVec<[Entity; 8]>);
 
 impl BufferAccessors {
+    pub(crate) fn add_accessor(&mut self, accessor: Entity) {
+        self.0.push(accessor);
+        self.0.sort();
+        self.0.dedup();
+    }
+
     pub(crate) fn is_reachable(r: &mut OperationReachability) -> ReachabilityResult {
         let Some(accessors) = r.world.get::<Self>(r.source) else {
             return Ok(false);

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -25,7 +25,7 @@ use std::{
 use smallvec::SmallVec;
 
 use crate::{
-    Accessed, BufferKeyBuilder, ChannelQueue, Input, InputBundle, ManageInput, Operation,
+    Accessing, BufferKeyBuilder, ChannelQueue, Input, InputBundle, ManageInput, Operation,
     OperationCleanup, OperationError, OperationReachability, OperationRequest, OperationResult,
     OperationSetup, OrBroken, ReachabilityResult, ScopeStorage, SingleInputStorage,
     SingleTargetStorage,
@@ -34,7 +34,7 @@ use crate::{
 pub(crate) struct OperateBufferAccess<T, B>
 where
     T: 'static + Send + Sync,
-    B: Accessed,
+    B: Accessing,
 {
     buffers: B,
     target: Entity,
@@ -44,7 +44,7 @@ where
 impl<T, B> OperateBufferAccess<T, B>
 where
     T: 'static + Send + Sync,
-    B: Accessed,
+    B: Accessing,
 {
     pub(crate) fn new(buffers: B, target: Entity) -> Self {
         Self {
@@ -59,12 +59,12 @@ where
 pub struct BufferKeyUsage(pub(crate) fn(Entity, Entity, &World) -> ReachabilityResult);
 
 #[derive(Component)]
-pub(crate) struct BufferAccessStorage<B: Accessed> {
+pub(crate) struct BufferAccessStorage<B: Accessing> {
     pub(crate) buffers: B,
     pub(crate) keys: HashMap<Entity, B::Key>,
 }
 
-impl<B: Accessed> BufferAccessStorage<B> {
+impl<B: Accessing> BufferAccessStorage<B> {
     pub(crate) fn new(buffers: B) -> Self {
         Self {
             buffers,
@@ -76,7 +76,7 @@ impl<B: Accessed> BufferAccessStorage<B> {
 impl<T, B> Operation for OperateBufferAccess<T, B>
 where
     T: 'static + Send + Sync,
-    B: Accessed + 'static + Send + Sync,
+    B: Accessing + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
@@ -138,7 +138,7 @@ pub(crate) fn get_access_keys<B>(
     world: &mut World,
 ) -> Result<B::Key, OperationError>
 where
-    B: Accessed + 'static + Send + Sync,
+    B: Accessing + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     let scope = world.get::<ScopeStorage>(source).or_broken()?.get();
@@ -180,7 +180,7 @@ pub(crate) fn buffer_key_usage<B>(
     world: &World,
 ) -> ReachabilityResult
 where
-    B: Accessed + 'static + Send + Sync,
+    B: Accessing + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     let key = world

--- a/src/operation/operate_gate.rs
+++ b/src/operation/operate_gate.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    emit_disposal, Buffered, Disposal, Gate, GateRequest, Input, InputBundle, ManageInput,
+    emit_disposal, Buffering, Disposal, Gate, GateRequest, Input, InputBundle, ManageInput,
     Operation, OperationCleanup, OperationReachability, OperationRequest, OperationResult,
     OperationSetup, OrBroken, ReachabilityResult, SingleInputStorage, SingleTargetStorage,
 };
@@ -48,7 +48,7 @@ impl<B, T> OperateDynamicGate<T, B> {
 impl<T, B> Operation for OperateDynamicGate<T, B>
 where
     T: 'static + Send + Sync,
-    B: Buffered + 'static + Send + Sync,
+    B: Buffering + 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
         world
@@ -144,7 +144,7 @@ impl<T, B> OperateStaticGate<T, B> {
 
 impl<T, B> Operation for OperateStaticGate<T, B>
 where
-    B: Buffered + 'static + Send + Sync,
+    B: Buffering + 'static + Send + Sync,
     T: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    check_reachability, execute_operation, is_downstream_of, Accessed, AddOperation, Blocker,
+    check_reachability, execute_operation, is_downstream_of, Accessing, AddOperation, Blocker,
     BufferKeyBuilder, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents, ClearBufferFn,
     CollectMarker, DisposalListener, DisposalUpdate, FinalizeCleanup, FinalizeCleanupRequest,
     Input, InputBundle, InspectDisposals, ManageCancellation, ManageInput, Operation,
@@ -1124,7 +1124,7 @@ impl<B> BeginCleanupWorkflow<B> {
 
 impl<B> Operation for BeginCleanupWorkflow<B>
 where
-    B: Accessed + 'static + Send + Sync,
+    B: Accessing + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -17,7 +17,7 @@
 
 use crate::{
     check_reachability, execute_operation, is_downstream_of, Accessed, AddOperation, Blocker,
-    BufferKeyBuilder, Buffered, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents,
+    BufferKeyBuilder, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents,
     ClearBufferFn, CollectMarker, DisposalListener, DisposalUpdate, FinalizeCleanup,
     FinalizeCleanupRequest, Input, InputBundle, InspectDisposals, ManageCancellation, ManageInput,
     Operation, OperationCancel, OperationCleanup, OperationError, OperationReachability,

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -17,14 +17,13 @@
 
 use crate::{
     check_reachability, execute_operation, is_downstream_of, Accessed, AddOperation, Blocker,
-    BufferKeyBuilder, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents,
-    ClearBufferFn, CollectMarker, DisposalListener, DisposalUpdate, FinalizeCleanup,
-    FinalizeCleanupRequest, Input, InputBundle, InspectDisposals, ManageCancellation, ManageInput,
-    Operation, OperationCancel, OperationCleanup, OperationError, OperationReachability,
-    OperationRequest, OperationResult, OperationRoster, OperationSetup, OrBroken,
-    ReachabilityResult, ScopeSettings, SingleInputStorage, SingleTargetStorage, Stream, StreamPack,
-    StreamRequest, StreamTargetMap, StreamTargetStorage, UnhandledErrors, Unreachability,
-    UnusedTarget,
+    BufferKeyBuilder, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents, ClearBufferFn,
+    CollectMarker, DisposalListener, DisposalUpdate, FinalizeCleanup, FinalizeCleanupRequest,
+    Input, InputBundle, InspectDisposals, ManageCancellation, ManageInput, Operation,
+    OperationCancel, OperationCleanup, OperationError, OperationReachability, OperationRequest,
+    OperationResult, OperationRoster, OperationSetup, OrBroken, ReachabilityResult, ScopeSettings,
+    SingleInputStorage, SingleTargetStorage, Stream, StreamPack, StreamRequest, StreamTargetMap,
+    StreamTargetStorage, UnhandledErrors, Unreachability, UnusedTarget,
 };
 
 use backtrace::Backtrace;

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -16,7 +16,7 @@
 */
 
 use crate::{
-    check_reachability, execute_operation, is_downstream_of, AddOperation, Blocker,
+    check_reachability, execute_operation, is_downstream_of, Accessed, AddOperation, Blocker,
     BufferKeyBuilder, Buffered, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents,
     ClearBufferFn, CollectMarker, DisposalListener, DisposalUpdate, FinalizeCleanup,
     FinalizeCleanupRequest, Input, InputBundle, InspectDisposals, ManageCancellation, ManageInput,
@@ -1125,7 +1125,7 @@ impl<B> BeginCleanupWorkflow<B> {
 
 impl<B> Operation for BeginCleanupWorkflow<B>
 where
-    B: Buffered + 'static + Send + Sync,
+    B: Accessed + 'static + Send + Sync,
     B::Key: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {

--- a/src/re_exports.rs
+++ b/src/re_exports.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+//! This module contains symbols that are being re-exported so they can be used
+//! by bevy_impulse_derive.
+
+pub use bevy_ecs::prelude::{Entity, World};

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -33,8 +33,8 @@ use smallvec::SmallVec;
 
 use crate::{
     flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsAnyBuffer, AsyncServiceInput,
-    BlockingMap, BlockingServiceInput, Buffer, BufferKey, Bufferable, Buffered, Builder,
-    ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
+    BlockingMap, BlockingServiceInput, Buffer, BufferKey, BufferKeyLifecycle, Bufferable, Buffered,
+    Builder, ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
     GetBufferedSessionsFn, Joined, OperationError, OperationResult, OperationRoster, Promise,
     RunCommandsOnWorldExt, Scope, Service, SpawnWorkflowExt, StreamOf, StreamPack, UnhandledErrors,
     WorkflowSettings,

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -32,11 +32,12 @@ pub use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use crate::{
-    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsAnyBuffer, AsyncServiceInput, BlockingMap,
-    BlockingServiceInput, Buffer, BufferKey, Bufferable, Buffered, Builder, ContinuousQuery,
-    ContinuousQueueView, ContinuousService, FlushParameters, GetBufferedSessionsFn, Joined,
-    OperationError, OperationResult, OperationRoster, Promise, RunCommandsOnWorldExt, Scope,
-    Service, SpawnWorkflowExt, StreamOf, StreamPack, UnhandledErrors, WorkflowSettings,
+    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsAnyBuffer, AsyncServiceInput,
+    BlockingMap, BlockingServiceInput, Buffer, BufferKey, Bufferable, Buffered, Builder,
+    ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
+    GetBufferedSessionsFn, Joined, OperationError, OperationResult, OperationRoster, Promise,
+    RunCommandsOnWorldExt, Scope, Service, SpawnWorkflowExt, StreamOf, StreamPack, UnhandledErrors,
+    WorkflowSettings,
 };
 
 pub struct TestingContext {

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -32,10 +32,10 @@ pub use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use crate::{
-    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsAnyBuffer, AsyncServiceInput,
-    BlockingMap, BlockingServiceInput, Buffer, BufferKey, BufferKeyLifecycle, Bufferable, Buffered,
-    Builder, ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
-    GetBufferedSessionsFn, Joined, OperationError, OperationResult, OperationRoster, Promise,
+    flush_impulses, Accessing, AddContinuousServicesExt, AnyBuffer, AsAnyBuffer, AsyncServiceInput,
+    BlockingMap, BlockingServiceInput, Buffer, BufferKey, BufferKeyLifecycle, Bufferable,
+    Buffering, Builder, ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
+    GetBufferedSessionsFn, Joining, OperationError, OperationResult, OperationRoster, Promise,
     RunCommandsOnWorldExt, Scope, Service, SpawnWorkflowExt, StreamOf, StreamPack, UnhandledErrors,
     WorkflowSettings,
 };
@@ -524,7 +524,7 @@ impl<T: 'static + Send + Sync> Bufferable for NonCopyBuffer<T> {
     }
 }
 
-impl<T: 'static + Send + Sync> Buffered for NonCopyBuffer<T> {
+impl<T: 'static + Send + Sync> Buffering for NonCopyBuffer<T> {
     fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
         self.inner.add_listener(listener, world)
     }
@@ -556,14 +556,14 @@ impl<T: 'static + Send + Sync> Buffered for NonCopyBuffer<T> {
     }
 }
 
-impl<T: 'static + Send + Sync> Joined for NonCopyBuffer<T> {
+impl<T: 'static + Send + Sync> Joining for NonCopyBuffer<T> {
     type Item = T;
     fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
         self.inner.pull(session, world)
     }
 }
 
-impl<T: 'static + Send + Sync> Accessed for NonCopyBuffer<T> {
+impl<T: 'static + Send + Sync> Accessing for NonCopyBuffer<T> {
     type Key = BufferKey<T>;
     fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
         self.inner.add_accessor(accessor, world)

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -32,7 +32,7 @@ pub use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use crate::{
-    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsyncServiceInput, BlockingMap,
+    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsAnyBuffer, AsyncServiceInput, BlockingMap,
     BlockingServiceInput, Buffer, BufferKey, Bufferable, Buffered, Builder, ContinuousQuery,
     ContinuousQueueView, ContinuousService, FlushParameters, GetBufferedSessionsFn, Joined,
     OperationError, OperationResult, OperationRoster, Promise, RunCommandsOnWorldExt, Scope,
@@ -504,15 +504,15 @@ impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
     }
 }
 
-impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
-    pub fn as_any_buffer(&self) -> AnyBuffer {
-        self.inner.as_any_buffer()
-    }
-}
-
 impl<T> Clone for NonCopyBuffer<T> {
     fn clone(&self) -> Self {
         Self { inner: self.inner }
+    }
+}
+
+impl<T: 'static + Send + Sync> AsAnyBuffer for NonCopyBuffer<T> {
+    fn as_any_buffer(&self) -> AnyBuffer {
+        self.inner.as_any_buffer()
     }
 }
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -19,7 +19,7 @@ use bevy_app::ScheduleRunnerPlugin;
 pub use bevy_app::{App, Update};
 use bevy_core::{FrameCountPlugin, TaskPoolPlugin, TypeRegistrationPlugin};
 pub use bevy_ecs::{
-    prelude::{Commands, Component, Entity, In, Local, Query, ResMut, Resource},
+    prelude::{Commands, Component, Entity, In, Local, Query, ResMut, Resource, World},
     system::{CommandQueue, IntoSystem},
 };
 use bevy_time::TimePlugin;
@@ -32,10 +32,11 @@ pub use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use crate::{
-    flush_impulses, AddContinuousServicesExt, AsyncServiceInput, BlockingMap, BlockingServiceInput,
-    Builder, ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
-    GetBufferedSessionsFn, Promise, RunCommandsOnWorldExt, Scope, Service, SpawnWorkflowExt,
-    StreamOf, StreamPack, UnhandledErrors, WorkflowSettings,
+    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsyncServiceInput, BlockingMap,
+    BlockingServiceInput, Buffer, BufferKey, Bufferable, Buffered, Builder, ContinuousQuery,
+    ContinuousQueueView, ContinuousService, FlushParameters, GetBufferedSessionsFn, Joined,
+    OperationError, OperationResult, OperationRoster, Promise, RunCommandsOnWorldExt, Scope,
+    Service, SpawnWorkflowExt, StreamOf, StreamPack, UnhandledErrors, WorkflowSettings,
 };
 
 pub struct TestingContext {
@@ -477,4 +478,105 @@ pub struct TestComponent;
 #[derive(Component, Resource)]
 pub struct Integer {
     pub value: i32,
+}
+
+/// This is an ordinary buffer newtype whose only purpose is to test the
+/// #[joined(noncopy_buffer)] feature. We intentionally do not implement
+/// the Copy trait for it.
+pub struct NonCopyBuffer<T> {
+    inner: Buffer<T>,
+}
+
+impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
+    pub fn register_downcast() {
+        let any_interface = AnyBuffer::interface_for::<T>();
+        any_interface.register_buffer_downcast(
+            std::any::TypeId::of::<NonCopyBuffer<T>>(),
+            Box::new(|location| {
+                Box::new(NonCopyBuffer::<T> {
+                    inner: Buffer {
+                        location,
+                        _ignore: Default::default(),
+                    },
+                })
+            }),
+        );
+    }
+}
+
+impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
+    pub fn as_any_buffer(&self) -> AnyBuffer {
+        self.inner.as_any_buffer()
+    }
+}
+
+impl<T> Clone for NonCopyBuffer<T> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner }
+    }
+}
+
+impl<T: 'static + Send + Sync> Bufferable for NonCopyBuffer<T> {
+    type BufferType = Self;
+    fn into_buffer(self, _builder: &mut Builder) -> Self::BufferType {
+        self
+    }
+}
+
+impl<T: 'static + Send + Sync> Buffered for NonCopyBuffer<T> {
+    fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
+        self.inner.add_listener(listener, world)
+    }
+
+    fn as_input(&self) -> smallvec::SmallVec<[Entity; 8]> {
+        self.inner.as_input()
+    }
+
+    fn buffered_count(&self, session: Entity, world: &World) -> Result<usize, OperationError> {
+        self.inner.buffered_count(session, world)
+    }
+
+    fn ensure_active_session(&self, session: Entity, world: &mut World) -> OperationResult {
+        self.inner.ensure_active_session(session, world)
+    }
+
+    fn gate_action(
+        &self,
+        session: Entity,
+        action: crate::Gate,
+        world: &mut World,
+        roster: &mut OperationRoster,
+    ) -> OperationResult {
+        self.inner.gate_action(session, action, world, roster)
+    }
+
+    fn verify_scope(&self, scope: Entity) {
+        self.inner.verify_scope(scope);
+    }
+}
+
+impl<T: 'static + Send + Sync> Joined for NonCopyBuffer<T> {
+    type Item = T;
+    fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
+        self.inner.pull(session, world)
+    }
+}
+
+impl<T: 'static + Send + Sync> Accessed for NonCopyBuffer<T> {
+    type Key = BufferKey<T>;
+    fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
+        self.inner.add_accessor(accessor, world)
+    }
+
+    fn create_key(&self, builder: &crate::BufferKeyBuilder) -> Self::Key {
+        self.inner.create_key(builder)
+    }
+
+    fn deep_clone_key(key: &Self::Key) -> Self::Key {
+        key.deep_clone()
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        key.is_in_use()
+    }
 }


### PR DESCRIPTION
This PR is to address issues in the core library that are creating roadblocks for #51

This is a hefty PR but adds some important layers of flexibility to buffers. The highlights are:
* `AnyBuffer` can represent a buffer of any message type, and is now a first-class citizen of the library
  * Use `AnyBufferKey` to access any buffer through the `World`
* `JsonBuffer` can represent a buffer of any message type that supports serialization and deserialization
  * Use `JsonBufferKey` to access the JSON data in the buffer through the `World`
* `BufferMap` can now be used with `Builder::join_into` to join a dictionary of `AnyBuffer` instances into a value that implements `JoinedValue`
  * This should make it much easier and more robust to define how the join operation works in JSON and convert that into actual workflow connections

I'm leaving this PR as a draft because there are a few more items to finish:
- [x] Create a `Joined` macro that implements the `JoinedValue` and `BufferMapLayout` traits for any struct
- [x] Create a `BufferKeyMap` macro that implements the `BufferKeyMap` and `BufferMapLayout` traits for any struct that consists entirely of `BufferKey<T>`,  and/or `AnyBufferKey` fields
- [x] Implement `Builder::try_listen` to convert a `BufferMap` into a specific struct that implements `BufferKeyMap`.