### PR TITLE
Fix github workflow setup

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust-version: stable
+        rust-version: [stable]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
An earlier change created a quiet error in CI because an array in the github workflow config was accidentally changed to a single value, which is not correct syntax.