### PR TITLE
avoid conflict in Promise and Iterator

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1198,7 +1198,9 @@ mod tests {
             context.command(|commands| commands.request(input, workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(2));
-        assert!(promise.take().available().is_some_and(|v| v == expectation));
+        assert!(Promise::take(&mut promise)
+            .available()
+            .is_some_and(|v| v == expectation));
         assert!(context.no_unhandled_errors());
     }
 }


### PR DESCRIPTION
Not sure if it is just me but rust-analyzer thinks `Promise` is an `Iterator` and `Promise::take` conflicts with `Iterator::take`. Switched to the full form avoid the conflict.