### PR TITLE
Scope operation in diagrams

### DIFF
--- a/diagram.schema.json
+++ b/diagram.schema.json
@@ -222,6 +222,17 @@
                 "$ref": "#/definitions/DiagramOperation"
               }
             },
+            "settings": {
+              "description": "Settings specific to the scope, e.g. whether it is interruptible.",
+              "default": {
+                "uninterruptible": false
+              },
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ScopeSettings"
+                }
+              ]
+            },
             "start": {
               "description": "Indicates which node inside the scope should receive the input into the scope.",
               "allOf": [
@@ -662,6 +673,19 @@
           ]
         }
       ]
+    },
+    "ScopeSettings": {
+      "description": "Settings which determine how the top-level scope of the workflow behaves.",
+      "type": "object",
+      "required": [
+        "uninterruptible"
+      ],
+      "properties": {
+        "uninterruptible": {
+          "description": "Should we prevent the scope from being interrupted (e.g. cancelled)? False by default, meaning by default scopes can be cancelled or interrupted.",
+          "type": "boolean"
+        }
+      }
     },
     "SectionTemplate": {
       "type": "object",

--- a/diagram.schema.json
+++ b/diagram.schema.json
@@ -186,6 +186,67 @@
           }
         },
         {
+          "description": "The schema to define a scope within a diagram.",
+          "type": "object",
+          "required": [
+            "next",
+            "ops",
+            "start",
+            "type"
+          ],
+          "properties": {
+            "next": {
+              "description": "Where to connect the output of this scope.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NextOperation"
+                }
+              ]
+            },
+            "on_implicit_error": {
+              "description": "To simplify diagram definitions, the diagram workflow builder will sometimes insert implicit operations into the workflow, such as implicit serializing and deserializing. These implicit operations may be fallible.\n\nThis field indicates how a failed implicit operation should be handled. If left unspecified, an implicit error will cause the entire workflow to be cancelled.",
+              "default": null,
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NextOperation"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "ops": {
+              "description": "Operations that exist inside this scope.",
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/DiagramOperation"
+              }
+            },
+            "start": {
+              "description": "Indicates which node inside the scope should receive the input into the scope.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/NextOperation"
+                }
+              ]
+            },
+            "stream_out": {
+              "description": "Where to connect streams that are coming out of this scope.",
+              "default": {},
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/NextOperation"
+              }
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "scope"
+              ]
+            }
+          }
+        },
+        {
           "description": "Declare a stream output for the current scope. Outputs that you connect to this operation will be streamed out of the scope that this operation is declared in.\n\nFor the root-level scope, make sure you use a stream pack that is compatible with all stream out operations that you declare, otherwise you may get a connection error at runtime.\n\n# Examples ``` # bevy_impulse::Diagram::from_json_str(r#\" { \"version\": \"0.1.0\", \"start\": \"plan\", \"ops\": { \"progress_stream\": { \"type\": \"stream_out\", \"name\": \"progress\" }, \"plan\": { \"type\": \"node\", \"builder\": \"planner\", \"next\": \"drive\", \"stream_out\" : { \"progress\": \"progress_stream\" } }, \"drive\": { \"type\": \"node\", \"builder\": \"navigation\", \"next\": { \"builtin\": \"terminate\" }, \"stream_out\": { \"progress\": \"progress_stream\" } } } } # \"#)?; # Ok::<_, serde_json::Error>(()) ```",
           "type": "object",
           "required": [

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -74,7 +74,7 @@ impl<T> Buffer<T> {
         &self,
         builder: &'b mut Builder<'w, 's, 'a>,
     ) -> Chain<'w, 's, 'a, 'b, ()> {
-        assert_eq!(self.scope(), builder.scope);
+        assert_eq!(self.scope(), builder.scope());
         let target = builder.commands.spawn(UnusedTarget).id();
         builder
             .commands

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -192,7 +192,7 @@ pub trait IterBufferable {
             Join::new(buffers, target),
         ));
 
-        Output::new(builder.scope, target).chain(builder)
+        Output::new(builder.scope(), target).chain(builder)
     }
 }
 

--- a/src/buffer/buffering.rs
+++ b/src/buffer/buffering.rs
@@ -114,14 +114,14 @@ pub trait Accessing: Buffering {
         let source = builder.commands.spawn(()).id();
         let target = builder.commands.spawn(UnusedTarget).id();
         builder.commands.add(AddOperation::new(
-            Some(builder.scope),
+            Some(builder.scope()),
             source,
             OperateBufferAccess::<T, Self>::new(self, target),
         ));
 
         Node {
-            input: InputSlot::new(builder.scope, source),
-            output: Output::new(builder.scope, target),
+            input: InputSlot::new(builder.scope(), source),
+            output: Output::new(builder.scope(), target),
             streams: (),
         }
     }
