### PR TITLE
Lock in "js" feature for uuid on wasm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ tracing = "0.1.41"
 strum = { version = "0.26.3", optional = true, features = ["derive"] }
 semver = { version = "1.0.24", optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+uuid = { version = "1.13.1", default-features = false, features = ["js"] }
+
 [features]
 single_threaded_async = ["dep:async-task"]
 diagram = [


### PR DESCRIPTION
An [update to `uuid`](https://github.com/uuid-rs/uuid/pull/797) now requires the `js` feature to be explicitly enabled when targeting wasm. The latest version of bevy has [fixed this upstream](https://github.com/bevyengine/bevy/pull/17689), but our `main` is still depending on bevy 0.12, which so far has not been updated.

There are two ways we can fix this for ourselves:
1. Lock the version of `uuid` down to a known-good version, such as 1.4.1
2. Lock the version of `uuid` up to 1.13.1 and then explicitly enable the `js` feature

I've opted for (2) so that we don't lose the benefit of whatever updates come into the `uuid` library over time.

I've already tested that these changes work for the web build of `rmf_site_editor`, although we will probably need to do a `cargo update` on the lockfile of the site editor.