### PR TITLE
derive `Joined` to implement `JoinedValue` and `BufferMapLayout`

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -16,3 +16,4 @@ proc-macro = true
 [dependencies]
 syn = "2.0"
 quote = "1.0"
+proc-macro2 = "1.0.93"

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -6,61 +6,18 @@ use crate::Result;
 
 pub(crate) fn impl_joined_value(ast: DeriveInput) -> Result<TokenStream> {
     let struct_ident = ast.ident;
-    let (field_ident, field_type) = match ast.data {
-        syn::Data::Struct(data) => get_fields_map(data.fields)?,
+    let (field_ident, field_type): (Vec<Ident>, Vec<Type>) = match ast.data {
+        syn::Data::Struct(data) => get_fields_map(data.fields)?.into_iter().unzip(),
         _ => return Err("expected struct".to_string()),
     };
     let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
     let struct_buffer_ident = format_ident!("__{}Buffers", struct_ident);
 
+    let impl_buffer_map_layout =
+        buffer_map_layout(&struct_ident, &field_ident, &field_type, &map_key);
+
     let gen = quote! {
-        impl BufferMapLayout for #struct_ident {
-            fn is_compatible(buffers: &BufferMap) -> Result<(), ::bevy_impulse::IncompatibleLayout> {
-                let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
-                #(
-                    compatibility.require_buffer::<#field_type>(#map_key, buffers);
-                )*
-                compatibility.into_result()
-            }
-
-            fn buffered_count(
-                buffers: &::bevy_impulse::BufferMap,
-                session: ::bevy_ecs::prelude::Entity,
-                world: &::bevy_ecs::prelude::World,
-            ) -> Result<usize, ::bevy_impulse::OperationError> {
-                use ::bevy_impulse::{InspectBuffer, OrBroken};
-
-                #(
-                    let #field_ident = world
-                        .get_entity(buffers.get(#map_key).or_broken()?.id())
-                        .or_broken()?
-                        .buffered_count::<#field_type>(session)?;
-                )*
-
-                Ok([#( #field_ident ),*]
-                    .iter()
-                    .min()
-                    .copied()
-                    .unwrap_or(0))
-            }
-
-            fn ensure_active_session(
-                buffers: &::bevy_impulse::BufferMap,
-                session: ::bevy_ecs::prelude::Entity,
-                world: &mut ::bevy_ecs::prelude::World,
-            ) -> ::bevy_impulse::OperationResult {
-                use ::bevy_impulse::{ManageBuffer, OrBroken};
-
-                #(
-                    world
-                        .get_entity_mut(buffers.get(#map_key).or_broken()?.id())
-                        .or_broken()?
-                        .ensure_session::<#field_type>(session)?;
-                )*
-
-                Ok(())
-            }
-        }
+        #impl_buffer_map_layout
 
         impl ::bevy_impulse::JoinedValue for #struct_ident {
             type Buffers = #struct_buffer_ident;
@@ -107,18 +64,125 @@ pub(crate) fn impl_joined_value(ast: DeriveInput) -> Result<TokenStream> {
     Ok(gen.into())
 }
 
-fn get_fields_map(fields: syn::Fields) -> Result<(Vec<Ident>, Vec<Type>)> {
+fn get_fields_map(fields: syn::Fields) -> Result<Vec<(Ident, Type)>> {
     match fields {
         syn::Fields::Named(data) => {
-            let mut idents = Vec::with_capacity(data.named.len());
-            let mut types = Vec::with_capacity(data.named.len());
+            let mut idents_types = Vec::with_capacity(data.named.len());
             for field in data.named {
                 let ident = field.ident.ok_or("expected named fields".to_string())?;
-                idents.push(ident);
-                types.push(field.ty);
+                idents_types.push((ident, field.ty));
             }
-            Ok((idents, types))
+            Ok(idents_types)
         }
         _ => return Err("expected named fields".to_string()),
     }
+}
+
+fn buffer_map_layout(
+    struct_ident: &Ident,
+    field_ident: &Vec<Ident>,
+    field_type: &Vec<Type>,
+    map_key: &Vec<String>,
+) -> proc_macro2::TokenStream {
+    quote! {
+        impl ::bevy_impulse::BufferMapLayout for #struct_ident {
+            fn is_compatible(buffers: &BufferMap) -> Result<(), ::bevy_impulse::IncompatibleLayout> {
+                let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
+                #(
+                    compatibility.require_buffer::<#field_type>(#map_key, buffers);
+                )*
+                compatibility.into_result()
+            }
+
+            fn buffered_count(
+                buffers: &::bevy_impulse::BufferMap,
+                session: ::bevy_ecs::prelude::Entity,
+                world: &::bevy_ecs::prelude::World,
+            ) -> Result<usize, ::bevy_impulse::OperationError> {
+                use ::bevy_impulse::{InspectBuffer, OrBroken};
+
+                #(
+                    let #field_ident = world
+                        .get_entity(buffers.get(#map_key).or_broken()?.id())
+                        .or_broken()?
+                        .buffered_count::<#field_type>(session)?;
+                )*
+
+                Ok([#( #field_ident ),*]
+                    .iter()
+                    .min()
+                    .copied()
+                    .unwrap_or(0))
+            }
+
+            fn ensure_active_session(
+                buffers: &::bevy_impulse::BufferMap,
+                session: ::bevy_ecs::prelude::Entity,
+                world: &mut ::bevy_ecs::prelude::World,
+            ) -> ::bevy_impulse::OperationResult {
+                use ::bevy_impulse::{ManageBuffer, OrBroken};
+
+                #(
+                    world
+                        .get_entity_mut(buffers.get(#map_key).or_broken()?.id())
+                        .or_broken()?
+                        .ensure_session::<#field_type>(session)?;
+                )*
+
+                Ok(())
+            }
+        }
+    }
+}
+
+pub(crate) fn impl_buffer_key_map(ast: DeriveInput) -> Result<TokenStream> {
+    let struct_ident = ast.ident;
+    let (field_ident, field_type): (Vec<Ident>, Vec<Type>) = match ast.data {
+        syn::Data::Struct(data) => get_fields_map(data.fields)?.into_iter().unzip(),
+        _ => return Err("expected struct".to_string()),
+    };
+    let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
+
+    let impl_buffer_map_layout =
+        buffer_map_layout(&struct_ident, &field_ident, &field_type, &map_key);
+
+    // FIXME(koonpeng): `create_key` does not allow failure and we can't guarantee that the buffer
+    // from buffer is valid.
+    let gen = quote! {
+        impl ::bevy_impulse::BufferKeyMap for #struct_ident {
+            fn add_accessor(buffers: &::bevy_impulse::BufferMap, accessor: ::bevy_ecs::prelude::Entity, world: &mut ::bevy_ecs::prelude::World) -> ::bevy_impulse::OperationResult {
+                use ::bevy_impulse::{Accessed, OrBroken};
+
+                #(
+                    buffers.get(#map_key).or_broken()?.add_accessor(accessor, world)?;
+                )*
+
+                Ok(())
+            }
+
+            fn create_key(buffers: &::bevy_impulse::BufferMap, builder: &::bevy_impulse::BufferKeyBuilder) -> Self {
+                use ::bevy_impulse::{Accessed, OrBroken};
+
+                Self {#(
+                    #field_ident: buffers.get(#map_key).unwrap().create_key(builder).try_into().unwrap(),
+                )*}
+            }
+
+            fn deep_clone_key(&self) -> Self {
+                Self {#(
+                    #field_ident: self.#field_ident.deep_clone(),
+                )*}
+            }
+
+            fn is_key_in_use(&self) -> bool {
+                #(
+                    self.#field_ident.is_in_use()
+                )||*
+            }
+        }
+
+        #impl_buffer_map_layout
+    };
+
+    Ok(gen.into())
 }

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -1,24 +1,29 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_quote, Ident, ItemStruct, Type};
+use syn::{parse_quote, Field, Generics, Ident, ItemStruct, Type, TypePath};
 
 use crate::Result;
 
 pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream> {
     let struct_ident = &input_struct.ident;
     let (impl_generics, ty_generics, where_clause) = input_struct.generics.split_for_impl();
-    let (field_ident, field_type) = get_fields_map(&input_struct.fields)?;
-    let BufferStructConfig {
-        struct_name: buffer_struct_ident,
-    } = BufferStructConfig::from_data_struct(&input_struct);
+    let StructConfig {
+        buffer_struct_name: buffer_struct_ident,
+    } = StructConfig::from_data_struct(&input_struct);
     let buffer_struct_vis = &input_struct.vis;
+
+    let (field_ident, _, field_config) = get_fields_map(&input_struct.fields)?;
+    let buffer_type: Vec<&Type> = field_config
+        .iter()
+        .map(|config| &config.buffer_type)
+        .collect();
 
     let buffer_struct: ItemStruct = parse_quote! {
         #[derive(Clone)]
         #[allow(non_camel_case_types)]
         #buffer_struct_vis struct #buffer_struct_ident #impl_generics #where_clause {
             #(
-                #buffer_struct_vis #field_ident: ::bevy_impulse::Buffer<#field_type>,
+                #buffer_struct_vis #field_ident: #buffer_type,
             )*
         }
     };