@@ -183,17 +183,17 @@ pub trait Accessing: Buffering {
         let cancelling_scope_id = builder.commands.spawn(()).id();
         let _ = builder.create_scope_impl::<Self::Key, (), (), Settings>(
             cancelling_scope_id,
-            builder.finish_scope_cancel,
+            builder.context.finish_scope_cancel,
             build,
         );
 
-        let begin_cancel = builder.commands.spawn(()).set_parent(builder.scope).id();
-        self.verify_scope(builder.scope);
+        let begin_cancel = builder.commands.spawn(()).set_parent(builder.context.scope).id();
+        self.verify_scope(builder.scope());
         builder.commands.add(AddOperation::new(
             None,
             begin_cancel,
             BeginCleanupWorkflow::<Self>::new(
-                builder.scope,
+                builder.scope(),
                 self,
                 cancelling_scope_id,
                 conditions.run_on_terminate,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -49,6 +49,7 @@ pub struct Builder<'w, 's, 'a> {
     pub(crate) commands: &'a mut Commands<'w, 's>,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub(crate) struct BuilderScopeContext {
     /// The scope that this builder is meant to help build
     pub(crate) scope: Entity,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -703,7 +703,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
             terminal,
             enter_scope,
             finish_scope_cancel,
-        } = OperateScope::<Request, Response, Streams>::add(
+        } = OperateScope::<Request, Response>::add(
             Some(self.scope()),
             scope_id,
             Some(exit_scope),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -703,7 +703,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
             terminal,
             enter_scope,
             finish_scope_cancel,
-        } = OperateScope::<Request, Response>::add(
+        } = OperateScope::add::<Request, Response>(
             Some(self.scope()),
             scope_id,
             Some(exit_scope),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -58,6 +58,15 @@ pub struct BuilderScopeContext {
 }
 
 impl<'w, 's, 'a> Builder<'w, 's, 'a> {
+
+    /// Begin building a chain of operations off of an output.
+    pub fn chain<'b, Response: 'static + Send + Sync>(
+        &'b mut self,
+        output: Output<Response>,
+    ) -> Chain<'w, 's, 'a, 'b, Response> {
+        output.chain(self)
+    }
+
     /// Create a node for a provider. This will give access to an input slot, an
     /// output slots, and a pack of stream outputs which can all be connected to
     /// other nodes.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -50,7 +50,7 @@ pub struct Builder<'w, 's, 'a> {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub(crate) struct BuilderScopeContext {
+pub struct BuilderScopeContext {
     /// The scope that this builder is meant to help build
     pub(crate) scope: Entity,
     /// The target for cancellation workflows
@@ -771,6 +771,10 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
             output: Output::new(self.scope(), target),
             streams,
         }
+    }
+
+    pub fn context(&self) -> BuilderScopeContext {
+        self.context
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,11 +45,15 @@ pub(crate) use connect::*;
 /// please open an issue with a minimal reproducible example if you find a way
 /// to make it panic.
 pub struct Builder<'w, 's, 'a> {
+    pub(crate) context: BuilderScopeContext,
+    pub(crate) commands: &'a mut Commands<'w, 's>,
+}
+
+pub(crate) struct BuilderScopeContext {
     /// The scope that this builder is meant to help build
     pub(crate) scope: Entity,
     /// The target for cancellation workflows
     pub(crate) finish_scope_cancel: Entity,
-    pub(crate) commands: &'a mut Commands<'w, 's>,
 }
 
 impl<'w, 's, 'a> Builder<'w, 's, 'a> {
@@ -67,14 +71,14 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     {
         let source = self.commands.spawn(()).id();
         let target = self.commands.spawn(UnusedTarget).id();
-        provider.connect(Some(self.scope), source, target, self.commands);
+        provider.connect(Some(self.scope()), source, target, self.commands);
 
         let mut map = StreamTargetMap::default();
         let streams = <P::Streams as StreamPack>::spawn_node_streams(source, &mut map, self);
         self.commands.entity(source).insert(map);
         Node {
-            input: InputSlot::new(self.scope, source),
-            output: Output::new(self.scope, target),
+            input: InputSlot::new(self.scope(), source),
+            output: Output::new(self.scope(), target),
             streams,
         }
     }
@@ -159,7 +163,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     ) -> Buffer<T> {
         let source = self.commands.spawn(()).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             OperateBuffer::<T>::new(settings),
         ));
@@ -222,13 +226,13 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     {
         let source = self.commands.spawn(()).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             ForkClone::<T>::new(ForkTargetStorage::new()),
         ));
         (
-            InputSlot::new(self.scope, source),
-            ForkCloneOutput::new(self.scope, source),
+            InputSlot::new(self.scope(), source),
+            ForkCloneOutput::new(self.scope(), source),
         )
     }
 
@@ -240,8 +244,8 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     {
         let source = self.commands.spawn(()).id();
         (
-            InputSlot::new(self.scope, source),
-            T::unzip_output(Output::<T>::new(self.scope, source), self),
+            InputSlot::new(self.scope(), source),
+            T::unzip_output(Output::<T>::new(self.scope(), source), self),
         )
     }
 
@@ -258,16 +262,16 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         let target_err = self.commands.spawn(UnusedTarget).id();
 
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             make_result_branching::<T, E>(ForkTargetStorage::from_iter([target_ok, target_err])),
         ));
 
         (
-            InputSlot::new(self.scope, source),
+            InputSlot::new(self.scope(), source),
             ForkResultOutput {
-                ok: Output::new(self.scope, target_ok),
-                err: Output::new(self.scope, target_err),
+                ok: Output::new(self.scope(), target_ok),
+                err: Output::new(self.scope(), target_err),
             },
         )
     }
@@ -287,16 +291,16 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         let target_none = self.commands.spawn(UnusedTarget).id();
 
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             make_option_branching::<T>(ForkTargetStorage::from_iter([target_some, target_none])),
         ));
 
         (
-            InputSlot::new(self.scope, source),
+            InputSlot::new(self.scope(), source),
             ForkOptionOutput {
-                some: Output::new(self.scope, target_some),
-                none: Output::new(self.scope, target_none),
+                some: Output::new(self.scope(), target_some),
+                none: Output::new(self.scope(), target_none),
             },
         )
     }
@@ -390,14 +394,14 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         let source = self.commands.spawn(()).id();
         let target = self.commands.spawn(UnusedTarget).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             Collect::<T, N>::new(target, min, max),
         ));
 
         Node {
-            input: InputSlot::new(self.scope, source),
-            output: Output::new(self.scope, target),
+            input: InputSlot::new(self.scope(), source),
+            output: Output::new(self.scope(), target),
             streams: (),
         }
     }
@@ -427,14 +431,14 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     {
         let source = self.commands.spawn(()).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             OperateSplit::<T>::default(),
         ));
 
         (
-            InputSlot::new(self.scope, source),
-            SplitOutputs::new(self.scope, source),
+            InputSlot::new(self.scope(), source),
+            SplitOutputs::new(self.scope(), source),
         )
     }
 
@@ -450,12 +454,12 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     {
         let source = self.commands.spawn(()).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             OperateCancel::<T>::new(),
         ));
 
-        InputSlot::new(self.scope, source)
+        InputSlot::new(self.scope(), source)
     }
 
     /// Create an input slot that will cancel that current scope when it gets
@@ -466,12 +470,12 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     pub fn create_quiet_cancel(&mut self) -> InputSlot<()> {
         let source = self.commands.spawn(()).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             OperateQuietCancel,
         ));
 
-        InputSlot::new(self.scope, source)
+        InputSlot::new(self.scope(), source)
     }
 
     /// This method allows you to define a cleanup workflow that branches off of
@@ -576,20 +580,20 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
     {
         let branches: SmallVec<[_; 16]> = branches.into_iter().collect();
         for branch in &branches {
-            branch.verify_scope(self.scope);
+            branch.verify_scope(self.scope());
         }
 
         let source = self.commands.spawn(()).id();
         let target = self.commands.spawn(UnusedTarget).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             Trim::<T>::new(branches, target),
         ));
 
         Node {
-            input: InputSlot::new(self.scope, source),
-            output: Output::new(self.scope, target),
+            input: InputSlot::new(self.scope(), source),
+            output: Output::new(self.scope(), target),
             streams: (),
         }
     }
