### PR TITLE
Force backtrace version that is compatible with 1.75

### DIFF
--- a/scripts/patch-versions-msrv-1_75.sh
+++ b/scripts/patch-versions-msrv-1_75.sh
@@ -2,3 +2,4 @@
 # Run this script in the root directory of the package.
 
 cargo add home@=0.5.9
+cargo add backtrace@=0.3.74


### PR DESCRIPTION
A recent version bump to the `backtrace` crate is incompatible with Rust v1.75. This PR forces a known-good version of `backtrace`.

This should help the CI pass for #72