### PR TITLE
BufferKeyMap macro

### DIFF
--- a/macros/src/buffer.rs
+++ b/macros/src/buffer.rs
@@ -1,58 +1,60 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_quote, Field, Generics, Ident, ItemStruct, Type, TypePath};
+use syn::{
+    parse_quote, Field, Generics, Ident, ImplGenerics, ItemStruct, Type, TypeGenerics, TypePath,
+    Visibility, WhereClause,
+};
 
 use crate::Result;
+
+const JOINED_ATTR_TAG: &'static str = "joined";
+const KEY_ATTR_TAG: &'static str = "key";
 
 pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream> {
     let struct_ident = &input_struct.ident;
     let (impl_generics, ty_generics, where_clause) = input_struct.generics.split_for_impl();
     let StructConfig {
         buffer_struct_name: buffer_struct_ident,
-    } = StructConfig::from_data_struct(&input_struct);
+    } = StructConfig::from_data_struct(&input_struct, &JOINED_ATTR_TAG);
     let buffer_struct_vis = &input_struct.vis;
 
-    let (field_ident, _, field_config) = get_fields_map(&input_struct.fields)?;
+    let (field_ident, _, field_config) =
+        get_fields_map(&input_struct.fields, FieldSettings::for_joined())?;
     let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
     let noncopy = field_config.iter().any(|config| config.noncopy);
 
-    let buffer_struct: ItemStruct = parse_quote! {
-        #[allow(non_camel_case_types, unused)]
-        #buffer_struct_vis struct #buffer_struct_ident #impl_generics #where_clause {
-            #(
-                #buffer_struct_vis #field_ident: #buffer,
-            )*
-        }
-    };
+    let buffer_struct: ItemStruct = generate_buffer_struct(
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
 
-    let impl_buffer_clone = if noncopy {
-        // Clone impl for structs with a buffer that is not copyable
-        quote! {
-            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
-                fn clone(&self) -> Self {
-                    Self {
-                        #(
-                            #field_ident: self.#field_ident.clone(),
-                        )*
-                    }
-                }
-            }
-        }
-    } else {
-        // Clone and copy impl for structs with buffers that are all copyable
-        quote! {
-            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
-                fn clone(&self) -> Self {
-                    *self
-                }
-            }
+    let impl_buffer_clone = impl_buffer_clone(
+        &buffer_struct_ident,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        noncopy,
+    );
 
-            impl #impl_generics ::std::marker::Copy for #buffer_struct_ident #ty_generics #where_clause {}
-        }
-    };
+    let impl_select_buffers = impl_select_buffers(
+        struct_ident,
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
 
-    let impl_buffer_map_layout = impl_buffer_map_layout(&buffer_struct, &input_struct)?;
-    let impl_joined = impl_joined(&buffer_struct, &input_struct)?;
+    let impl_buffer_map_layout =
+        impl_buffer_map_layout(&buffer_struct, &field_ident, &field_config)?;
+    let impl_joined = impl_joined(&buffer_struct, &input_struct, &field_ident)?;
 
     let gen = quote! {
         impl #impl_generics ::bevy_impulse::JoinedValue for #struct_ident #ty_generics #where_clause {
@@ -63,23 +65,76 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
 
         #impl_buffer_clone
 
-        impl #impl_generics #struct_ident #ty_generics #where_clause {
-            fn select_buffers(
-                #(
-                    #field_ident: #buffer,
-                )*
-            ) -> #buffer_struct_ident #ty_generics {
-                #buffer_struct_ident {
-                    #(
-                        #field_ident,
-                    )*
-                }
-            }
-        }
+        #impl_select_buffers
 
         #impl_buffer_map_layout
 
         #impl_joined