@@ -608,19 +612,19 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         T: 'static + Send + Sync,
     {
         let buffers = buffers.into_buffer(self);
-        buffers.verify_scope(self.scope);
+        buffers.verify_scope(self.scope());
 
         let source = self.commands.spawn(()).id();
         let target = self.commands.spawn(UnusedTarget).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             OperateDynamicGate::<T, _>::new(buffers, target),
         ));
 
         Node {
-            input: InputSlot::new(self.scope, source),
-            output: Output::new(self.scope, target),
+            input: InputSlot::new(self.scope(), source),
+            output: Output::new(self.scope(), target),
             streams: (),
         }
     }
@@ -637,19 +641,19 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         T: 'static + Send + Sync,
     {
         let buffers = buffers.into_buffer(self);
-        buffers.verify_scope(self.scope);
+        buffers.verify_scope(self.scope());
 
         let source = self.commands.spawn(()).id();
         let target = self.commands.spawn(UnusedTarget).id();
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             OperateStaticGate::<T, _>::new(buffers, target, action),
         ));
 
         Node {
-            input: InputSlot::new(self.scope, source),
-            output: Output::new(self.scope, target),
+            input: InputSlot::new(self.scope(), source),
+            output: Output::new(self.scope(), target),
             streams: (),
         }
     }
@@ -678,7 +682,7 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
 
     /// Get the scope that this builder is building for.
     pub fn scope(&self) -> Entity {
-        self.scope
+        self.context.scope
     }
 
     /// Borrow the commands for the builder
@@ -711,11 +715,13 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         );
 
         let (stream_in, stream_out) =
-            Streams::spawn_scope_streams(scope_id, self.scope, self.commands);
+            Streams::spawn_scope_streams(scope_id, self.scope(), self.commands);
 
         let mut builder = Builder {
-            scope: scope_id,
-            finish_scope_cancel,
+            context: BuilderScopeContext {
+                scope: scope_id,
+                finish_scope_cancel,
+            },
             commands: self.commands,
         };
 
@@ -731,8 +737,8 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
             .insert(ScopeSettingsStorage(settings));
 
         Node {
-            input: InputSlot::new(self.scope, scope_id),
-            output: Output::new(self.scope, exit_scope),
+            input: InputSlot::new(self.scope(), scope_id),
+            output: Output::new(self.scope(), exit_scope),
             streams: stream_out,
         }
     }
@@ -752,14 +758,14 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         let streams = Streams::spawn_node_streams(source, &mut map, self);
         self.commands.entity(source).insert(map);
         self.commands.add(AddOperation::new(
-            Some(self.scope),
+            Some(self.scope()),
             source,
             Injection::<Request, Response, Streams>::new(target),
         ));
 
         Node {
-            input: InputSlot::new(self.scope, source),
-            output: Output::new(self.scope, target),
+            input: InputSlot::new(self.scope(), source),
+            output: Output::new(self.scope(), target),
             streams,
         }
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -704,6 +704,8 @@ impl<'w, 's, 'a> Builder<'w, 's, 'a> {
         Streams: StreamPack,
         Settings: Into<ScopeSettings>,
     {
+        // NOTE(@mxgrey): When changing the implementation of this function,
+        // remember to similarly update the implementation of IncrementalScopeBuilder
         let ScopeEndpoints {
             terminal,
             enter_scope,

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -101,7 +101,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         provider.connect(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             target,
             self.builder.commands,
@@ -128,8 +128,8 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
             <P::Streams as StreamPack>::spawn_node_streams(source, &mut map, self.builder);
         self.builder.commands.entity(source).insert(map);
         Node {
-            input: InputSlot::new(self.builder.scope, source),
-            output: Output::new(self.builder.scope, target),
+            input: InputSlot::new(self.builder.scope(), source),
+            output: Output::new(self.builder.scope(), target),
             streams,
         }
     }
@@ -306,12 +306,12 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
         B::BufferType: Accessing,
     {
         let buffers = buffers.into_buffer(self.builder);
-        buffers.verify_scope(self.builder.scope);
+        buffers.verify_scope(self.builder.scope());
 
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             OperateBufferAccess::<T, B::BufferType>::new(buffers, target),
         ));
@@ -461,7 +461,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             Spread::<T>::new(target),
         ));
@@ -497,7 +497,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             Collect::<T, N>::new(target, min, max),
         ));
@@ -528,13 +528,13 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     ) -> Chain<'w, 's, 'a, 'b, T> {
         let branches: SmallVec<[_; 16]> = branches.into_iter().collect();
         for branch in &branches {
-            branch.verify_scope(self.builder.scope);
+            branch.verify_scope(self.builder.scope());
         }
 
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             Trim::<T>::new(branches, target),
         ));
@@ -548,7 +548,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// See also: [`Self::then_trim`], [`Builder::create_trim`].
     pub fn then_trim_node(self, branches: impl IntoIterator<Item = TrimBranch>) -> Node<T, T> {
         let source = self.target;
-        let scope = self.builder.scope;
+        let scope = self.builder.scope();
         let target = self.then_trim(branches).output().id();
         Node {
             input: InputSlot::new(scope, source),
@@ -576,12 +576,12 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
         B: Bufferable,
     {
         let buffers = buffers.into_buffer(self.builder);
-        buffers.verify_scope(self.builder.scope);
+        buffers.verify_scope(self.builder.scope());
 
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             OperateStaticGate::<T, _>::new(buffers, target, action),
         ));
@@ -628,7 +628,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     {
         let source = self.target;
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             OperateSplit::<T>::default(),
         ));