@@ -36,7 +41,7 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
         impl #impl_generics #struct_ident #ty_generics #where_clause {
             fn select_buffers(
                 #(
-                    #field_ident: ::bevy_impulse::Buffer<#field_type>,
+                    #field_ident: #buffer_type,
                 )*
             ) -> #buffer_struct_ident #ty_generics {
                 #buffer_struct_ident {
@@ -55,14 +60,30 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
     Ok(gen.into())
 }
 
-struct BufferStructConfig {
-    struct_name: Ident,
+/// Converts a list of generics to a [`PhantomData`] TypePath.
+/// e.g. `::std::marker::PhantomData<(T,)>`
+// Currently unused but could be used in the future
+fn _to_phantom_data(generics: &Generics) -> TypePath {
+    let lifetimes: Vec<Type> = generics
+        .lifetimes()
+        .map(|lt| {
+            let lt = &lt.lifetime;
+            let ty: Type = parse_quote! { & #lt () };
+            ty
+        })
+        .collect();
+    let ty_params: Vec<&Ident> = generics.type_params().map(|ty| &ty.ident).collect();
+    parse_quote! { ::std::marker::PhantomData<(#(#lifetimes,)* #(#ty_params,)*)> }
 }
 
-impl BufferStructConfig {
+struct StructConfig {
+    buffer_struct_name: Ident,
+}
+
+impl StructConfig {
     fn from_data_struct(data_struct: &ItemStruct) -> Self {
         let mut config = Self {
-            struct_name: format_ident!("__bevy_impulse_{}_Buffers", data_struct.ident),
+            buffer_struct_name: format_ident!("__bevy_impulse_{}_Buffers", data_struct.ident),
         };
 
         let attr = data_struct
@@ -72,8 +93,8 @@ impl BufferStructConfig {
 
         if let Some(attr) = attr {
             attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("struct_name") {
-                    config.struct_name = meta.value()?.parse()?;
+                if meta.path.is_ident("buffer_struct_name") {
+                    config.buffer_struct_name = meta.value()?.parse()?;
                 }
                 Ok(())
             })
@@ -85,11 +106,43 @@ impl BufferStructConfig {
     }
 }
 
-fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>)> {
+struct FieldConfig {
+    buffer_type: Type,
+}
+
+impl FieldConfig {
+    fn from_field(field: &Field) -> Self {
+        let ty = &field.ty;
+        let mut config = Self {
+            buffer_type: parse_quote! { ::bevy_impulse::Buffer<#ty> },
+        };
+
+        let attr = field
+            .attrs
+            .iter()
+            .find(|attr| attr.path().is_ident("buffers"));
+
+        if let Some(attr) = attr {
+            attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("buffer_type") {
+                    config.buffer_type = meta.value()?.parse()?;
+                }
+                Ok(())
+            })
+            // panic if attribute is malformed, this will result in a compile error which is intended.
+            .unwrap();
+        }
+
+        config
+    }
+}
+
+fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<FieldConfig>)> {
     match fields {
         syn::Fields::Named(data) => {
             let mut idents = Vec::new();
             let mut types = Vec::new();
+            let mut configs = Vec::new();
             for field in &data.named {
                 let ident = field
                     .ident
@@ -97,8 +150,9 @@ fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>)> {
                     .ok_or("expected named fields".to_string())?;
                 idents.push(ident);
                 types.push(&field.ty);
+                configs.push(FieldConfig::from_field(field));
             }
-            Ok((idents, types))
+            Ok((idents, types, configs))
         }
         _ => return Err("expected named fields".to_string()),
     }
@@ -113,7 +167,11 @@ fn impl_buffer_map_layout(
 ) -> Result<proc_macro2::TokenStream> {
     let struct_ident = &buffer_struct.ident;
     let (impl_generics, ty_generics, where_clause) = buffer_struct.generics.split_for_impl();
-    let (field_ident, field_type) = get_fields_map(&item_struct.fields)?;
+    let (field_ident, _, field_config) = get_fields_map(&item_struct.fields)?;
+    let buffer_type: Vec<&Type> = field_config
+        .iter()
+        .map(|config| &config.buffer_type)
+        .collect();
     let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
 
     Ok(quote! {
@@ -128,16 +186,18 @@ fn impl_buffer_map_layout(
             fn try_from_buffer_map(buffers: &::bevy_impulse::BufferMap) -> Result<Self, ::bevy_impulse::IncompatibleLayout> {
                 let mut compatibility = ::bevy_impulse::IncompatibleLayout::default();
                 #(
-                    let #field_ident = if let Ok(buffer) = compatibility.require_message_type::<#field_type>(#map_key, buffers) {
+                    let #field_ident = if let Ok(buffer) = compatibility.require_buffer_type::<#buffer_type>(#map_key, buffers) {
                         buffer
                     } else {
                         return Err(compatibility);
                     };
                 )*
 
-                Ok(Self {#(
-                    #field_ident,
-                )*})
+                Ok(Self {
+                    #(
+                        #field_ident,
+                    )*
+                })
             }
         }
     }
@@ -154,7 +214,7 @@ fn impl_joined(
     let struct_ident = &joined_struct.ident;
     let item_struct_ident = &item_struct.ident;
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
-    let (field_ident, _) = get_fields_map(&item_struct.fields)?;
+    let (field_ident, _, _) = get_fields_map(&item_struct.fields)?;
 
     Ok(quote! {
         impl #impl_generics ::bevy_impulse::Joined for #struct_ident #ty_generics #where_clause {

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -31,6 +31,20 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
 
         #buffer_struct
 
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
+            fn select_buffers(
+                #(
+                    #field_ident: ::bevy_impulse::Buffer<#field_type>,
+                )*
+            ) -> #struct_buffer_ident #ty_generics {
+                #struct_buffer_ident {
+                    #(
+                        #field_ident,
+                    )*
+                }
+            }
+        }
+
         #impl_buffer_map_layout
 
         #impl_joined

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -147,7 +147,7 @@ pub(crate) fn impl_buffer_key_map(ast: DeriveInput) -> Result<TokenStream> {
         buffer_map_layout(&struct_ident, &field_ident, &field_type, &map_key);
 
     // FIXME(koonpeng): `create_key` does not allow failure and we can't guarantee that the buffer
-    // from buffer is valid.
+    // from the buffer map is valid.
     let gen = quote! {
         impl ::bevy_impulse::BufferKeyMap for #struct_ident {
             fn add_accessor(buffers: &::bevy_impulse::BufferMap, accessor: ::bevy_ecs::prelude::Entity, world: &mut ::bevy_ecs::prelude::World) -> ::bevy_impulse::OperationResult {

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -35,14 +35,13 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
 
         impl #impl_generics #struct_ident #ty_generics #where_clause {
             fn select_buffers(
-                builder: &mut ::bevy_impulse::Builder,
                 #(
-                    #field_ident: impl ::bevy_impulse::Bufferable<BufferType = ::bevy_impulse::Buffer<#field_type>>,
+                    #field_ident: ::bevy_impulse::Buffer<#field_type>,
                 )*
             ) -> #buffer_struct_ident #ty_generics {
                 #buffer_struct_ident {
                     #(
-                        #field_ident: #field_ident.into_buffer(builder),
+                        #field_ident,
                     )*
                 }
             }

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -150,7 +150,11 @@ impl FieldConfig {
             noncopy: false,
         };
 
-        for attr in field.attrs.iter().filter(|attr| attr.path().is_ident("joined")) {
+        for attr in field
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("joined"))
+        {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("buffer") {
                     config.buffer = meta.value()?.parse()?;

--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -60,20 +60,26 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
     Ok(gen.into())
 }
 
-/// Converts a list of generics to a [`PhantomData`] TypePath.
-/// e.g. `::std::marker::PhantomData<(T,)>`
-// Currently unused but could be used in the future
-fn _to_phantom_data(generics: &Generics) -> TypePath {
-    let lifetimes: Vec<Type> = generics
-        .lifetimes()
-        .map(|lt| {
-            let lt = &lt.lifetime;
-            let ty: Type = parse_quote! { & #lt () };
-            ty
-        })
-        .collect();
-    let ty_params: Vec<&Ident> = generics.type_params().map(|ty| &ty.ident).collect();
-    parse_quote! { ::std::marker::PhantomData<(#(#lifetimes,)* #(#ty_params,)*)> }
+/// Code that are currently unused but could be used in the future, move them out of this mod if
+/// they are ever used.
+#[allow(unused)]
+mod _unused {
+    use super::*;
+
+    /// Converts a list of generics to a [`PhantomData`] TypePath.
+    /// e.g. `::std::marker::PhantomData<fn(T,)>`
+    fn to_phantom_data(generics: &Generics) -> TypePath {
+        let lifetimes: Vec<Type> = generics
+            .lifetimes()
+            .map(|lt| {
+                let lt = &lt.lifetime;
+                let ty: Type = parse_quote! { & #lt () };
+                ty
+            })
+            .collect();
+        let ty_params: Vec<&Ident> = generics.type_params().map(|ty| &ty.ident).collect();
+        parse_quote! { ::std::marker::PhantomData<fn(#(#lifetimes,)* #(#ty_params,)*)> }
+    }
 }
 
 struct StructConfig {

--- a/macros/src/buffers.rs
+++ b/macros/src/buffers.rs
@@ -1,0 +1,118 @@
+use proc_macro::TokenStream;
+use quote::{format_ident, quote};
+use syn::{DeriveInput, Ident, Type};
+
+use crate::Result;
+
+pub(crate) fn impl_buffer_map_layout(ast: DeriveInput) -> Result<TokenStream> {
+    let struct_ident = ast.ident;
+    let (field_ident, field_type) = match ast.data {
+        syn::Data::Struct(data) => get_fields_map(data.fields)?,
+        _ => return Err("expected struct".to_string()),
+    };
+    let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
+    let struct_buffer_ident = format_ident!("__{}Buffers", struct_ident);
+
+    let gen = quote! {
+        impl BufferMapLayout for #struct_ident {
+            fn is_compatible(buffers: &BufferMap) -> Result<(), IncompatibleLayout> {
+                let mut compatibility = IncompatibleLayout::default();
+                #(
+                    compatibility.require_buffer::<#field_type>(#map_key, buffers);
+                )*
+                compatibility.into_result()
+            }
+
+            fn buffered_count(
+                buffers: &BufferMap,
+                session: Entity,
+                world: &World,
+            ) -> Result<usize, OperationError> {
+                #(
+                    let #field_ident = world
+                        .get_entity(buffers.get(#map_key).unwrap().id())
+                        .or_broken()?
+                        .buffered_count::<#field_type>(session)?;
+                )*
+
+                Ok([#( #field_ident ),*]
+                    .iter()
+                    .min()
+                    .copied()
+                    .unwrap_or(0))
+            }
+
+            fn ensure_active_session(
+                buffers: &BufferMap,
+                session: Entity,
+                world: &mut World,
+            ) -> OperationResult {
+                #(
+                    world
+                        .get_entity_mut(buffers.get(#map_key).unwrap().id())
+                        .or_broken()?
+                        .ensure_session::<#field_type>(session)?;
+                )*
+
+                Ok(())
+            }
+        }
+
+        impl JoinedValue for #struct_ident {
+            type Buffers = #struct_buffer_ident;
+
+            fn pull(
+                buffers: &BufferMap,
+                session: Entity,
+                world: &mut World,
+            ) -> Result<Self, OperationError> {
+                #(
+                    let #field_ident = world
+                        .get_entity_mut(buffers.get(#map_key).unwrap().id())
+                        .or_broken()?
+                        .pull_from_buffer::<#field_type>(session)?;
+                )*
+
+                Ok(Self {
+                    #(
+                        #field_ident
+                    ),*
+                })
+            }
+        }
+
+        struct #struct_buffer_ident {
+            #(
+                #field_ident: Buffer<#field_type>
+            ),*
+        }
+
+        impl From<#struct_buffer_ident> for BufferMap {
+            fn from(value: #struct_buffer_ident) -> Self {
+                let mut buffers = BufferMap::default();
+                #(
+                    buffers.insert(Cow::Borrowed(#map_key), value.#field_ident);
+                )*
+                buffers
+            }
+        }
+    };
+
+    Ok(gen.into())
+}
+
+fn get_fields_map(fields: syn::Fields) -> Result<(Vec<Ident>, Vec<Type>)> {
+    match fields {
+        syn::Fields::Named(data) => {
+            let mut idents = Vec::with_capacity(data.named.len());
+            let mut types = Vec::with_capacity(data.named.len());
+            for field in data.named {
+                let ident = field.ident.ok_or("expected named fields".to_string())?;
+                idents.push(ident);
+                types.push(field.ty);
+            }
+            Ok((idents, types))
+        }
+        _ => return Err("expected named fields".to_string()),
+    }
+}

--- a/macros/src/buffers.rs
+++ b/macros/src/buffers.rs
@@ -30,7 +30,7 @@ pub(crate) fn impl_buffer_map_layout(ast: DeriveInput) -> Result<TokenStream> {
             ) -> Result<usize, OperationError> {
                 #(
                     let #field_ident = world
-                        .get_entity(buffers.get(#map_key).unwrap().id())
+                        .get_entity(buffers.get(#map_key).or_broken()?.id())
                         .or_broken()?
                         .buffered_count::<#field_type>(session)?;
                 )*
@@ -49,7 +49,7 @@ pub(crate) fn impl_buffer_map_layout(ast: DeriveInput) -> Result<TokenStream> {
             ) -> OperationResult {
                 #(
                     world
-                        .get_entity_mut(buffers.get(#map_key).unwrap().id())
+                        .get_entity_mut(buffers.get(#map_key).or_broken()?.id())
                         .or_broken()?
                         .ensure_session::<#field_type>(session)?;
                 )*
@@ -68,7 +68,7 @@ pub(crate) fn impl_buffer_map_layout(ast: DeriveInput) -> Result<TokenStream> {
             ) -> Result<Self, OperationError> {
                 #(
                     let #field_ident = world
-                        .get_entity_mut(buffers.get(#map_key).unwrap().id())
+                        .get_entity_mut(buffers.get(#map_key).or_broken()?.id())
                         .or_broken()?
                         .pull_from_buffer::<#field_type>(session)?;
                 )*

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -65,7 +65,7 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
 /// The result error is the compiler error message to be displayed.
 type Result<T> = std::result::Result<T, String>;
 
-#[proc_macro_derive(JoinedValue, attributes(bevy_impulse))]
+#[proc_macro_derive(JoinedValue, attributes(buffers))]
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_joined_value(&input) {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,8 +15,8 @@
  *
 */
 
-mod buffers;
-use buffers::impl_buffer_map_layout;
+mod buffer;
+use buffer::impl_joined_value;
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -65,10 +65,10 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
 // The result error is the compiler error message to be displayed.
 type Result<T> = std::result::Result<T, String>;
 
-#[proc_macro_derive(Joined)]
-pub fn derive_joined(input: TokenStream) -> TokenStream {
+#[proc_macro_derive(JoinedValue)]
+pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    match impl_buffer_map_layout(input) {
+    match impl_joined_value(input) {
         Ok(tokens) => tokens,
         Err(msg) => quote! {
             compile_error!(#msg);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -65,11 +65,11 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
 /// The result error is the compiler error message to be displayed.
 type Result<T> = std::result::Result<T, String>;
 
-#[proc_macro_derive(JoinedValue)]
+#[proc_macro_derive(JoinedValue, attributes(bevy_impulse))]
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_joined_value(&input) {
-        Ok(tokens) => tokens,
+        Ok(tokens) => tokens.into(),
         Err(msg) => quote! {
             compile_error!(#msg);
         }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -20,7 +20,7 @@ use buffer::impl_joined_value;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, DeriveInput, ItemStruct};
 
 #[proc_macro_derive(Stream)]
 pub fn simple_stream_macro(item: TokenStream) -> TokenStream {
@@ -67,8 +67,8 @@ type Result<T> = std::result::Result<T, String>;
 
 #[proc_macro_derive(JoinedValue)]
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
-    match impl_joined_value(input) {
+    let input = parse_macro_input!(input as ItemStruct);
+    match impl_joined_value(&input) {
         Ok(tokens) => tokens,
         Err(msg) => quote! {
             compile_error!(#msg);

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,9 +15,12 @@
  *
 */
 
+mod buffers;
+use buffers::impl_buffer_map_layout;
+
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::DeriveInput;
+use syn::{parse_macro_input, DeriveInput};
 
 #[proc_macro_derive(Stream)]
 pub fn simple_stream_macro(item: TokenStream) -> TokenStream {
@@ -57,4 +60,19 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
         }
     }
     .into()
+}
+
+// The result error is the compiler error message to be displayed.
+type Result<T> = std::result::Result<T, String>;
+
+#[proc_macro_derive(Joined)]
+pub fn derive_joined(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match impl_buffer_map_layout(input) {
+        Ok(tokens) => tokens,
+        Err(msg) => quote! {
+            compile_error!(#msg);
+        }
+        .into(),
+    }
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -65,7 +65,7 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
 /// The result error is the compiler error message to be displayed.
 type Result<T> = std::result::Result<T, String>;
 
-#[proc_macro_derive(JoinedValue, attributes(buffers))]
+#[proc_macro_derive(JoinedValue, attributes(joined))]
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_joined_value(&input) {

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -62,7 +62,7 @@ pub fn delivery_label_macro(item: TokenStream) -> TokenStream {
     .into()
 }
 
-// The result error is the compiler error message to be displayed.
+/// The result error is the compiler error message to be displayed.
 type Result<T> = std::result::Result<T, String>;
 
 #[proc_macro_derive(JoinedValue)]

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -16,7 +16,7 @@
 */
 
 mod buffer;
-use buffer::impl_joined_value;
+use buffer::{impl_buffer_key_map, impl_joined_value};
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -69,6 +69,18 @@ type Result<T> = std::result::Result<T, String>;
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     match impl_joined_value(input) {
+        Ok(tokens) => tokens,
+        Err(msg) => quote! {
+            compile_error!(#msg);
+        }
+        .into(),
+    }
+}
+
+#[proc_macro_derive(BufferKeyMap)]
+pub fn derive_buffer_key_map(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    match impl_buffer_key_map(input) {
         Ok(tokens) => tokens,
         Err(msg) => quote! {
             compile_error!(#msg);

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -176,11 +176,11 @@ impl AnyBufferKey {
         self.tag.session
     }
 
-    fn is_in_use(&self) -> bool {
+    pub fn is_in_use(&self) -> bool {
         self.tag.is_in_use()
     }
 
-    fn deep_clone(&self) -> Self {
+    pub fn deep_clone(&self) -> Self {
         Self {
             tag: self.tag.deep_clone(),
             interface: self.interface,
@@ -204,6 +204,14 @@ impl<T: 'static + Send + Sync + Any> From<BufferKey<T>> for AnyBufferKey {
             tag: value.tag,
             interface,
         }
+    }
+}
+
+impl<T: 'static + Send + Sync + Any> TryFrom<AnyBufferKey> for BufferKey<T> {
+    type Error = OperationError;
+
+    fn try_from(value: AnyBufferKey) -> Result<Self, Self::Error> {
+        value.downcast_for_message().or_broken()
     }
 }
 

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -861,6 +861,17 @@ impl<T: 'static + Send + Sync> AnyBufferAccessImpl<T> {
             })),
         );
 
+        // Allow downcasting back to the original Buffer<T>
+        buffer_downcasts.insert(
+            TypeId::of::<Buffer<T>>(),
+            Box::leak(Box::new(|location| -> Box<dyn Any> {
+                Box::new(Buffer::<T> {
+                    location,
+                    _ignore: Default::default(),
+                })
+            })),
+        );
+
         let mut key_downcasts: HashMap<_, KeyDowncastRef> = HashMap::new();
 
         // Automatically register a downcast to AnyBufferKey

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -86,6 +86,10 @@ impl AnyBuffer {
             .entry(TypeId::of::<T>())
             .or_insert_with(|| Box::leak(Box::new(AnyBufferAccessImpl::<T>::new())))
     }
+
+    pub fn as_any_buffer(self) -> AnyBuffer {
+        self
+    }
 }
 
 impl std::fmt::Debug for AnyBuffer {

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -86,10 +86,6 @@ impl AnyBuffer {
             .entry(TypeId::of::<T>())
             .or_insert_with(|| Box::leak(Box::new(AnyBufferAccessImpl::<T>::new())))
     }
-
-    pub fn as_any_buffer(self) -> AnyBuffer {
-        self
-    }
 }
 
 impl std::fmt::Debug for AnyBuffer {
@@ -212,14 +208,6 @@ impl<T: 'static + Send + Sync + Any> From<BufferKey<T>> for AnyBufferKey {
             tag: value.tag,
             interface,
         }
-    }
-}
-
-impl<T: 'static + Send + Sync + Any> TryFrom<AnyBufferKey> for BufferKey<T> {
-    type Error = OperationError;
-
-    fn try_from(value: AnyBufferKey) -> Result<Self, Self::Error> {
-        value.downcast_for_message().or_broken()
     }
 }
 

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -121,6 +121,10 @@ impl AnyBuffer {
             .ok()
             .map(|x| *x)
     }
+
+    pub fn as_any_buffer(&self) -> Self {
+        self.clone().into()
+    }
 }
 
 impl<T: 'static + Send + Sync + Any> From<Buffer<T>> for AnyBuffer {

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -29,7 +29,7 @@ use crate::{
     OperationRoster, Output, UnusedTarget,
 };
 
-pub use bevy_impulse_derive::JoinedValue;
+pub use bevy_impulse_derive::{BufferKeyMap, JoinedValue};
 
 #[derive(Clone, Default)]
 pub struct BufferMap {
@@ -408,5 +408,13 @@ mod tests {
         assert_eq!(value.float, 3.14);
         assert_eq!(value.string, "hello");
         assert!(context.no_unhandled_errors());
+    }
+
+    // TODO(koonpeng): Add test that uses `TestBufferKeyMap`.
+    #[derive(Clone, BufferKeyMap)]
+    struct TestBufferKeyMap {
+        integer: BufferKey<i64>,
+        float: BufferKey<f64>,
+        string: AnyBufferKey,
     }
 }

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -358,7 +358,7 @@ mod tests {
         let mut promise = context.command(|commands| {
             commands
                 .request(
-                    (5_i64, 3.14_f64, "hello".to_string(), "world", ()),
+                    (5_i64, 3.14_f64, "hello".to_string(), "world", 42_i64),
                     workflow,
                 )
                 .take_response()
@@ -370,6 +370,7 @@ mod tests {
         assert_eq!(value.float, 3.14);
         assert_eq!(value.string, "hello");
         assert_eq!(value.generic, "world");
+        assert_eq!(*value.any.downcast::<i64>().unwrap(), 42);
         assert!(context.no_unhandled_errors());
     }
 
@@ -382,7 +383,7 @@ mod tests {
             let buffer_f64 = builder.create_buffer(BufferSettings::default());
             let buffer_string = builder.create_buffer(BufferSettings::default());
             let buffer_generic = builder.create_buffer(BufferSettings::default());
-            let buffer_any = builder.create_buffer::<()>(BufferSettings::default());
+            let buffer_any = builder.create_buffer::<i64>(BufferSettings::default());
 
             scope.input.chain(builder).fork_unzip((
                 |chain: Chain<_>| chain.connect(buffer_i64.input_slot()),
@@ -406,7 +407,7 @@ mod tests {
         let mut promise = context.command(|commands| {
             commands
                 .request(
-                    (5_i64, 3.14_f64, "hello".to_string(), "world", ()),
+                    (5_i64, 3.14_f64, "hello".to_string(), "world", 42_i64),
                     workflow,
                 )
                 .take_response()
@@ -418,6 +419,7 @@ mod tests {
         assert_eq!(value.float, 3.14);
         assert_eq!(value.string, "hello");
         assert_eq!(value.generic, "world");
+        assert_eq!(*value.any.downcast::<i64>().unwrap(), 42);
         assert!(context.no_unhandled_errors());
     }
 
@@ -435,7 +437,7 @@ mod tests {
             let buffer_generic =
                 JsonBuffer::from(builder.create_buffer::<String>(BufferSettings::default()));
             let buffer_any =
-                JsonBuffer::from(builder.create_buffer::<()>(BufferSettings::default()));
+                JsonBuffer::from(builder.create_buffer::<i64>(BufferSettings::default()));
 
             let buffers = TestJoinedValue::select_buffers(
                 buffer_i64.downcast_for_message().unwrap(),
@@ -466,7 +468,7 @@ mod tests {
                         3.14_f64,
                         "hello".to_string(),
                         "world".to_string(),
-                        (),
+                        42_i64,
                     ),
                     workflow,
                 )
@@ -479,6 +481,7 @@ mod tests {
         assert_eq!(value.float, 3.14);
         assert_eq!(value.string, "hello");
         assert_eq!(value.generic, "world");
+        assert_eq!(*value.any.downcast::<i64>().unwrap(), 42);
         assert!(context.no_unhandled_errors());
     }
 

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -369,12 +369,12 @@ mod tests {
         let mut context = TestingContext::minimal_plugins();
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
-            let buffers = __bevy_impulse_TestJoinedValue_Buffers {
-                integer: builder.create_buffer(BufferSettings::default()),
-                float: builder.create_buffer(BufferSettings::default()),
-                string: builder.create_buffer(BufferSettings::default()),
-                generic: builder.create_buffer(BufferSettings::default()),
-            };
+            let buffers = TestJoinedValue::select_buffers(
+                builder.create_buffer(BufferSettings::default()),
+                builder.create_buffer(BufferSettings::default()),
+                builder.create_buffer(BufferSettings::default()),
+                builder.create_buffer(BufferSettings::default()),
+            );
 
             scope.input.chain(builder).fork_unzip((
                 |chain: Chain<_>| chain.connect(buffers.integer.input_slot()),

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -406,4 +406,14 @@ mod tests {
         assert_eq!(value.generic, "world");
         assert!(context.no_unhandled_errors());
     }
+
+    #[derive(Clone, JoinedValue)]
+    #[buffers(struct_name = FooBuffers)]
+    struct TestDeriveWithConfig {}
+
+    #[test]
+    fn test_derive_with_config() {
+        // a compile test to check that the name of the generated struct is correct
+        fn _check_buffer_struct_name(_: FooBuffers) {}
+    }
 }

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -423,68 +423,6 @@ mod tests {
         assert!(context.no_unhandled_errors());
     }
 
-    #[test]
-    fn test_select_buffers_json() {
-        let mut context = TestingContext::minimal_plugins();
-
-        let workflow = context.spawn_io_workflow(|scope, builder| {
-            let buffer_i64 =
-                JsonBuffer::from(builder.create_buffer::<i64>(BufferSettings::default()));
-            let buffer_f64 =
-                JsonBuffer::from(builder.create_buffer::<f64>(BufferSettings::default()));
-            let buffer_string =
-                JsonBuffer::from(builder.create_buffer::<String>(BufferSettings::default()));
-            let buffer_generic =
-                JsonBuffer::from(builder.create_buffer::<String>(BufferSettings::default()));
-            let buffer_any =
-                JsonBuffer::from(builder.create_buffer::<i64>(BufferSettings::default()));
-
-            let buffers = TestJoinedValue::select_buffers(
-                buffer_i64.downcast_for_message().unwrap(),
-                buffer_f64.downcast_for_message().unwrap(),
-                buffer_string.downcast_for_message().unwrap(),
-                buffer_generic.downcast_for_message().unwrap(),
-                buffer_any.downcast_buffer().unwrap(),
-            );
-
-            scope.input.chain(builder).fork_unzip((
-                |chain: Chain<_>| chain.connect(buffers.integer.input_slot()),
-                |chain: Chain<_>| chain.connect(buffers.float.input_slot()),
-                |chain: Chain<_>| chain.connect(buffers.string.input_slot()),
-                |chain: Chain<_>| chain.connect(buffers.generic.input_slot()),
-                |chain: Chain<_>| {
-                    chain.connect(buffers.any.downcast_for_message().unwrap().input_slot())
-                },
-            ));
-
-            builder.join(buffers).connect(scope.terminate);
-        });
-
-        let mut promise = context.command(|commands| {
-            commands
-                .request(
-                    (
-                        5_i64,
-                        3.14_f64,
-                        "hello".to_string(),
-                        "world".to_string(),
-                        42_i64,
-                    ),
-                    workflow,
-                )
-                .take_response()
-        });
-
-        context.run_with_conditions(&mut promise, Duration::from_secs(2));
-        let value: TestJoinedValue<String> = promise.take().available().unwrap();
-        assert_eq!(value.integer, 5);
-        assert_eq!(value.float, 3.14);
-        assert_eq!(value.string, "hello");
-        assert_eq!(value.generic, "world");
-        assert_eq!(*value.any.downcast::<i64>().unwrap(), 42);
-        assert!(context.no_unhandled_errors());
-    }
-
     #[derive(Clone, JoinedValue)]
     #[buffers(buffer_struct_name = FooBuffers)]
     struct TestDeriveWithConfig {}

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -375,7 +375,6 @@ mod tests {
         let mut context = TestingContext::minimal_plugins();
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
-            // ::bevy_impulse::OrBroken::or_broken(self)
             let buffer_i64 = builder.create_buffer(BufferSettings::default());
             let buffer_f64 = builder.create_buffer(BufferSettings::default());
             let buffer_string = builder.create_buffer(BufferSettings::default());

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -369,11 +369,17 @@ mod tests {
         let mut context = TestingContext::minimal_plugins();
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
+            let buffer_i64 = builder.create_buffer(BufferSettings::default());
+            let buffer_f64 = builder.create_buffer(BufferSettings::default());
+            let buffer_string = builder.create_buffer(BufferSettings::default());
+            let buffer_generic = builder.create_buffer(BufferSettings::default());
+
             let buffers = TestJoinedValue::select_buffers(
-                builder.create_buffer(BufferSettings::default()),
-                builder.create_buffer(BufferSettings::default()),
-                builder.create_buffer(BufferSettings::default()),
-                builder.create_buffer(BufferSettings::default()),
+                builder,
+                buffer_i64,
+                buffer_f64,
+                buffer_string,
+                buffer_generic,
             );
 
             scope.input.chain(builder).fork_unzip((

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -365,119 +365,13 @@ mod tests {
     };
 
     use bevy_ecs::prelude::World;
+    use bevy_impulse_derive::Joined;
 
-    #[derive(Clone)]
+    #[derive(Clone, Joined)]
     struct TestJoinedValue {
         integer: i64,
         float: f64,
         string: String,
-    }
-
-    impl BufferMapLayout for TestJoinedValue {
-        fn is_compatible(buffers: &BufferMap) -> Result<(), IncompatibleLayout> {
-            let mut compatibility = IncompatibleLayout::default();
-            compatibility.require_buffer::<i64>("integer", buffers);
-            compatibility.require_buffer::<f64>("float", buffers);
-            compatibility.require_buffer::<String>("string", buffers);
-            compatibility.into_result()
-        }
-
-        fn buffered_count(
-            buffers: &BufferMap,
-            session: Entity,
-            world: &World,
-        ) -> Result<usize, OperationError> {
-            let integer_count = world
-                .get_entity(buffers.get("integer").unwrap().id())
-                .or_broken()?
-                .buffered_count::<i64>(session)?;
-
-            let float_count = world
-                .get_entity(buffers.get("float").unwrap().id())
-                .or_broken()?
-                .buffered_count::<f64>(session)?;
-
-            let string_count = world
-                .get_entity(buffers.get("string").unwrap().id())
-                .or_broken()?
-                .buffered_count::<String>(session)?;
-
-            Ok([integer_count, float_count, string_count]
-                .iter()
-                .min()
-                .copied()
-                .unwrap_or(0))
-        }
-
-        fn ensure_active_session(
-            buffers: &BufferMap,
-            session: Entity,
-            world: &mut World,
-        ) -> OperationResult {
-            world
-                .get_entity_mut(buffers.get("integer").unwrap().id())
-                .or_broken()?
-                .ensure_session::<i64>(session)?;
-
-            world
-                .get_entity_mut(buffers.get("float").unwrap().id())
-                .or_broken()?
-                .ensure_session::<f64>(session)?;
-
-            world
-                .get_entity_mut(buffers.get("string").unwrap().id())
-                .or_broken()?
-                .ensure_session::<String>(session)?;
-
-            Ok(())
-        }
-    }
-
-    impl JoinedValue for TestJoinedValue {
-        type Buffers = TestJoinedValueBuffers;
-
-        fn pull(
-            buffers: &BufferMap,
-            session: Entity,
-            world: &mut World,
-        ) -> Result<Self, OperationError> {
-            let integer = world
-                .get_entity_mut(buffers.get("integer").unwrap().id())
-                .or_broken()?
-                .pull_from_buffer::<i64>(session)?;
-
-            let float = world
-                .get_entity_mut(buffers.get("float").unwrap().id())
-                .or_broken()?
-                .pull_from_buffer::<f64>(session)?;
-
-            let string = world
-                .get_entity_mut(buffers.get("string").unwrap().id())
-                .or_broken()?
-                .pull_from_buffer::<String>(session)?;
-
-            Ok(Self {
-                integer,
-                float,
-                string,
-            })
-        }
-    }
-
-    struct TestJoinedValueBuffers {
-        integer: Buffer<i64>,
-        float: Buffer<f64>,
-        string: Buffer<String>,
-    }
-
-    impl From<TestJoinedValueBuffers> for BufferMap {
-        fn from(value: TestJoinedValueBuffers) -> Self {
-            let mut buffers = BufferMap::default();
-            buffers.insert(Cow::Borrowed("integer"), value.integer);
-            buffers.insert(Cow::Borrowed("float"), value.float);
-            buffers.insert(Cow::Borrowed("string"), value.string);
-            buffers
-        }
     }
 
     #[test]

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -321,8 +321,7 @@ mod tests {
         float: f64,
         string: String,
         generic: T,
-        #[buffers(buffer_type = AnyBuffer)]
-        #[allow(unused)]
+        #[joined(buffer = AnyBuffer)]
         any: AnyMessageBox,
     }
 
@@ -424,7 +423,7 @@ mod tests {
     }
 
     #[derive(Clone, JoinedValue)]
-    #[buffers(buffer_struct_name = FooBuffers)]
+    #[joined(buffers_struct_name = FooBuffers)]
     struct TestDeriveWithConfig {}
 
     #[test]

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -29,6 +29,8 @@ use crate::{
     OperationRoster, Output, UnusedTarget,
 };
 
+pub use bevy_impulse_derive::JoinedValue;
+
 #[derive(Clone, Default)]
 pub struct BufferMap {
     inner: HashMap<Cow<'static, str>, AnyBuffer>,
@@ -359,15 +361,9 @@ impl BufferMapLayout for AnyBufferKeyMap {
 mod tests {
     use std::borrow::Cow;
 
-    use crate::{
-        prelude::*, testing::*, BufferMap, InspectBuffer, ManageBuffer, OperationError,
-        OperationResult, OrBroken,
-    };
+    use crate::{prelude::*, testing::*, BufferMap};
 
-    use bevy_ecs::prelude::World;
-    use bevy_impulse_derive::Joined;
-
-    #[derive(Clone, Joined)]
+    #[derive(Clone, JoinedValue)]
     struct TestJoinedValue {
         integer: i64,
         float: f64,
@@ -379,6 +375,7 @@ mod tests {
         let mut context = TestingContext::minimal_plugins();
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
+            // ::bevy_impulse::OrBroken::or_broken(self)
             let buffer_i64 = builder.create_buffer(BufferSettings::default());
             let buffer_f64 = builder.create_buffer(BufferSettings::default());
             let buffer_string = builder.create_buffer(BufferSettings::default());

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1354,11 +1354,11 @@ mod tests {
     }
 
     #[derive(Clone, JoinedValue)]
-    #[buffers(buffer_struct_name = TestJoinedValueJsonBuffers)]
+    #[joined(buffers_struct_name = TestJoinedValueJsonBuffers)]
     struct TestJoinedValueJson {
         integer: i64,
         float: f64,
-        #[buffers(buffer_type = JsonBuffer)]
+        #[joined(buffer = JsonBuffer)]
         json: JsonMessage,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,8 @@ pub use trim::*;
 use bevy_app::prelude::{App, Plugin, Update};
 use bevy_ecs::prelude::{Entity, In};
 
+extern crate self as bevy_impulse;
+
 /// Use `BlockingService` to indicate that your system is a blocking [`Service`].
 ///
 /// A blocking service will have exclusive world access while it runs, which

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -32,11 +32,11 @@ pub use std::time::{Duration, Instant};
 use smallvec::SmallVec;
 
 use crate::{
-    flush_impulses, AddContinuousServicesExt, AsyncServiceInput, BlockingMap, BlockingServiceInput,
-    Builder, ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
-    GetBufferedSessionsFn, Promise, RunCommandsOnWorldExt, Scope, Service, SpawnWorkflowExt,
-    StreamOf, StreamPack, UnhandledErrors, WorkflowSettings, OperationRoster, OperationResult,
-    OperationError, Buffered, Bufferable, Joined, Buffer, Accessed, BufferKey, AnyBuffer,
+    flush_impulses, Accessed, AddContinuousServicesExt, AnyBuffer, AsyncServiceInput, BlockingMap,
+    BlockingServiceInput, Buffer, BufferKey, Bufferable, Buffered, Builder, ContinuousQuery,
+    ContinuousQueueView, ContinuousService, FlushParameters, GetBufferedSessionsFn, Joined,
+    OperationError, OperationResult, OperationRoster, Promise, RunCommandsOnWorldExt, Scope,
+    Service, SpawnWorkflowExt, StreamOf, StreamPack, UnhandledErrors, WorkflowSettings,
 };
 
 pub struct TestingContext {
@@ -494,9 +494,12 @@ impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
             std::any::TypeId::of::<NonCopyBuffer<T>>(),
             Box::new(|location| {
                 Box::new(NonCopyBuffer::<T> {
-                    inner: Buffer { location, _ignore: Default::default() },
+                    inner: Buffer {
+                        location,
+                        _ignore: Default::default(),
+                    },
                 })
-            })
+            }),
         );
     }
 }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -19,7 +19,7 @@ use bevy_app::ScheduleRunnerPlugin;
 pub use bevy_app::{App, Update};
 use bevy_core::{FrameCountPlugin, TaskPoolPlugin, TypeRegistrationPlugin};
 pub use bevy_ecs::{
-    prelude::{Commands, Component, Entity, In, Local, Query, ResMut, Resource},
+    prelude::{Commands, Component, Entity, In, Local, Query, ResMut, Resource, World},
     system::{CommandQueue, IntoSystem},
 };
 use bevy_time::TimePlugin;
@@ -35,7 +35,8 @@ use crate::{
     flush_impulses, AddContinuousServicesExt, AsyncServiceInput, BlockingMap, BlockingServiceInput,
     Builder, ContinuousQuery, ContinuousQueueView, ContinuousService, FlushParameters,
     GetBufferedSessionsFn, Promise, RunCommandsOnWorldExt, Scope, Service, SpawnWorkflowExt,
-    StreamOf, StreamPack, UnhandledErrors, WorkflowSettings,
+    StreamOf, StreamPack, UnhandledErrors, WorkflowSettings, OperationRoster, OperationResult,
+    OperationError, Buffered, Bufferable, Joined, Buffer, Accessed, BufferKey, AnyBuffer,
 };
 
 pub struct TestingContext {
@@ -477,4 +478,102 @@ pub struct TestComponent;
 #[derive(Component, Resource)]
 pub struct Integer {
     pub value: i32,
+}
+
+/// This is an ordinary buffer newtype whose only purpose is to test the
+/// #[joined(noncopy_buffer)] feature. We intentionally do not implement
+/// the Copy trait for it.
+pub struct NonCopyBuffer<T> {
+    inner: Buffer<T>,
+}
+
+impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
+    pub fn register_downcast() {
+        let any_interface = AnyBuffer::interface_for::<T>();
+        any_interface.register_buffer_downcast(
+            std::any::TypeId::of::<NonCopyBuffer<T>>(),
+            Box::new(|location| {
+                Box::new(NonCopyBuffer::<T> {
+                    inner: Buffer { location, _ignore: Default::default() },
+                })
+            })
+        );
+    }
+}
+
+impl<T: 'static + Send + Sync> NonCopyBuffer<T> {
+    pub fn as_any_buffer(&self) -> AnyBuffer {
+        self.inner.as_any_buffer()
+    }
+}
+
+impl<T> Clone for NonCopyBuffer<T> {
+    fn clone(&self) -> Self {
+        Self { inner: self.inner }
+    }
+}
+
+impl<T: 'static + Send + Sync> Bufferable for NonCopyBuffer<T> {
+    type BufferType = Self;
+    fn into_buffer(self, _builder: &mut Builder) -> Self::BufferType {
+        self
+    }
+}
+
+impl<T: 'static + Send + Sync> Buffered for NonCopyBuffer<T> {
+    fn add_listener(&self, listener: Entity, world: &mut World) -> OperationResult {
+        self.inner.add_listener(listener, world)
+    }
+
+    fn as_input(&self) -> smallvec::SmallVec<[Entity; 8]> {
+        self.inner.as_input()
+    }
+
+    fn buffered_count(&self, session: Entity, world: &World) -> Result<usize, OperationError> {
+        self.inner.buffered_count(session, world)
+    }
+
+    fn ensure_active_session(&self, session: Entity, world: &mut World) -> OperationResult {
+        self.inner.ensure_active_session(session, world)
+    }
+
+    fn gate_action(
+        &self,
+        session: Entity,
+        action: crate::Gate,
+        world: &mut World,
+        roster: &mut OperationRoster,
+    ) -> OperationResult {
+        self.inner.gate_action(session, action, world, roster)
+    }
+
+    fn verify_scope(&self, scope: Entity) {
+        self.inner.verify_scope(scope);
+    }
+}
+
+impl<T: 'static + Send + Sync> Joined for NonCopyBuffer<T> {
+    type Item = T;
+    fn pull(&self, session: Entity, world: &mut World) -> Result<Self::Item, OperationError> {
+        self.inner.pull(session, world)
+    }
+}
+
+impl<T: 'static + Send + Sync> Accessed for NonCopyBuffer<T> {
+    type Key = BufferKey<T>;
+    fn add_accessor(&self, accessor: Entity, world: &mut World) -> OperationResult {
+        self.inner.add_accessor(accessor, world)
+    }
+
+    fn create_key(&self, builder: &crate::BufferKeyBuilder) -> Self::Key {
+        self.inner.create_key(builder)
+    }
+
+    fn deep_clone_key(key: &Self::Key) -> Self::Key {
+        key.deep_clone()
+    }
+
+    fn is_key_in_use(key: &Self::Key) -> bool {
+        key.is_in_use()
+    }
 }


### PR DESCRIPTION
### Status:

Updated to the new `join` api. Added derive helper attributes, but the only config now is to change the generated buffer struct name.

* With `select_buffers` there should no longer be a need to change the buffer type. Allowing to customize the types also lead to other issues as explained in https://github.com/open-rmf/bevy_impulse/pull/53#issuecomment-2652846213.
* It is not possible to change expose pub idents in a private span and vice versa ([E0446](https://doc.rust-lang.org/error_codes/E0446.html)). In derive macros, my guess is that it inherits the visibility of the target struct, attempting to generate structs with different visibility than the original will result in E0446.

---

For now only struct with named fields is supported, tuple struct or newtype struct doesn't make sense as a buffer map layout. enums are questionable but they will require more logic to validate and select which branch to use.