+    };
+
+    Ok(gen.into())
+}
+
+pub(crate) fn impl_buffer_key_map(input_struct: &ItemStruct) -> Result<TokenStream> {
+    let struct_ident = &input_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = input_struct.generics.split_for_impl();
+    let StructConfig {
+        buffer_struct_name: buffer_struct_ident,
+    } = StructConfig::from_data_struct(&input_struct, &KEY_ATTR_TAG);
+    let buffer_struct_vis = &input_struct.vis;
+
+    let (field_ident, field_type, field_config) =
+        get_fields_map(&input_struct.fields, FieldSettings::for_key())?;
+    let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
+    let noncopy = field_config.iter().any(|config| config.noncopy);
+
+    let buffer_struct: ItemStruct = generate_buffer_struct(
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
+
+    let impl_buffer_clone = impl_buffer_clone(
+        &buffer_struct_ident,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        noncopy,
+    );
+
+    let impl_select_buffers = impl_select_buffers(
+        struct_ident,
+        &buffer_struct_ident,
+        buffer_struct_vis,
+        &impl_generics,
+        &ty_generics,
+        &where_clause,
+        &field_ident,
+        &buffer,
+    );
+
+    let impl_buffer_map_layout =
+        impl_buffer_map_layout(&buffer_struct, &field_ident, &field_config)?;
+    let impl_accessed = impl_accessed(&buffer_struct, &input_struct, &field_ident, &field_type)?;
+
+    let gen = quote! {
+        impl #impl_generics ::bevy_impulse::BufferKeyMap for #struct_ident #ty_generics #where_clause {
+            type Buffers = #buffer_struct_ident #ty_generics;
+        }
+
+        #buffer_struct
+
+        #impl_buffer_clone
+
+        #impl_select_buffers
+
+        #impl_buffer_map_layout
+
+        #impl_accessed
     };
 
     Ok(gen.into())
@@ -112,7 +167,7 @@ struct StructConfig {
 }
 
 impl StructConfig {
-    fn from_data_struct(data_struct: &ItemStruct) -> Self {
+    fn from_data_struct(data_struct: &ItemStruct, attr_tag: &str) -> Self {
         let mut config = Self {
             buffer_struct_name: format_ident!("__bevy_impulse_{}_Buffers", data_struct.ident),
         };
@@ -120,7 +175,7 @@ impl StructConfig {
         let attr = data_struct
             .attrs
             .iter()
-            .find(|attr| attr.path().is_ident("joined"));
+            .find(|attr| attr.path().is_ident(attr_tag));
 
         if let Some(attr) = attr {
             attr.parse_nested_meta(|meta| {
@@ -137,23 +192,52 @@ impl StructConfig {
     }
 }
 
+struct FieldSettings {
+    default_buffer: fn(&Type) -> Type,
+    attr_tag: &'static str,
+}
+
+impl FieldSettings {
+    fn for_joined() -> Self {
+        Self {
+            default_buffer: Self::default_field_for_joined,
+            attr_tag: JOINED_ATTR_TAG,
+        }
+    }
+
+    fn for_key() -> Self {
+        Self {
+            default_buffer: Self::default_field_for_key,
+            attr_tag: KEY_ATTR_TAG,
+        }
+    }
+
+    fn default_field_for_joined(ty: &Type) -> Type {
+        parse_quote! { ::bevy_impulse::Buffer<#ty> }
+    }
+
+    fn default_field_for_key(ty: &Type) -> Type {
+        parse_quote! { <#ty as ::bevy_impulse::BufferKeyLifecycle>::TargetBuffer }
+    }
+}
+
 struct FieldConfig {
     buffer: Type,
     noncopy: bool,
 }
 
 impl FieldConfig {
-    fn from_field(field: &Field) -> Self {
+    fn from_field(field: &Field, settings: &FieldSettings) -> Self {
         let ty = &field.ty;
         let mut config = Self {
-            buffer: parse_quote! { ::bevy_impulse::Buffer<#ty> },
+            buffer: (settings.default_buffer)(ty),
             noncopy: false,
         };
 
         for attr in field
             .attrs
             .iter()
-            .filter(|attr| attr.path().is_ident("joined"))
+            .filter(|attr| attr.path().is_ident(settings.attr_tag))
         {
             attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("buffer") {
@@ -172,7 +256,10 @@ impl FieldConfig {
     }
 }
 
-fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<FieldConfig>)> {
+fn get_fields_map(
+    fields: &syn::Fields,
+    settings: FieldSettings,
+) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<FieldConfig>)> {
     match fields {
         syn::Fields::Named(data) => {
             let mut idents = Vec::new();
@@ -185,7 +272,7 @@ fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<
                     .ok_or("expected named fields".to_string())?;
                 idents.push(ident);
                 types.push(&field.ty);
-                configs.push(FieldConfig::from_field(field));
+                configs.push(FieldConfig::from_field(field, &settings));
             }
             Ok((idents, types, configs))
         }
@@ -193,16 +280,98 @@ fn get_fields_map(fields: &syn::Fields) -> Result<(Vec<&Ident>, Vec<&Type>, Vec<
     }
 }
 
+fn generate_buffer_struct(
+    buffer_struct_ident: &Ident,
+    buffer_struct_vis: &Visibility,
+    impl_generics: &ImplGenerics,
+    where_clause: &Option<&WhereClause>,
+    field_ident: &Vec<&Ident>,
+    buffer: &Vec<&Type>,
+) -> ItemStruct {
+    parse_quote! {
+        #[allow(non_camel_case_types, unused)]
+        #buffer_struct_vis struct #buffer_struct_ident #impl_generics #where_clause {
+            #(
+                #buffer_struct_vis #field_ident: #buffer,
+            )*
+        }
+    }
+}
+
+fn impl_select_buffers(
+    struct_ident: &Ident,
+    buffer_struct_ident: &Ident,
+    buffer_struct_vis: &Visibility,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    field_ident: &Vec<&Ident>,
+    buffer: &Vec<&Type>,
+) -> TokenStream {
+    quote! {
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
+            #buffer_struct_vis fn select_buffers(
+                #(
+                    #field_ident: #buffer,
+                )*
+            ) -> #buffer_struct_ident #ty_generics {
+                #buffer_struct_ident {
+                    #(
+                        #field_ident,
+                    )*
+                }
+            }
+        }
+    }
+    .into()
+}
+
+fn impl_buffer_clone(
+    buffer_struct_ident: &Ident,
+    impl_generics: &ImplGenerics,
+    ty_generics: &TypeGenerics,
+    where_clause: &Option<&WhereClause>,
+    field_ident: &Vec<&Ident>,
+    noncopy: bool,
+) -> TokenStream {
+    if noncopy {
+        // Clone impl for structs with a buffer that is not copyable
+        quote! {
+            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+                fn clone(&self) -> Self {
+                    Self {
+                        #(
+                            #field_ident: self.#field_ident.clone(),
+                        )*
+                    }
+                }
+            }
+        }
+    } else {
+        // Clone and copy impl for structs with buffers that are all copyable
+        quote! {
+            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
+
+            impl #impl_generics ::std::marker::Copy for #buffer_struct_ident #ty_generics #where_clause {}
+        }
+    }
+}
+
 /// Params:
 ///   buffer_struct: The struct to implement `BufferMapLayout`.
 ///   item_struct: The struct which `buffer_struct` is derived from.
+///   settings: [`FieldSettings`] to use when parsing the field attributes
 fn impl_buffer_map_layout(
     buffer_struct: &ItemStruct,
-    item_struct: &ItemStruct,
+    field_ident: &Vec<&Ident>,
+    field_config: &Vec<FieldConfig>,
 ) -> Result<proc_macro2::TokenStream> {
     let struct_ident = &buffer_struct.ident;
     let (impl_generics, ty_generics, where_clause) = buffer_struct.generics.split_for_impl();
-    let (field_ident, _, field_config) = get_fields_map(&item_struct.fields)?;
     let buffer: Vec<&Type> = field_config.iter().map(|config| &config.buffer).collect();
     let map_key: Vec<String> = field_ident.iter().map(|v| v.to_string()).collect();
 
@@ -249,17 +418,17 @@ fn impl_buffer_map_layout(
 fn impl_joined(
     joined_struct: &ItemStruct,
     item_struct: &ItemStruct,
+    field_ident: &Vec<&Ident>,
 ) -> Result<proc_macro2::TokenStream> {
     let struct_ident = &joined_struct.ident;
     let item_struct_ident = &item_struct.ident;
     let (impl_generics, ty_generics, where_clause) = item_struct.generics.split_for_impl();
-    let (field_ident, _, _) = get_fields_map(&item_struct.fields)?;
 
     Ok(quote! {
         impl #impl_generics ::bevy_impulse::Joined for #struct_ident #ty_generics #where_clause {
             type Item = #item_struct_ident #ty_generics;
 
-            fn pull(&self, session: ::bevy_ecs::prelude::Entity, world: &mut ::bevy_ecs::prelude::World) -> Result<Self::Item, ::bevy_impulse::OperationError> {
+            fn pull(&self, session: ::bevy_impulse::re_exports::Entity, world: &mut ::bevy_impulse::re_exports::World) -> Result<Self::Item, ::bevy_impulse::OperationError> {
                 #(
                     let #field_ident = self.#field_ident.pull(session, world)?;
                 )*
@@ -267,6 +436,57 @@ fn impl_joined(
                 Ok(Self::Item {#(
                     #field_ident,
                 )*})
+            }
+        }
+    }.into())
+}
+
+fn impl_accessed(
+    accessed_struct: &ItemStruct,
+    key_struct: &ItemStruct,
+    field_ident: &Vec<&Ident>,
+    field_type: &Vec<&Type>,
+) -> Result<proc_macro2::TokenStream> {
+    let struct_ident = &accessed_struct.ident;
+    let key_struct_ident = &key_struct.ident;
+    let (impl_generics, ty_generics, where_clause) = key_struct.generics.split_for_impl();
+
+    Ok(quote! {
+        impl #impl_generics ::bevy_impulse::Accessed for #struct_ident #ty_generics #where_clause {
+            type Key = #key_struct_ident #ty_generics;
+
+            fn add_accessor(
+                &self,
+                accessor: ::bevy_impulse::re_exports::Entity,
+                world: &mut ::bevy_impulse::re_exports::World,
+            ) -> ::bevy_impulse::OperationResult {
+                #(
+                    ::bevy_impulse::Accessed::add_accessor(&self.#field_ident, accessor, world)?;
+                )*
+                Ok(())
+            }
+
+            fn create_key(&self, builder: &::bevy_impulse::BufferKeyBuilder) -> Self::Key {
+                Self::Key {#(
+                    // TODO(@mxgrey): This currently does not have good support for the user
+                    // substituting in a different key type than what the BufferKeyLifecycle expects.
+                    // We could consider adding a .clone().into() to help support that use case, but
+                    // this would be such a niche use case that I think we can ignore it for now.
+                    #field_ident: <#field_type as ::bevy_impulse::BufferKeyLifecycle>::create_key(&self.#field_ident, builder),
+                )*}
+            }
+
+            fn deep_clone_key(key: &Self::Key) -> Self::Key {
+                Self::Key {#(
+                    #field_ident: ::bevy_impulse::BufferKeyLifecycle::deep_clone(&key.#field_ident),
+                )*}
+            }
+
+            fn is_key_in_use(key: &Self::Key) -> bool {
+                false
+                    #(
+                        || ::bevy_impulse::BufferKeyLifecycle::is_in_use(&key.#field_ident)
+                    )*
             }
         }
     }.into())

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -16,7 +16,7 @@
 */
 
 mod buffer;
-use buffer::impl_joined_value;
+use buffer::{impl_buffer_key_map, impl_joined_value};
 
 use proc_macro::TokenStream;
 use quote::quote;
@@ -69,6 +69,18 @@ type Result<T> = std::result::Result<T, String>;
 pub fn derive_joined_value(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as ItemStruct);
     match impl_joined_value(&input) {
+        Ok(tokens) => tokens.into(),
+        Err(msg) => quote! {
+            compile_error!(#msg);
+        }
+        .into(),
+    }
+}
+
+#[proc_macro_derive(BufferKeyMap, attributes(key))]
+pub fn derive_buffer_key_map(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    match impl_buffer_key_map(&input) {
         Ok(tokens) => tokens.into(),
         Err(msg) => quote! {
             compile_error!(#msg);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -38,7 +38,7 @@ pub use buffer_access_lifecycle::BufferKeyLifecycle;
 pub(crate) use buffer_access_lifecycle::*;
 
 mod buffer_key_builder;
-pub(crate) use buffer_key_builder::*;
+pub use buffer_key_builder::*;
 
 mod buffer_map;
 pub use buffer_map::*;
@@ -428,7 +428,7 @@ pub trait BufferWorldAccess {
 impl BufferWorldAccess for World {
     fn buffer_view<T>(&self, key: &BufferKey<T>) -> Result<BufferView<'_, T>, BufferError>
     where
-        T: 'static + Send + Sync
+        T: 'static + Send + Sync,
     {
         let buffer_ref = self
             .get_entity(key.tag.buffer)
@@ -452,11 +452,12 @@ impl BufferWorldAccess for World {
         f: impl FnOnce(BufferMut<T>) -> U,
     ) -> Result<U, BufferError>
     where
-        T: 'static + Send + Sync
+        T: 'static + Send + Sync,
     {
         let mut state = SystemState::<BufferAccessMut<T>>::new(self);
         let mut buffer_access_mut = state.get_mut(self);
-        let buffer_mut = buffer_access_mut.get_mut(key)
+        let buffer_mut = buffer_access_mut
+            .get_mut(key)
             .map_err(|_| BufferError::BufferMissing)?;
         Ok(f(buffer_mut))
     }

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -517,7 +517,7 @@ pub trait AnyBufferWorldAccess {
     /// For technical reasons this requires direct [`World`] access, but you can
     /// do other read-only queries on the world while holding onto the
     /// [`AnyBufferView`].
-    fn any_buffer_view<'a>(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError>;
+    fn any_buffer_view(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError>;
 
     /// Call this to get mutable access to any buffer.
     ///
@@ -531,7 +531,7 @@ pub trait AnyBufferWorldAccess {
 }
 
 impl AnyBufferWorldAccess for World {
-    fn any_buffer_view<'a>(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError> {
+    fn any_buffer_view(&self, key: &AnyBufferKey) -> Result<AnyBufferView<'_>, BufferError> {
         key.interface.create_any_buffer_view(key, self)
     }
 

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -833,6 +833,10 @@ mod tests {
         assert!(context.no_unhandled_errors());
     }
 
+    /// This macro is a manual implementation of the join operation that uses
+    /// the buffer listening mechanism. There isn't any reason to reimplement
+    /// join here except so we can test that listening is working correctly for
+    /// BufferKeyMap.
     fn join_via_listen(
         In(keys): In<TestKeys<&'static str>>,
         world: &mut World,

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -1581,4 +1581,15 @@ mod tests {
         assert_eq!(values[2], serde_json::Value::String("hello".to_string()));
         assert_eq!(values[3], serde_json::to_value(TestMessage::new()).unwrap());
     }
+
+    // We define this struct just to make sure the BufferKeyMap macro successfully
+    // compiles with JsonBufferKey.
+    #[derive(Clone, BufferKeyMap)]
+    #[allow(unused)]
+    struct TestJsonKeyMap {
+        integer: BufferKey<i64>,
+        string: BufferKey<String>,
+        json: JsonBufferKey,
+        any: AnyBufferKey,
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,7 +340,7 @@ pub mod prelude {
         buffer::{
             Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox,
             AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
-            BufferMapLayout, BufferSettings, Bufferable, Buffered, IncompatibleLayout,
+            BufferMapLayout, BufferSettings, Bufferable, Buffered, BufferWorldAccess, IncompatibleLayout,
             IterBufferable, Joinable, JoinedValue, RetentionPolicy,
         },
         builder::Builder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub use async_execution::Sendish;
 pub mod buffer;
 pub use buffer::*;
 
+pub mod re_exports;
+
 pub mod builder;
 pub use builder::*;
 
@@ -340,8 +342,8 @@ pub mod prelude {
         buffer::{
             Accessible, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess, AnyMessageBox,
             AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey, BufferKeyMap, BufferMap,
-            BufferMapLayout, BufferSettings, Bufferable, Buffered, BufferWorldAccess, IncompatibleLayout,
-            IterBufferable, Joinable, JoinedValue, RetentionPolicy,
+            BufferMapLayout, BufferSettings, BufferWorldAccess, Bufferable, Buffered,
+            IncompatibleLayout, IterBufferable, Joinable, JoinedValue, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},

--- a/src/re_exports.rs
+++ b/src/re_exports.rs
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+//! This module contains symbols that are being re-exported so they can be used
+//! by bevy_impulse_derive.
+
+pub use bevy_ecs::prelude::{Entity, World};


### PR DESCRIPTION
This PR adds the `BufferKeyMap` macro to the `buffer_map` branch.

With `#[derive(BufferKeyMap)]` users can easily define structs of buffer keys which can then be used with `Builder::listen` and `Builder::create_buffer_access`. These structs also support `Builder::try_listen` and `Builder::try_create_buffer_access`, which will make listen and buffer access operations much more reasonable to support in the `diagram` module.

These changes also involve some refactoring of the `macros/src/buffer.rs` so I'm splitting it out as its own PR to make it easier to review.

Note that I introduced the `bevy_impulse::re_exports` module so we don't need a dependency on `bevy_ecs` inside of `bevy_impulse_derive` since that could lead to problems if the user's crate doesn't have a dependency on `bevy_ecs` in their `Cargo.toml`.