### PR TITLE
fix section schema

### DIFF
--- a/diagram.schema.json
+++ b/diagram.schema.json
@@ -145,8 +145,7 @@
                 "builder": {
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             },
             {
               "type": "object",
@@ -157,8 +156,7 @@
                 "template": {
                   "type": "string"
                 }
-              },
-              "additionalProperties": false
+              }
             }
           ],
           "required": [


### PR DESCRIPTION
<!--
For support requests, please read the Support Guidelines to know where to ask: https://github.com/open-rmf/rmf/wiki/Support-guidelines
For general questions and design discussion, please use the Discussions page: https://github.com/open-rmf/rmf/discussions
Not sure if this is the right repository? Open an issue on https://github.com/open-rmf/rmf
We require contributors to GPG Sign their commits. Follow the guide here to set up a GPG key and add it to your GitHub account: https://docs.github.com/en/github/authenticating-to-github/generating-a-new-gpg-key
A quick guide to how to sign your commits can be seen here: https://gist.github.com/mort3za/ad545d47dd2b54970c102fe39912f305
To GPG sign several commits at once (for example, if you forgot to sign some commits), you can run this command, followed by a force-push: git rebase --exec 'git commit --amend --no-edit -n -S' -i <commit before the first commit you want signed>
For bug fix pull requests, please fill out the information below.
Be as detailed as possible.
-->

## Bug fix

### Fixed bug

schemars generates schemas with `additionalProperties: false` for enums.
When the enum is flatten, that `additionalProperties: false` is inherited by the parent
struct, which leads to schemas that can never be valid.

Example:

```json
{
  "description": "Connect the request to a registered section.\n\n``` # bevy_impulse::Diagram::from_json_str(r#\" { \"version\": \"0.1.0\", \"start\": \"section_op\", \"ops\": { \"section_op\": { \"type\": \"section\", \"builder\": \"my_section_builder\", \"connect\": { \"my_section_output\": { \"builtin\": \"terminate\" } } } } } # \"#)?; # Ok::<_, serde_json::Error>(()) ```\n\nCustom sections can also be created via templates ``` # bevy_impulse::Diagram::from_json_str(r#\" { \"version\": \"0.1.0\", \"templates\": { \"my_template\": { \"inputs\": [\"section_input\"], \"outputs\": [\"section_output\"], \"buffers\": [], \"ops\": { \"section_input\": { \"type\": \"node\", \"builder\": \"my_node\", \"next\": \"section_output\" } } } }, \"start\": \"section_op\", \"ops\": { \"section_op\": { \"type\": \"section\", \"template\": \"my_template\", \"connect\": { \"section_output\": { \"builtin\": \"terminate\" } } } } } # \"#)?; # Ok::<_, serde_json::Error>(()) ```",
  "type": "object",
  "oneOf": [
    {
      "type": "object",
      "required": [
        "builder"
      ],
      "properties": {
        "builder": {
          "type": "string"
        }
      },
      "additionalProperties": false
    },
    {
      "type": "object",
      "required": [
        "template"
      ],
      "properties": {
        "template": {
          "type": "string"
        }
      },
      "additionalProperties": false
    }
  ],
  "required": [
    "type"
  ],
  "properties": {
    "config": {
      "default": null
    },
    "connect": {
      "default": {},
      "type": "object",
      "additionalProperties": {
        "$ref": "#/definitions/NextOperation"
      }
    },
    "type": {
      "type": "string",
      "enum": [
        "section"
      ]
    }
  }
},
```

Here the section schema needs to have a `builder` or `template` with no additional properties.
Which includes other properties like `type`, `config` etc, but `type` is also required which
breaks the schema.

<!-- Briefly describe the bug being fixed.
If there is a bug report issue for the bug, link to that issue.
If there is not a bug report issue for the bug, create one first and fill out all the required information there, then link to that issue from this bug fix pull request. -->

### Fix applied

Remove `additionalProperties` from the flattened field. The new `unevaluatedProperties` option in new json schema drafts addresses this issue, but schemars uses draft-07 so we can't use it. We could update the schema to draft-2020-12 but it's better not to make potentially breaking change.

<!-- Describe in detail the approach taken, tools used, etc. to identify the cause of the bug and what was done to fix it. -->

**If your pull request is a bug fix, delete this line and all the below lines.**

**If your pull request is a feature implementation, delete this line and all the above lines.**

## New feature implementation

### Implemented feature

<!-- Briefly describe the feature being implemented.
If there is a feature request issue for the feature, link to that feature.
If there is not a feature request issue for the feature, create one first and fill out all the required information there, then link to that issue from this new feature pull request. -->

### Implementation description

<!-- Describe the approach taken to implement the feature.
Provide a link to a detailed design document and discussion of that design.
Implementations without design documentation will not be accepted until design documentation has been provided and discussed.
Usually this is done via the feature request issue. -->