@@ -709,7 +709,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
     /// Get a whole node that is simply a [no-op](Self::noop).
     pub fn noop_node(self) -> Node<T, T> {
         let source = self.target;
-        let scope = self.builder.scope;
+        let scope = self.builder.scope();
         let target = self.noop().output().id();
         Node {
             input: InputSlot::new(scope, source),
@@ -720,7 +720,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Send + Sync> Chain<'w, 's, 'a, 'b, T> {
 
     /// The scope that the chain is building inside of.
     pub fn scope(&self) -> Entity {
-        self.builder.scope
+        self.builder.scope()
     }
 
     /// The target where the chain will be sending its latest output.
@@ -1105,12 +1105,12 @@ where
         B::BufferType: 'static + Send + Sync,
     {
         let buffers = buffers.into_buffer(self.builder);
-        buffers.verify_scope(self.builder.scope);
+        buffers.verify_scope(self.builder.scope());
 
         let source = self.target;
         let target = self.builder.commands.spawn(UnusedTarget).id();
         self.builder.commands.add(AddOperation::new(
-            Some(self.builder.scope),
+            Some(self.builder.scope()),
             source,
             OperateDynamicGate::<T, _>::new(buffers, target),
         ));

--- a/src/chain/split.rs
+++ b/src/chain/split.rs
@@ -225,7 +225,7 @@ impl<'w, 's, 'a, 'b, T: 'static + Splittable> SplitBuilder<'w, 's, 'a, 'b, T> {
     /// Used internally to create a new split connector
     pub(crate) fn new(source: Entity, builder: &'b mut Builder<'w, 's, 'a>) -> Self {
         Self {
-            outputs: SplitOutputs::new(builder.scope, source),
+            outputs: SplitOutputs::new(builder.scope(), source),
             builder,
         }
     }
@@ -285,7 +285,7 @@ impl<T: Splittable> SplitOutputs<T> {
         self,
         builder: &'b mut Builder<'w, 's, 'a>,
     ) -> SplitBuilder<'w, 's, 'a, 'b, T> {
-        assert_eq!(self.scope, builder.scope);
+        assert_eq!(self.scope, builder.scope());
         SplitBuilder {
             outputs: self,
             builder,

--- a/src/chain/unzip.rs
+++ b/src/chain/unzip.rs
@@ -56,7 +56,7 @@ macro_rules! impl_unzippable_for_tuple {
                                 let $T = std::marker::PhantomData::<$T>;
                                 let target = builder.commands.spawn(UnusedTarget).id();
                                 targets.push(target);
-                                Output::new(builder.scope, target)
+                                Output::new(builder.scope(), target)
                             },
                         )*
                     );

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -105,6 +105,10 @@ impl NextOperation {
             builtin: BuiltinTarget::Dispose,
         }
     }
+
+    pub fn terminate() -> Self {
+        NextOperation::Builtin { builtin: BuiltinTarget::Terminate }
+    }
 }
 
 impl Display for NextOperation {

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -389,6 +389,8 @@ pub enum DiagramOperation {
     /// ```
     Section(SectionSchema),
 
+    Scope(ScopeSchema),
+
     /// Declare a stream output for the current scope. Outputs that you connect
     /// to this operation will be streamed out of the scope that this operation
     /// is declared in.
@@ -907,6 +909,7 @@ impl BuildDiagramOperation for DiagramOperation {
             Self::Join(op) => op.build_diagram_operation(id, builder, ctx),
             Self::Listen(op) => op.build_diagram_operation(id, builder, ctx),
             Self::Node(op) => op.build_diagram_operation(id, builder, ctx),
+            Self::Scope(op) => op.build_diagram_operation(id, builder, ctx),
             Self::Section(op) => op.build_diagram_operation(id, builder, ctx),
             Self::SerializedJoin(op) => op.build_diagram_operation(id, builder, ctx),
             Self::Split(op) => op.build_diagram_operation(id, builder, ctx),

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -60,7 +60,7 @@ use std::{
 
 pub use crate::type_info::TypeInfo;
 use crate::{
-    Builder, IncompatibleLayout, JsonMessage, Scope, Service, SpawnWorkflowExt,
+    Builder, IncompatibleLayout, IncrementalScopeError, JsonMessage, Scope, Service, SpawnWorkflowExt,
     SplitConnectionError, StreamPack,
 };
 
@@ -1435,6 +1435,9 @@ pub enum DiagramErrorCode {
 
     #[error("An error occurred while finishing the workflow build: {0}")]
     FinishingErrors(FinishingErrors),
+
+    #[error("An error occurred while creating a scope: {0}")]
+    IncrementalScopeError(#[from] IncrementalScopeError),
 }
 
 fn format_list<T: std::fmt::Display>(list: &[T]) -> String {

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -29,7 +29,8 @@ use bevy_ecs::prelude::Commands;
 pub use crate::dyn_node::*;
 use crate::{
     Accessor, AnyBuffer, AsAnyBuffer, BufferMap, BufferSettings, Builder, Joined, JsonBuffer,
-    JsonMessage, Node, StreamPack, IncrementalScope, IncrementalScopeBuilder, IncrementalScopeResult,
+    JsonMessage, Node, StreamPack, IncrementalScopeBuilder, IncrementalScopeRequest,
+    IncrementalScopeResponseResult, IncrementalScopeResponse, IncrementalScopeRequestResult,
 };
 
 use schemars::{
@@ -98,8 +99,8 @@ type CreateTriggerFn = fn(&mut Builder) -> DynNode;
 type ToStringFn = fn(&mut Builder) -> DynNode;
 
 struct BuildScope {
-    set_request: fn(&mut IncrementalScopeBuilder, &mut Commands) -> IncrementalScopeResult,
-    set_response: fn(&mut IncrementalScopeBuilder, &mut Commands) -> IncrementalScopeResult,
+    set_request: fn(&mut IncrementalScopeBuilder, &mut Commands) -> IncrementalScopeRequestResult,
+    set_response: fn(&mut IncrementalScopeBuilder, &mut Commands) -> IncrementalScopeResponseResult,
 }
 
 impl BuildScope {
@@ -113,14 +114,14 @@ impl BuildScope {
     fn impl_set_request<T: 'static + Send + Sync>(
         incremental: &mut IncrementalScopeBuilder,
         commands: &mut Commands,
-    ) -> IncrementalScopeResult {
+    ) -> IncrementalScopeRequestResult {
         incremental.set_request::<T>(commands)
     }
 
     fn impl_set_response<T: 'static + Send + Sync>(
         incremental: &mut IncrementalScopeBuilder,
         commands: &mut Commands,
-    ) -> IncrementalScopeResult {
+    ) -> IncrementalScopeResponseResult {
         incremental.set_response::<T>(commands)
     }
 }
@@ -988,7 +989,7 @@ impl MessageRegistry {
         message_info: &TypeInfo,
         incremental: &mut IncrementalScopeBuilder,
         commands: &mut Commands,
-    ) -> Result<Option<IncrementalScope>, DiagramErrorCode> {
+    ) -> Result<IncrementalScopeRequest, DiagramErrorCode> {
         let f = self
             .messages
             .get(message_info)
@@ -1005,7 +1006,7 @@ impl MessageRegistry {
         message_info: &TypeInfo,
         incremental: &mut IncrementalScopeBuilder,
         commands: &mut Commands,
-    ) -> Result<Option<IncrementalScope>, DiagramErrorCode> {
+    ) -> Result<IncrementalScopeResponse, DiagramErrorCode> {
         let f = self
             .messages
             .get(message_info)

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -657,7 +657,7 @@ pub(super) struct MessageOperation {
     pub(super) to_string_impl: Option<ToStringFn>,
     pub(super) create_buffer_impl: CreateBufferFn,
     pub(super) create_trigger_impl: CreateTriggerFn,
-    pub(super) build_scope: BuildScope,
+    build_scope: BuildScope,
 }
 
 impl MessageOperation {

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -58,6 +58,10 @@ pub struct ScopeSchema {
 
     /// Where to connect the output of this scope.
     pub next: NextOperation,
+
+    /// Settings specific to the scope, e.g. whether it is interruptible.
+    #[serde(default)]
+    pub settings: ScopeSettings,
 }
 
 impl BuildDiagramOperation for ScopeSchema {
@@ -67,7 +71,7 @@ impl BuildDiagramOperation for ScopeSchema {
         builder: &mut Builder,
         ctx: &mut DiagramContext,
     ) -> Result<BuildStatus, DiagramErrorCode> {
-        let scope = IncrementalScopeBuilder::begin(ScopeSettings::default(), builder);
+        let scope = IncrementalScopeBuilder::begin(self.settings.clone(), builder);
 
         for (stream_in_id, stream_out_target) in &self.stream_out {
             ctx.set_connect_into_target(
@@ -487,4 +491,6 @@ mod tests {
         assert_eq!(outcome_stream_i32, [5, 10, -3, -27]);
         assert_eq!(outcome_stream_string, ["5", "10", "-3", "-27", "hello"]);
     }
+
+    // TODO(@mxgrey): Add an interruptibility test
 }

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use std::{collections::HashMap, sync::Arc};
+
+use schemars::{schema::Schema, JsonSchema};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AnyBuffer, AnyMessageBox, Buffer, Builder, InputSlot, JsonBuffer, JsonMessage, Output,
+};
+
+use super::{
+    BuildDiagramOperation, BuildStatus, BuilderId, DiagramContext, DiagramElementRegistry,
+    DiagramErrorCode, DynInputSlot, DynOutput, NamespacedOperation, NextOperation, OperationName,
+    Operations, TypeInfo,
+};
+
+/// The schema to define a scope within a diagram.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ScopeSchema {
+    /// Indicates which node inside the scope should receive the input into the
+    /// scope.
+    pub start: NextOperation,
+
+    /// To simplify diagram definitions, the diagram workflow builder will
+    /// sometimes insert implicit operations into the workflow, such as implicit
+    /// serializing and deserializing. These implicit operations may be fallible.
+    ///
+    /// This field indicates how a failed implicit operation should be handled.
+    /// If left unspecified, an implicit error will cause the entire workflow to
+    /// be cancelled.
+    #[serde(default)]
+    pub on_implicit_error: Option<NextOperation>,
+
+    /// Operations that exist inside this scope.
+    pub ops: Operations,
+}

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -51,3 +51,14 @@ pub struct ScopeSchema {
     /// Operations that exist inside this scope.
     pub ops: Operations,
 }
+
+impl BuildDiagramOperation for ScopeSchema {
+    fn build_diagram_operation(
+        &self,
+        id: &OperationName,
+        builder: &mut Builder,
+        ctx: &mut DiagramContext,
+    ) -> Result<BuildStatus, DiagramErrorCode> {
+        Ok(BuildStatus::Finished)
+    }
+}

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -50,6 +50,13 @@ pub struct ScopeSchema {
 
     /// Operations that exist inside this scope.
     pub ops: Operations,
+
+    /// Where to connect streams that are coming out of this scope.
+    #[serde(default)]
+    pub stream_out: HashMap<OperationName, NextOperation>,
+
+    /// Where to connect the output of this scope.
+    pub next: NextOperation,
 }
 
 impl BuildDiagramOperation for ScopeSchema {

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -72,11 +72,10 @@ impl BuildDiagramOperation for ScopeSchema {
                 id,
                 child_id,
                 op,
-                &self.ops,
-                Some(scope.builder_scope_context()),
+                self.ops.clone(),
+                Some(scope.builder_scope_context())
             );
         }
-
 
 
         Ok(BuildStatus::Finished)
@@ -159,7 +158,7 @@ impl ConnectIntoTarget for ConnectScopeResponse {
                 )?;
 
             if let Some(external_output) = external_output {
-                ctx.add_output_into_target(self.next.clone(), output);
+                ctx.add_output_into_target(self.next.clone(), external_output);
             }
 
             let mut connection = standard_input_connection(terminate, ctx.registry)?;

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -19,10 +19,10 @@ use std::{collections::{HashMap, HashSet}, sync::Arc};
 
 use schemars::{schema::Schema, JsonSchema};
 use serde::{Deserialize, Serialize};
+use smallvec::smallvec;
 
 use crate::{
-    AnyBuffer, AnyMessageBox, Buffer, Builder, InputSlot, JsonBuffer, JsonMessage, Output,
-    IncrementalScopeBuilder, IncrementalScopeRequest, IncrementalScopeResponse, ConnectIntoTarget,
+    Builder, IncrementalScopeBuilder, IncrementalScopeRequest, IncrementalScopeResponse, ConnectIntoTarget,
     InferMessageType,BuildDiagramOperation, BuildStatus, DiagramContext, DiagramElementRegistry,
     DiagramErrorCode, DynInputSlot, DynOutput, NamespacedOperation, NextOperation, OperationName,
     Operations, TypeInfo, OperationRef, ScopeSettings,
@@ -77,6 +77,23 @@ impl BuildDiagramOperation for ScopeSchema {
             );
         }
 
+        ctx.set_connect_into_target(
+            id,
+            ConnectScopeRequest {
+                scope: scope.clone(),
+                start: ctx.into_operation_ref(id),
+                connection: None,
+            },
+        )?;
+
+        ctx.set_connect_into_target(
+            OperationRef::Terminate(smallvec![Arc::clone(id)]),
+            ConnectScopeResponse {
+                scope,
+                next: ctx.into_operation_ref(&self.next),
+                connection: None,
+            },
+        )?;
 
         Ok(BuildStatus::Finished)
     }

--- a/src/diagram/section_schema.rs
+++ b/src/diagram/section_schema.rs
@@ -180,7 +180,7 @@ impl BuildDiagramOperation for SectionSchema {
                 let section = ctx.templates.get_template(section_template)?;
 
                 for (child_id, op) in section.ops.iter() {
-                    ctx.add_child_operation(id, child_id, op, &section.ops);
+                    ctx.add_child_operation(id, child_id, op, &section.ops, None);
                 }
 
                 section

--- a/src/diagram/section_schema.rs
+++ b/src/diagram/section_schema.rs
@@ -180,7 +180,7 @@ impl BuildDiagramOperation for SectionSchema {
                 let section = ctx.templates.get_template(section_template)?;
 
                 for (child_id, op) in section.ops.iter() {
-                    ctx.add_child_operation(id, child_id, op, &section.ops, None);
+                    ctx.add_child_operation(id, child_id, op, section.ops.clone(), None);
                 }
 
                 section

--- a/src/diagram/section_schema.rs
+++ b/src/diagram/section_schema.rs
@@ -27,7 +27,7 @@ use crate::{
 use super::{
     BuildDiagramOperation, BuildStatus, BuilderId, DiagramContext, DiagramElementRegistry,
     DiagramErrorCode, DynInputSlot, DynOutput, NamespacedOperation, NextOperation, OperationName,
-    Operations, TypeInfo,
+    Operations, TypeInfo, OperationRef, RedirectConnection,
 };
 
 pub use bevy_impulse_derive::Section;
@@ -210,6 +210,11 @@ impl BuildDiagramOperation for SectionSchema {
                 }
             }
         }
+
+        ctx.set_connect_into_target(
+            OperationRef::terminate_for(id.clone()),
+            RedirectConnection::new(ctx.into_operation_ref(&NextOperation::terminate())),
+        )?;
 
         Ok(BuildStatus::Finished)
     }

--- a/src/diagram/stream_out_schema.rs
+++ b/src/diagram/stream_out_schema.rs
@@ -40,7 +40,7 @@ impl BuildDiagramOperation for StreamOutSchema {
         _builder: &mut Builder,
         ctx: &mut DiagramContext,
     ) -> Result<BuildStatus, DiagramErrorCode> {
-        let redirect_to = ctx.into_operation_ref(StreamOutRef::new(Arc::clone(&self.name)));
+        let redirect_to = ctx.into_operation_ref(StreamOutRef::new_for_root(Arc::clone(&self.name)));
         ctx.set_connect_into_target(id, RedirectConnection::new(redirect_to))?;
 
         Ok(BuildStatus::Finished)

--- a/src/diagram/testing.rs
+++ b/src/diagram/testing.rs
@@ -87,7 +87,7 @@ impl DiagramTestFixture {
             .context
             .command(|cmds| cmds.request(request, workflow).take());
         self.context.run_while_pending(&mut recipient.response);
-        assert!(self.context.no_unhandled_errors());
+        assert!(self.context.no_unhandled_errors(), "{:#?}", self.context.get_unhandled_errors());
         let taken = recipient.response.take();
         if taken.is_available() {
             Ok((taken.available().unwrap(), recipient.streams))

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -962,15 +962,15 @@ where
     Ok(())
 }
 
-pub struct UnfinishedOperation<'a> {
+struct UnfinishedOperation<'a> {
     /// Name of the operation within its scope
-    pub id: OperationName,
+    id: OperationName,
     /// The namespaces that this operation takes place inside
-    pub namespaces: NamespaceList,
+    namespaces: NamespaceList,
     /// Description of the operation
-    pub op: &'a DiagramOperation,
+    op: &'a DiagramOperation,
     /// The sibling operations of the one that is being built
-    pub sibling_ops: &'a Operations,
+    sibling_ops: &'a Operations,
 }
 
 impl<'a> std::fmt::Debug for UnfinishedOperation<'a> {

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -574,12 +574,16 @@ impl<'a, 'c> DiagramContext<'a, 'c> {
     /// Operations added this way will be internal to the parent operation,
     /// which means they are not "exposed" to be connected to other operations
     /// that are not inside the parent.
+    ///
+    /// Use the scope argument if the child operation exists in a different scope
+    /// than the parent. For the child of a Section, this is None.
     pub fn add_child_operation(
         &mut self,
         id: &OperationName,
         child_id: &OperationName,
         op: impl Into<CowOperation<'a>>,
         sibling_ops: &'a Operations,
+        scope: Option<BuilderScopeContext>,
     ) {
         let mut namespaces = self.namespaces.clone();
         namespaces.push(Arc::clone(id));
@@ -591,7 +595,7 @@ impl<'a, 'c> DiagramContext<'a, 'c> {
                 namespaces,
                 op: op.into(),
                 sibling_ops,
-                scope: self.scope,
+                scope: scope.unwrap_or(self.scope),
             });
     }
 

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -28,7 +28,7 @@ use crate::{
 
 use super::{
     BufferSelection, BuiltinTarget, Diagram, DiagramElementRegistry, DiagramError,
-    DiagramErrorCode, DiagramOperation, DynInputSlot, DynOutput, ImplicitDeserialization,
+    DiagramErrorCode, DynInputSlot, DynOutput, ImplicitDeserialization,
     ImplicitSerialization, ImplicitStringify, NamespacedOperation, NextOperation, OperationName,
     Operations, Templates, TypeInfo, FinishingErrors,
 };
@@ -234,10 +234,20 @@ pub struct StreamOutRef {
 }
 
 impl StreamOutRef {
-    pub fn new(name: impl Into<Arc<str>>) -> Self {
+    pub fn new_for_root(stream_name: impl Into<Arc<str>>) -> Self {
         Self {
             namespaces: NamespaceList::new(),
-            name: name.into(),
+            name: stream_name.into(),
+        }
+    }
+
+    pub fn new_for_scope(
+        scope_name: impl Into<Arc<str>>,
+        stream_name: impl Into<Arc<str>>,
+    ) -> Self {
+        Self {
+            namespaces: smallvec![scope_name.into()],
+            name: stream_name.into(),
         }
     }
 
@@ -1127,7 +1137,7 @@ where
     let mut streams = DynStreamInputPack::default();
     Streams::into_dyn_stream_input_pack(&mut streams, scope.streams);
     for (name, input) in streams.named {
-        ctx.set_input_for_target(StreamOutRef::new(name), input)?;
+        ctx.set_input_for_target(StreamOutRef::new_for_root(name), input)?;
     }
 
     // Add the dispose operation

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -572,6 +572,17 @@ impl<'a, 'c> DiagramContext<'a, 'c> {
         id.in_namespaces(&self.namespaces)
     }
 
+    pub fn into_child_operation_ref(
+        &self,
+        id: &OperationName,
+        child_id: impl Into<OperationRef>,
+    ) -> OperationRef {
+        let child_id: OperationRef = child_id.into();
+        child_id
+            .in_namespaces(&[id.clone()])
+            .in_namespaces(&self.namespaces)
+    }
+
     /// Add an operation which exists as a child inside another operation.
     ///
     /// For example this is used by section templates to add their inner

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -51,6 +51,7 @@ pub enum OperationRef {
     Terminate(NamespaceList),
     Dispose,
     Cancel(NamespaceList),
+    EnterScope(NamespaceList),
     StreamOut(StreamOutRef),
 }
 
@@ -61,6 +62,7 @@ impl OperationRef {
             Self::Terminate(_) => Self::Terminate(parent_namespaces.iter().cloned().collect()),
             Self::Dispose => Self::Dispose,
             Self::Cancel(_) => Self::Cancel(parent_namespaces.iter().cloned().collect()),
+            Self::EnterScope(_) => Self::EnterScope(parent_namespaces.iter().cloned().collect()),
             Self::StreamOut(stream_out) => {
                 Self::StreamOut(stream_out.in_namespaces(parent_namespaces))
             }
@@ -103,6 +105,7 @@ impl std::fmt::Display for OperationRef {
             Self::Terminate(namespaces) => write!(f, "{}(terminate)", DisplayNamespaces(namespaces)),
             Self::Cancel(namespaces) => write!(f, "{}(cancel)", DisplayNamespaces(namespaces)),
             Self::Dispose => write!(f, "(dispose)"),
+            Self::EnterScope(namespaces) => write!(f, "{}(enter)", DisplayNamespaces(namespaces)),
             Self::StreamOut(stream_out) => write!(f, "{stream_out}"),
         }
     }

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -971,6 +971,9 @@ struct UnfinishedOperation<'a> {
     op: &'a DiagramOperation,
     /// The sibling operations of the one that is being built
     sibling_ops: &'a Operations,
+    /// The scope of this operation. This is used to create the correct Builder
+    /// for the operation.
+    // scope: BuilderScopeContext,
 }
 
 impl<'a> std::fmt::Debug for UnfinishedOperation<'a> {

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -122,6 +122,10 @@ fn flush_impulses_impl(
                 roster: &mut roster,
             });
             garbage_cleanup(world, &mut roster);
+            loop_count += 1;
+            if flush_loop_limit.is_some_and(|limit| limit < loop_count) {
+                break;
+            }
         }
 
         while let Some(source) = roster.awake.pop_front() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -117,7 +117,7 @@ impl<Response: 'static + Send + Sync> Output<Response> {
     where
         Response: 'static + Send + Sync,
     {
-        assert_eq!(self.scope, builder.scope);
+        assert_eq!(self.scope, builder.scope());
         Chain::new(self.target, builder)
     }
 
@@ -127,7 +127,7 @@ impl<Response: 'static + Send + Sync> Output<Response> {
     where
         Response: Clone,
     {
-        assert_eq!(self.scope, builder.scope);
+        assert_eq!(self.scope, builder.scope());
         builder.commands.add(AddOperation::new(
             Some(self.scope),
             self.target,
@@ -166,7 +166,7 @@ pub struct ForkCloneOutput<Response> {
 
 impl<Response: 'static + Send + Sync> ForkCloneOutput<Response> {
     pub fn clone_output(&self, builder: &mut Builder) -> Output<Response> {
-        assert_eq!(self.scope, builder.scope);
+        assert_eq!(self.scope, builder.scope());
         let target = builder
             .commands
             .spawn((SingleInputStorage::new(self.id()), UnusedTarget))

--- a/src/node/dyn_node.rs
+++ b/src/node/dyn_node.rs
@@ -180,7 +180,7 @@ where
 
 /// Error type that happens when you try to convert a [`DynOutput`] to an
 /// <code>[Output]&lt;T&gt;</code> for the wrong `T`.
-#[derive(ThisError, Debug)]
+#[derive(ThisError, Debug, Clone)]
 #[error("type mismatch: source {source_type}, target {target_type}")]
 pub struct TypeMismatch {
     /// What type of message is the [`DynOutput`] able to provide.

--- a/src/node/dyn_node.rs
+++ b/src/node/dyn_node.rs
@@ -53,7 +53,7 @@ where
 }
 
 /// A type erased [`InputSlot`]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DynInputSlot {
     scope: Entity,
     source: Entity,

--- a/src/node/dyn_node.rs
+++ b/src/node/dyn_node.rs
@@ -72,6 +72,14 @@ impl DynInputSlot {
     pub fn message_info(&self) -> &TypeInfo {
         &self.type_info
     }
+
+    pub(crate) fn new(
+        scope: Entity,
+        source: Entity,
+        type_info: TypeInfo,
+    ) -> Self {
+        Self { scope, source, type_info }
+    }
 }
 
 impl<T: Any> From<InputSlot<T>> for DynInputSlot {
@@ -107,14 +115,6 @@ pub struct DynOutput {
 }
 
 impl DynOutput {
-    pub fn new(scope: Entity, target: Entity, message_info: TypeInfo) -> Self {
-        Self {
-            scope,
-            target,
-            message_info,
-        }
-    }
-
     pub fn message_info(&self) -> &TypeInfo {
         &self.message_info
     }
@@ -160,6 +160,14 @@ impl DynOutput {
         });
 
         Ok(())
+    }
+
+    pub(crate) fn new(scope: Entity, target: Entity, message_info: TypeInfo) -> Self {
+        Self {
+            scope,
+            target,
+            message_info,
+        }
     }
 }
 

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -2207,7 +2207,7 @@ mod tests {
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
             let inner_scope = builder.create_io_scope(|scope, builder| {
-                scope.input.chain(builder).fork_clone((
+                builder.chain(scope.input).fork_clone((
                     |chain: Chain<_>| chain.then(long_delay).map_block(|_| "slow").connect(scope.terminate),
                     |chain: Chain<_>| chain.then(short_delay).map_block(|_| "fast").connect(scope.terminate),
                 ));

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -742,12 +742,6 @@ impl IncrementalScopeBuilder {
 
         commands.entity(scope_id).insert(ScopeSettingsStorage(settings));
 
-        let endpoints = ScopeEndpoints {
-            terminal,
-            enter_scope,
-            finish_scope_cancel,
-        };
-
         let scope = OperateScope {
             enter_scope,
             terminal,
@@ -760,7 +754,6 @@ impl IncrementalScopeBuilder {
         IncrementalScopeBuilder { inner: Arc::new(Mutex::new(IncrementalScopeBuilderInner {
             parent_scope,
             scope_id,
-            endpoints,
             enter_scope,
             terminal,
             exit_scope,
@@ -879,7 +872,6 @@ impl IncrementalScopeBuilder {
 struct IncrementalScopeBuilderInner {
     parent_scope: Entity,
     scope_id: Entity,
-    endpoints: ScopeEndpoints,
     enter_scope: Entity,
     terminal: Entity,
     exit_scope: Entity,

--- a/src/service/workflow.rs
+++ b/src/service/workflow.rs
@@ -266,7 +266,7 @@ where
             blocker,
         },
     );
-    begin_scope::<Request, Response, Streams>(
+    begin_scope::<Request>(
         input,
         scoped_session,
         OperationRequest {

--- a/src/stream/anonymous_stream.rs
+++ b/src/stream/anonymous_stream.rs
@@ -87,7 +87,7 @@ impl<S: StreamEffect> StreamPack for AnonymousStream<S> {
             source,
             RedirectWorkflowStream::new(AnonymousStreamRedirect::<S>::new(None)),
         ));
-        InputSlot::new(builder.scope, source)
+        InputSlot::new(builder.scope(), source)
     }
 
     fn spawn_node_streams(
@@ -101,7 +101,7 @@ impl<S: StreamEffect> StreamPack for AnonymousStream<S> {
             .id();
 
         map.add_anonymous::<S::Output>(target, builder.commands());
-        Output::new(builder.scope, target)
+        Output::new(builder.scope(), target)
     }
 
     fn take_streams(

--- a/src/stream/dynamically_named_stream.rs
+++ b/src/stream/dynamically_named_stream.rs
@@ -83,7 +83,7 @@ impl<S: StreamEffect> StreamPack for DynamicallyNamedStream<S> {
             source,
             RedirectWorkflowStream::new(NamedStreamRedirect::<S>::dynamic()),
         ));
-        InputSlot::new(builder.scope, source)
+        InputSlot::new(builder.scope(), source)
     }
 
     fn spawn_node_streams(
@@ -97,7 +97,7 @@ impl<S: StreamEffect> StreamPack for DynamicallyNamedStream<S> {
             .id();
 
         map.add_anonymous::<NamedValue<S::Output>>(target, builder.commands());
-        Output::new(builder.scope, target)
+        Output::new(builder.scope(), target)
     }
 
     fn take_streams(

--- a/src/stream/named_stream.rs
+++ b/src/stream/named_stream.rs
@@ -66,7 +66,7 @@ impl<S: StreamEffect> NamedStream<S> {
             source,
             RedirectWorkflowStream::new(NamedStreamRedirect::<S>::static_name(name.into())),
         ));
-        InputSlot::new(builder.scope, source)
+        InputSlot::new(builder.scope(), source)
     }
 
     pub fn spawn_node_stream(
@@ -81,7 +81,7 @@ impl<S: StreamEffect> NamedStream<S> {
             .id();
 
         map.add_named::<S::Output>(name.into(), target, builder.commands());
-        Output::new(builder.scope, target)
+        Output::new(builder.scope(), target)
     }
 
     pub fn take_stream(

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -180,7 +180,12 @@ pub enum DeliverySettings {
 }
 
 /// Settings which determine how the top-level scope of the workflow behaves.
-#[derive(Default, Clone)]
+#[cfg_attr(
+    feature = "diagram",
+    derive(serde::Serialize, serde::Deserialize, schemars::JsonSchema),
+    serde(rename_all = "snake_case")
+)]
+#[derive(Default, Clone, Debug)]
 pub struct ScopeSettings {
     /// Should we prevent the scope from being interrupted (e.g. cancelled)?
     /// False by default, meaning by default scopes can be cancelled or

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -233,7 +233,7 @@ impl<'w, 's> SpawnWorkflowExt for Commands<'w, 's> {
             terminal,
             enter_scope,
             finish_scope_cancel,
-        } = OperateScope::<Request, Response>::add(None, scope_id, None, self);
+        } = OperateScope::add::<Request, Response>(None, scope_id, None, self);
 
         let mut builder = Builder {
             scope: scope_id,

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -233,7 +233,7 @@ impl<'w, 's> SpawnWorkflowExt for Commands<'w, 's> {
             terminal,
             enter_scope,
             finish_scope_cancel,
-        } = OperateScope::<Request, Response, Streams>::add(None, scope_id, None, self);
+        } = OperateScope::<Request, Response>::add(None, scope_id, None, self);
 
         let mut builder = Builder {
             scope: scope_id,

--- a/src/workflow.rs
+++ b/src/workflow.rs
@@ -22,8 +22,9 @@ use bevy_ecs::{
 use bevy_hierarchy::BuildChildren;
 
 use crate::{
-    Builder, DeliveryChoice, InputSlot, OperateScope, Output, ScopeEndpoints, ScopeSettingsStorage,
-    Service, ServiceBundle, StreamAvailability, StreamPack, WorkflowService, WorkflowStorage,
+    Builder, BuilderScopeContext, DeliveryChoice, InputSlot, OperateScope, Output,
+    ScopeEndpoints, ScopeSettingsStorage, Service, ServiceBundle, StreamAvailability,
+    StreamPack, WorkflowService, WorkflowStorage,
 };
 
 mod internal;
@@ -236,8 +237,7 @@ impl<'w, 's> SpawnWorkflowExt for Commands<'w, 's> {
         } = OperateScope::add::<Request, Response>(None, scope_id, None, self);
 
         let mut builder = Builder {
-            scope: scope_id,
-            finish_scope_cancel,
+            context: BuilderScopeContext { scope: scope_id, finish_scope_cancel },
             commands: self,
         };
 


### PR DESCRIPTION
This PR introduces the ability to create workflow scopes within diagrams that can be built at runtime.

Workflow scopes have several different practical uses:
- Isolate a portion of a workflow from interference with other simultaneous workflow activity. Each time a scope is entered, an isolated workflow session is started. Buffer data and all other activity within the same scope operation will be separate for each session.
- Race multiple branches against each other, keeping the result of the branch that finishes first while disposing of the rest. Within a scope, whichever message is sent to the `terminate` operation first will end the scope immediately and all other operations within the scope will be cancelled. This is useful for parallelized problem solving: If you have multiple ways to achieve a result and they can run in parallel, you can use a scope to run all of them at once and take the outcome of whichever finished first.
- Mark a portion of a workflow as uninterruptible. Even if a workflow terminates or gets cancelled, an uninterruptible scope will finish its execution before the the workflow can enter its cleanup stage.