### PR TITLE
Zenoh examples

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -18,7 +18,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rust-version: [stable, 1.75]
+        rust-version: [stable]
 
     runs-on: ubuntu-latest
 
@@ -27,14 +27,6 @@ jobs:
 
     - name: Setup rust
       run: rustup default ${{ matrix.rust-version }}
-
-    # As new versions of our dependencies come out, they might depend on newer
-    # versions of the Rust compiler. When that happens, we'll use this step to
-    # lock down the dependency to a version that is known to be compatible with
-    # compiler version 1.75.
-    - name: Patch dependencies
-      if: ${{ matrix.rust-version == 1.75 }}
-      run: ./scripts/patch-versions-msrv-1_75.sh
 
     - name: Build default features
       run: cargo build --workspace

--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -25,6 +25,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Get apt dependencies
+      run: sudo apt-get install libprotoc-dev
+
     - name: Setup rust
       run: rustup default ${{ matrix.rust-version }}
 

--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Get apt dependencies
-      run: sudo apt-get install libprotoc-dev
+      run: sudo apt-get install protobuf-compiler
 
     - name: Setup rust
       run: rustup default ${{ matrix.rust-version }}

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -30,21 +30,21 @@ jobs:
       shell: powershell
 
     - name: Build default features
-      run: cargo build --workspace
+      run: cargo build --package bevy_impulse --workspace
       shell: cmd
 
     - name: Test default features
-      run: cargo test --workspace
+      run: cargo test --package bevy_impulse --workspace
       shell: cmd
 
     - name: Test diagram
-      run: cargo test --workspace -F=diagram
+      run: cargo test --package bevy_impulse --workspace -F=diagram
       shell: cmd
 
     - name: Build single_threaded_async
-      run: cargo build --features single_threaded_async
+      run: cargo build --package bevy_impulse --features single_threaded_async
       shell: cmd
 
     - name: Test single_threaded_async
-      run: cargo test --features single_threaded_async
+      run: cargo test --package bevy_impulse --features single_threaded_async
       shell: cmd

--- a/.github/workflows/ci_windows.yaml
+++ b/.github/workflows/ci_windows.yaml
@@ -30,15 +30,15 @@ jobs:
       shell: powershell
 
     - name: Build default features
-      run: cargo build --package bevy_impulse --workspace
+      run: cargo build --package bevy_impulse
       shell: cmd
 
     - name: Test default features
-      run: cargo test --package bevy_impulse --workspace
+      run: cargo test --package bevy_impulse
       shell: cmd
 
     - name: Test diagram
-      run: cargo test --package bevy_impulse --workspace -F=diagram
+      run: cargo test --package bevy_impulse -F=diagram
       shell: cmd
 
     - name: Build single_threaded_async

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,10 @@ test-log = { version = "0.2.16", features = [
 ], default-features = false }
 
 [workspace]
-members = ["examples/diagram/calculator"]
+members = [
+  "examples/diagram/calculator",
+  "examples/zenoh-examples",
+]
 
 [[bin]]
 name = "generate_schema"

--- a/diagram.schema.json
+++ b/diagram.schema.json
@@ -51,9 +51,6 @@
     "BufferSelection": {
       "anyOf": [
         {
-          "$ref": "#/definitions/NextOperation"
-        },
-        {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/NextOperation"

--- a/examples/diagram/calculator/src/main.rs
+++ b/examples/diagram/calculator/src/main.rs
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
 use std::{error::Error, fs::File, str::FromStr};
 
 use bevy_impulse::{

--- a/examples/zenoh-examples/Cargo.toml
+++ b/examples/zenoh-examples/Cargo.toml
@@ -14,6 +14,8 @@ bevy_ecs = "0.12"
 bevy_time = "0.12"
 bevy_impulse = { version = "0.0.2", path = "../..", features = ["diagram"] }
 futures = "0.3"
+schemars = { version = "0.8.21" }
+serde = { version = "1.0.210", features = ["derive", "rc"] }
 serde_json = "1.0.128"
 prost = "0.13.5"
 tracing = "0.1.41"

--- a/examples/zenoh-examples/Cargo.toml
+++ b/examples/zenoh-examples/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "zenoh-examples"
+version = "0.0.2"
+edition = "2021"
+
+[[bin]]
+name = "door-manager"
+path = "src/door_manager.rs"
+
+[dependencies]
+bevy_app = "0.12"
+bevy_core = "0.12"
+bevy_ecs = "0.12"
+bevy_impulse = { version = "0.0.2", path = "../..", features = ["diagram"] }
+futures = "0.3"
+serde_json = "1.0.128"
+prost = "0.13.5"
+clap = { version = "4.5.23", features = ["derive"] }
+zenoh = { version = "1.3.2", features = ["unstable"] }
+zenoh-ext = { version = "*", features = ["unstable"] }
+
+[build-dependencies]
+prost-build = "0.13.5"

--- a/examples/zenoh-examples/Cargo.toml
+++ b/examples/zenoh-examples/Cargo.toml
@@ -7,6 +7,10 @@ edition = "2021"
 name = "door-manager"
 path = "src/door_manager.rs"
 
+[[bin]]
+name = "use-door"
+path = "src/use_door.rs"
+
 [dependencies]
 bevy_app = "0.12"
 bevy_core = "0.12"
@@ -20,6 +24,7 @@ serde_json = "1.0.128"
 prost = "0.13.5"
 tracing = "0.1.41"
 clap = { version = "4.5.23", features = ["derive"] }
+uuid = { version = "*", features = ["v4"] }
 zenoh = { version = "1.3.2", features = ["unstable"] }
 zenoh-ext = { version = "*", features = ["unstable"] }
 

--- a/examples/zenoh-examples/Cargo.toml
+++ b/examples/zenoh-examples/Cargo.toml
@@ -11,10 +11,12 @@ path = "src/door_manager.rs"
 bevy_app = "0.12"
 bevy_core = "0.12"
 bevy_ecs = "0.12"
+bevy_time = "0.12"
 bevy_impulse = { version = "0.0.2", path = "../..", features = ["diagram"] }
 futures = "0.3"
 serde_json = "1.0.128"
 prost = "0.13.5"
+tracing = "0.1.41"
 clap = { version = "4.5.23", features = ["derive"] }
 zenoh = { version = "1.3.2", features = ["unstable"] }
 zenoh-ext = { version = "*", features = ["unstable"] }

--- a/examples/zenoh-examples/build.rs
+++ b/examples/zenoh-examples/build.rs
@@ -16,11 +16,7 @@
 */
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    prost_build::compile_protos(
-        &["protos/door.proto"],
-        &["protos/"],
-    )
-    .map_err(box_error)?;
+    prost_build::compile_protos(&["protos/door.proto"], &["protos/"]).map_err(box_error)?;
 
     Ok(())
 }

--- a/examples/zenoh-examples/build.rs
+++ b/examples/zenoh-examples/build.rs
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    prost_build::compile_protos(
+        &["protos/door.proto"],
+        &["protos/"],
+    )
+    .map_err(box_error)?;
+
+    Ok(())
+}
+
+fn box_error<E: std::error::Error + 'static>(err: E) -> Box<dyn std::error::Error> {
+    Box::new(err)
+}

--- a/examples/zenoh-examples/protos/door.proto
+++ b/examples/zenoh-examples/protos/door.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+syntax = "proto3";
+package impulse.zenoh_examples;
+
+message DoorState {
+    enum Status {
+        MOVING = 0;
+        CLOSED = 1;
+        OPEN = 2;
+    }
+
+    Status status = 1;
+    repeated string sessions = 2;
+}
+
+message DoorRequest {
+    enum Mode {
+        OPEN = 0;
+        RELEASE = 1;
+    }
+
+    Mode mode = 1;
+    string session = 2;
+}

--- a/examples/zenoh-examples/src/door_manager.rs
+++ b/examples/zenoh-examples/src/door_manager.rs
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_impulse::prelude::*;
+use clap::Parser;
+use zenoh_examples::protos;
+
+fn main() {
+    let args = Args::parse();
+
+
+}
+
+#[derive(Parser, Debug)]
+struct Args {
+    names: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DoorCommand {
+    Close,
+    Open,
+}
+
+struct DoorPosition {
+    position: f32,
+    speed: f32,
+}
+
+#[derive(Clone, Accessor)]
+struct DoorBuffers {
+    position: BufferKey<DoorPosition>,
+    command: BufferKey<DoorCommand>,
+}
+
+#[derive(StreamPack)]
+struct DoorControlStream {
+    status: protos::door_state::Status,
+}
+
+fn door_controller(
+    In(input): ContinuousServiceInput<((), DoorBuffers), (), DoorControlStream>,
+
+) {
+
+}

--- a/examples/zenoh-examples/src/door_manager.rs
+++ b/examples/zenoh-examples/src/door_manager.rs
@@ -16,8 +16,11 @@
 */
 
 use bevy_impulse::prelude::*;
+use bevy_time::Time;
 use clap::Parser;
 use zenoh_examples::protos;
+use std::collections::HashSet;
+use tracing::error;
 
 fn main() {
     let args = Args::parse();
@@ -30,21 +33,17 @@ struct Args {
     names: Vec<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum DoorCommand {
+    #[default]
     Close,
     Open,
 }
 
+#[derive(Clone, Copy, Debug)]
 struct DoorPosition {
     position: f32,
-    speed: f32,
-}
-
-#[derive(Clone, Accessor)]
-struct DoorBuffers {
-    position: BufferKey<DoorPosition>,
-    command: BufferKey<DoorCommand>,
+    nominal_speed: f32,
 }
 
 #[derive(StreamPack)]
@@ -52,9 +51,98 @@ struct DoorControlStream {
     status: protos::door_state::Status,
 }
 
-fn door_controller(
-    In(input): ContinuousServiceInput<((), DoorBuffers), (), DoorControlStream>,
+#[derive(Clone, Debug, Default)]
+struct DoorSessions {
+    names: HashSet<String>,
+}
 
+#[derive(Clone, Copy, Accessor)]
+struct ProcessRequestBuffers {
+    sessions: BufferKey<DoorSessions>,
+    commands: BufferKey<DoorCommand>,
+}
+
+fn process_request(
+    In(service): BlockingServiceInput<(protos::DoorRequest, ProcessRequestBuffers)>,
+    mut session_access: BufferAccessMut<DoorSessions>,
+    mut command_access: BufferAccessMut<DoorCommand>,
 ) {
+    let (request, keys) = service.request;
+    let Ok(mut sessions) = session_access.get_mut(&keys.sessions) else {
+        error!("Session buffer is broken");
+    };
 
+    let sessions = sessions.newest_mut_or_default().unwrap();
+
+    let Ok(mut commands) = command_access.get_mut(&keys.commands) else {
+        error!("Command buffer is broken");
+    };
+
+    match request.mode() {
+        protos::door_request::Mode::Open => {
+            if sessions.names.insert(request.session) {
+                commands.push(DoorCommand::Open);
+            }
+        }
+        protos::door_request::Mode::Release => {
+            if sessions.names.remove(&request.session) {
+                commands.push(DoorCommand::Close);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Accessor)]
+struct DoorControlBuffers {
+    position: BufferKey<DoorPosition>,
+    command: BufferKey<DoorCommand>,
+}
+
+fn door_controller(
+    In(input): ContinuousServiceInput<((), DoorControlBuffers), (), DoorControlStream>,
+    mut requests: ContinuousQuery<((), DoorControlBuffers), (), DoorControlStream>,
+    mut position_access: BufferAccessMut<DoorPosition>,
+    mut command_access: BufferAccess<DoorCommand>,
+    time: Res<Time>,
+) {
+    let mut orders = requests.get_mut(&input.key).unwrap();
+    orders.for_each(|order| {
+        let keys = order.request().1;
+        let Ok(mut position_buffer) = position_access.get_mut(&keys.position) else {
+            error!("Position buffer is broken");
+            return;
+        };
+        let Some(state) = position_buffer.newest_mut() else {
+            return;
+        };
+
+        let Some(command_buffer) = command_access.get_newest(&keys.command) else {
+            return;
+        };
+
+        match command {
+            DoorCommand::Close => {
+                if state.position < 1.0 {
+                    // The door is not closed, so let's drive it toward 1.0
+                    let delta = state.nominal_speed * time.delta_seconds();
+                    let new_position = f32::min(state.position + delta, 1.0);
+                    state.position = new_position;
+                    if new_position == 1.0 {
+                        order.streams().status.send(protos::door_state::Status::Closed);
+                    }
+                }
+            }
+            DoorCommand::Open => {
+                if state.position > 0.0 {
+                    // The door is not open, so let's drive it toward 0.0
+                    let delta = state.nominal_speed * time.delta_seconds();
+                    let new_position = f32::max(state.position - delta, 0.0);
+                    state.position = new_position;
+                    if new_position == 0.0 {
+                        order.streams().status.send(protos::door_state::Status::Open);
+                    }
+                }
+            }
+        }
+    });
 }

--- a/examples/zenoh-examples/src/lib.rs
+++ b/examples/zenoh-examples/src/lib.rs
@@ -31,7 +31,7 @@ use std::{
 use zenoh::Session;
 use zenoh_ext::{AdvancedPublisher, AdvancedPublisherBuilderExt, AdvancedSubscriberBuilderExt, CacheConfig, HistoryConfig, RecoveryConfig};
 
-type ArcError = Arc<dyn Error + Send + Sync + 'static>;
+pub type ArcError = Arc<dyn Error + Send + Sync + 'static>;
 
 #[derive(Default)]
 pub struct ZenohImpulsePlugin {}

--- a/examples/zenoh-examples/src/lib.rs
+++ b/examples/zenoh-examples/src/lib.rs
@@ -107,3 +107,10 @@ pub fn zenoh_subscription_node<T: 'static + Send + Sync + Message + Default>(
 
     builder.create_node(service)
 }
+
+pub fn zenoh_publisher_node<T: 'static + Send + Sync>(
+    topic_name: Arc<str>,
+    builder: &mut Builder,
+) -> Node<(), Result<(), ArcError>> {
+
+}

--- a/examples/zenoh-examples/src/lib.rs
+++ b/examples/zenoh-examples/src/lib.rs
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_app::{App, Plugin};
+use bevy_ecs::prelude::*;
+use bevy_impulse::prelude::*;
+use futures::future::Shared;
+use prost::Message;
+pub mod protos;
+use std::{
+    error::Error,
+    sync::Arc
+};
+use zenoh::Session;
+use zenoh_ext::{AdvancedSubscriberBuilderExt, HistoryConfig, RecoveryConfig};
+
+type ArcError = Arc<dyn Error + Send + Sync + 'static>;
+
+#[derive(Default)]
+pub struct ZenohImpulsePlugin {}
+
+impl Plugin for ZenohImpulsePlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ZenohSession>();
+    }
+}
+
+#[derive(Resource)]
+pub struct ZenohSession {
+    pub promise: Shared<Promise<Result<Session, ArcError>>>,
+}
+
+impl FromWorld for ZenohSession {
+    fn from_world(world: &mut World) -> Self {
+        let promise = world.command(|commands| {
+            commands
+                .serve(async {
+                    zenoh::open(zenoh::Config::default())
+                        .await
+                        .map_err(Arc::from)
+                })
+                .take_response()
+        })
+        .shared();
+
+        Self { promise }
+    }
+}
+
+pub struct ZenoSubscriptionRequest {
+    pub topic_name: String,
+}
+
+#[derive(StreamPack)]
+pub struct ZenohSubscriptionStream<T: 'static + Send + Sync> {
+    pub sample: T,
+}
+
+pub fn zenoh_subscription_node<T: 'static + Send + Sync + Message + Default>(
+    topic_name: Arc<str>,
+    builder: &mut Builder,
+) -> Node<(), Result<(), ArcError>, ZenohSubscriptionStream<T>> {
+    let service = builder.commands().spawn_service(
+        move |
+            In(input): AsyncServiceInput<(), ZenohSubscriptionStream<T>>,
+            session: Res<ZenohSession>,
+        | {
+            let session = session.promise.clone();
+            let topic_name = topic_name.clone();
+            async move {
+                let session = session.await.available().unwrap()?;
+
+                let subscriber = session
+                    .declare_subscriber(topic_name.as_ref())
+                    .history(HistoryConfig::default().detect_late_publishers())
+                    .recovery(RecoveryConfig::default())
+                    .await?;
+
+                loop {
+                    let sample = subscriber.recv_async().await?;
+                    match T::decode(&*sample.payload().to_bytes()) {
+                        Ok(msg) => {
+                            input.streams.sample.send(msg);
+                        }
+                        Err(err) => {
+                            println!("Error decoding incoming sample on topic [{topic_name}]: {err}");
+                        }
+                    }
+                }
+            }
+        }
+    );
+
+    builder.create_node(service)
+}

--- a/examples/zenoh-examples/src/protos.rs
+++ b/examples/zenoh-examples/src/protos.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+include!(concat!(env!("OUT_DIR"), "/impulse.zenoh_examples.rs"));

--- a/examples/zenoh-examples/src/use_door.rs
+++ b/examples/zenoh-examples/src/use_door.rs
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_app::{App, Update};
+use bevy_ecs::prelude::Res;
+use bevy_impulse::prelude::*;
+use bevy_time::{Time, TimePlugin};
+use clap::Parser;
+use zenoh_examples::protos;
+use serde::{Serialize, Deserialize};
+use schemars::JsonSchema;
+use serde_json::json;
+use std::collections::HashSet;
+use tracing::error;
+use uuid::Uuid;
+
+use zenoh_examples::{
+    zenoh_publisher_node, zenoh_subscription_node,
+    ArcError, ZenohImpulsePlugin, ZenohTopicConfig,
+};
+
+fn main() {
+    let args = Args::parse();
+
+    let mut registry = DiagramElementRegistry::default();
+
+    let session = format!("{}", Uuid::new_v4());
+
+    registry
+        .opt_out()
+        .no_serializing()
+        .no_deserializing()
+        .register_node_builder(
+            NodeBuilderOptions::new("door_request_publisher"),
+            |builder, config: ZenohTopicConfig| {
+                zenoh_publisher_node::<protos::DoorRequest>(config.topic_name, builder)
+            }
+        );
+
+    registry
+        .opt_out()
+        .no_serializing()
+        .no_deserializing()
+        .register_node_builder(
+            NodeBuilderOptions::new("door_state_subscription"),
+            |builder, config: ZenohTopicConfig| {
+                zenoh_subscription_node::<protos::DoorState>(config.topic_name, builder)
+            }
+        );
+
+    // registry.register_node_builder(
+    //     NodeBuilderOptions::new("door_handshake"),
+    //     |builder, config: HandshakeConfig| {
+
+    //     }
+    // )
+
+    let diagram = Diagram::from_json(json!({
+        "version": "0.1.0",
+        "start": "request_door",
+        "ops": {
+            "request_door": {
+
+            }
+        }
+    }))
+    .unwrap();
+}
+
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct HandshakeConfig {
+    session: String,
+    door: String,
+    // status: protos::door_request::Mode,
+}
+
+#[derive(Parser)]
+struct Args {
+    #[arg(short, long, required = true)]
+    door: String,
+
+    #[arg(short, long, default_value_t = 1.0)]
+    time: f32,
+}

--- a/examples/zenoh-examples/src/use_door.rs
+++ b/examples/zenoh-examples/src/use_door.rs
@@ -15,8 +15,8 @@
  *
 */
 
-use bevy_app::{App, Update};
-use bevy_ecs::prelude::Res;
+use bevy_app::{App, Update, AppExit};
+use bevy_ecs::prelude::{Res, EventWriter};
 use bevy_impulse::prelude::*;
 use bevy_time::{Time, TimePlugin};
 use clap::Parser;
@@ -24,76 +24,228 @@ use zenoh_examples::protos;
 use serde::{Serialize, Deserialize};
 use schemars::JsonSchema;
 use serde_json::json;
-use std::collections::HashSet;
 use tracing::error;
 use uuid::Uuid;
 
 use zenoh_examples::{
     zenoh_publisher_node, zenoh_subscription_node,
-    ArcError, ZenohImpulsePlugin, ZenohTopicConfig,
+    ZenohImpulsePlugin,
 };
-
-fn main() {
-    let args = Args::parse();
-
-    let mut registry = DiagramElementRegistry::default();
-
-    let session = format!("{}", Uuid::new_v4());
-
-    registry
-        .opt_out()
-        .no_serializing()
-        .no_deserializing()
-        .register_node_builder(
-            NodeBuilderOptions::new("door_request_publisher"),
-            |builder, config: ZenohTopicConfig| {
-                zenoh_publisher_node::<protos::DoorRequest>(config.topic_name, builder)
-            }
-        );
-
-    registry
-        .opt_out()
-        .no_serializing()
-        .no_deserializing()
-        .register_node_builder(
-            NodeBuilderOptions::new("door_state_subscription"),
-            |builder, config: ZenohTopicConfig| {
-                zenoh_subscription_node::<protos::DoorState>(config.topic_name, builder)
-            }
-        );
-
-    // registry.register_node_builder(
-    //     NodeBuilderOptions::new("door_handshake"),
-    //     |builder, config: HandshakeConfig| {
-
-    //     }
-    // )
-
-    let diagram = Diagram::from_json(json!({
-        "version": "0.1.0",
-        "start": "request_door",
-        "ops": {
-            "request_door": {
-
-            }
-        }
-    }))
-    .unwrap();
-}
-
-
-#[derive(Serialize, Deserialize, JsonSchema)]
-struct HandshakeConfig {
-    session: String,
-    door: String,
-    // status: protos::door_request::Mode,
-}
 
 #[derive(Parser)]
 struct Args {
     #[arg(short, long, required = true)]
     door: String,
 
-    #[arg(short, long, default_value_t = 1.0)]
+    #[arg(short, long, default_value_t = 5.0)]
     time: f32,
+}
+
+fn main() {
+    let args = Args::parse();
+    let mut app = App::new();
+    app.add_plugins((
+        ImpulseAppPlugin::default(),
+        ZenohImpulsePlugin::default(),
+        TimePlugin::default(),
+    ));
+
+    let mut registry = DiagramElementRegistry::default();
+
+    let session = format!("{}", Uuid::new_v4());
+
+    registry.register_node_builder(
+        NodeBuilderOptions::new("use_door"),
+        |builder, config: UseDoorConfig| {
+            let door_name = &config.door;
+            let request_topic_name = format!("door_request/{door_name}");
+            let state_topic_name = format!("door_state/{door_name}");
+
+            let subscriber = zenoh_subscription_node::<protos::DoorState>(
+                state_topic_name.as_str().into(),
+                builder,
+            );
+            let publisher = zenoh_publisher_node::<protos::DoorRequest>(
+                request_topic_name.as_str().into(),
+                builder,
+            );
+
+            let (input, startup) = builder.create_fork_clone::<()>();
+            startup.clone_chain(builder).connect(subscriber.input);
+
+            let request_msg = match config.usage {
+                DoorUsageMode::Open => {
+                    protos::DoorRequest {
+                        mode: protos::door_request::Mode::Open.into(),
+                        session: config.session.clone(),
+                    }
+                }
+                DoorUsageMode::Release => {
+                    protos::DoorRequest {
+                        mode: protos::door_request::Mode::Release.into(),
+                        session: config.session.clone(),
+                    }
+                }
+            };
+
+            startup
+                .clone_chain(builder)
+                .map_block(move |_| request_msg.clone())
+                .connect(publisher.input);
+
+            let output = builder
+                .chain(subscriber.streams.sample)
+                .map_block(move |state| {
+                    match config.usage {
+                        DoorUsageMode::Open => {
+                            // We want to see that the door is both open and
+                            // includes our session ID
+                            if state.sessions.contains(&config.session) {
+                                if state.status() == protos::door_state::Status::Open {
+                                    return Some(());
+                                }
+                            }
+
+                            None
+                        }
+                        DoorUsageMode::Release => {
+                            // We just need to see that the session is not
+                            // present in the door state
+                            if !state.sessions.contains(&config.session) {
+                                return Some(());
+                            }
+
+                            None
+                        }
+                    }
+                })
+                .dispose_on_none()
+                // Stop the subscriber once we have what we need
+                .then_trim([TrimBranch::single_point(&subscriber.input)])
+                .output();
+
+            Node::<_, _, ()> { input, output, streams: () }
+        }
+    );
+
+    let move_robot_service = app.spawn_continuous_service(Update, move_robot);
+    registry.register_node_builder(
+        NodeBuilderOptions::new("move"),
+        move |builder, config: MoveConfig| {
+            let time_buffer = builder.create_buffer(BufferSettings::default());
+            let access = builder.create_buffer_access(time_buffer);
+            let output = builder.chain(access.output).then(move_robot_service).output();
+
+            let (input, startup) = builder.create_fork_clone::<()>();
+            startup
+                .clone_chain(builder)
+                .map_block(move |_| {
+                    println!("Moving for the next {}s", config.time);
+                    config.time
+                })
+                .connect(time_buffer.input_slot());
+
+            startup.clone_chain(builder).connect(access.input);
+
+            Node::<_, _, ()> { input, output, streams: () }
+        }
+    );
+
+    let diagram = Diagram::from_json(json!({
+        "version": "0.1.0",
+        "start": "open_door",
+        "ops": {
+            "open_door": {
+                "type": "node",
+                "builder": "use_door",
+                "config": {
+                    "session": session,
+                    "door": args.door,
+                    "usage": "open"
+                },
+                "next": "move_through_door"
+            },
+            "move_through_door": {
+                "type": "node",
+                "builder": "move",
+                "config": {
+                    "time": args.time,
+                },
+                "next": "close_door"
+            },
+            "close_door": {
+                "type": "node",
+                "builder": "use_door",
+                "config": {
+                    "session": session,
+                    "door": args.door,
+                    "usage": "release"
+                },
+                "next": { "builtin": "terminate" }
+            }
+        }
+    }))
+    .unwrap();
+
+    app.world.command(|commands| {
+        let workflow = diagram.spawn_io_workflow::<(), ()>(commands, &mut registry).unwrap();
+        let _ = commands.request((), workflow).then(exit_app.into_blocking_callback()).detach();
+    });
+
+    app.run();
+}
+
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct UseDoorConfig {
+    session: String,
+    door: String,
+    usage: DoorUsageMode,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct MoveConfig {
+    time: f32,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum DoorUsageMode {
+    Open,
+    Release,
+}
+
+fn move_robot(
+    In(service): ContinuousServiceInput<((), BufferKey<f32>), ()>,
+    mut query: ContinuousQuery<((), BufferKey<f32>), ()>,
+    mut remaining_time_access: BufferAccessMut<f32>,
+    time: Res<Time>,
+) {
+    let Some(mut requests) = query.get_mut(&service.key) else {
+        return;
+    };
+
+    requests.for_each(|order| {
+        let time_key = &order.request().1;
+        let Ok(mut remaining_time) = remaining_time_access.get_mut(time_key) else {
+            error!("Unable to access remaining time buffer");
+            return;
+        };
+
+        let Some(t) = remaining_time.newest_mut() else {
+            return;
+        };
+
+        *t -= time.delta_seconds();
+        if *t <= 0.0 {
+            order.respond(());
+        }
+    });
+}
+
+fn exit_app(
+    In(_): In<()>,
+    mut exit: EventWriter<AppExit>,
+) {
+    exit.send(AppExit);
 }

--- a/macros/src/derive_buffer.rs
+++ b/macros/src/derive_buffer.rs
@@ -337,11 +337,11 @@ fn impl_buffer_clone(
     if noncopy {
         // Clone impl for structs with a buffer that is not copyable
         quote! {
-            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+            impl #impl_generics ::bevy_impulse::re_exports::Clone for #buffer_struct_ident #ty_generics #where_clause {
                 fn clone(&self) -> Self {
                     Self {
                         #(
-                            #field_ident: ::std::clone::Clone::clone(&self.#field_ident),
+                            #field_ident: ::bevy_impulse::re_exports::Clone::clone(&self.#field_ident),
                         )*
                     }
                 }
@@ -350,13 +350,13 @@ fn impl_buffer_clone(
     } else {
         // Clone and copy impl for structs with buffers that are all copyable
         quote! {
-            impl #impl_generics ::std::clone::Clone for #buffer_struct_ident #ty_generics #where_clause {
+            impl #impl_generics ::bevy_impulse::re_exports::Clone for #buffer_struct_ident #ty_generics #where_clause {
                 fn clone(&self) -> Self {
                     *self
                 }
             }
 
-            impl #impl_generics ::std::marker::Copy for #buffer_struct_ident #ty_generics #where_clause {}
+            impl #impl_generics ::bevy_impulse::re_exports::Copy for #buffer_struct_ident #ty_generics #where_clause {}
         }
     }
 }
@@ -401,9 +401,8 @@ fn impl_buffer_map_layout(
         }
 
         impl #impl_generics ::bevy_impulse::BufferMapStruct for #struct_ident #ty_generics #where_clause {
-            fn buffer_list(&self) -> ::smallvec::SmallVec<[::bevy_impulse::AnyBuffer; 8]> {
-                use smallvec::smallvec;
-                smallvec![#(
+            fn buffer_list(&self) -> ::bevy_impulse::re_exports::SmallVec<[::bevy_impulse::AnyBuffer; 8]> {
+                ::bevy_impulse::re_exports::smallvec![#(
                     ::bevy_impulse::AsAnyBuffer::as_any_buffer(&self.#field_ident),
                 )*]
             }

--- a/macros/src/derive_stream_pack.rs
+++ b/macros/src/derive_stream_pack.rs
@@ -120,11 +120,11 @@ pub(crate) fn impl_stream_pack(pack_struct: &ItemStruct) -> Result<TokenStream, 
         }
 
         impl #impl_generics ::bevy_impulse::StreamPack for #pack_ident #ty_generics #where_clause {
-            type StreamInputPack = #inputs;
-            type StreamOutputPack = #outputs;
-            type StreamReceivers = #receivers;
-            type StreamChannels = #channels;
-            type StreamBuffers = #buffers;
+            type StreamInputPack = #inputs #ty_generics;
+            type StreamOutputPack = #outputs #ty_generics;
+            type StreamReceivers = #receivers #ty_generics;
+            type StreamChannels = #channels #ty_generics;
+            type StreamBuffers = #buffers #ty_generics;
 
             fn spawn_scope_streams(
                 in_scope: ::bevy_impulse::re_exports::Entity,

--- a/scripts/patch-versions-msrv-1_75.sh
+++ b/scripts/patch-versions-msrv-1_75.sh
@@ -1,5 +1,0 @@
-# This script is useful for forcing dependencies to be compatible with Rust v1.75
-# Run this script in the root directory of the package.
-
-cargo add home@=0.5.9
-cargo add backtrace@=0.3.74

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -366,10 +366,7 @@ impl<'w, 's, T: 'static + Send + Sync> BufferAccess<'w, 's, T> {
         let session = key.session();
         self.query
             .get(key.buffer())
-            .map(|storage| BufferView {
-                storage,
-                session,
-            })
+            .map(|storage| BufferView { storage, session })
     }
 
     pub fn get_newest<'a>(&'a self, key: &BufferKey<T>) -> Option<&'a T> {
@@ -398,10 +395,7 @@ where
         let session = key.session();
         self.query
             .get(key.buffer())
-            .map(|storage| BufferView {
-                storage,
-                session,
-            })
+            .map(|storage| BufferView { storage, session })
     }
 
     pub fn get_newest<'a>(&'a self, key: &BufferKey<T>) -> Option<&'a T> {
@@ -415,9 +409,9 @@ where
         let buffer = key.buffer();
         let session = key.session();
         let accessor = key.tag.accessor;
-        self.query.get_mut(key.buffer()).map(|storage| {
-            BufferMut::new(storage, buffer, session, accessor, &mut self.commands)
-        })
+        self.query
+            .get_mut(key.buffer())
+            .map(|storage| BufferMut::new(storage, buffer, session, accessor, &mut self.commands))
     }
 }
 
@@ -477,7 +471,10 @@ impl BufferWorldAccess for World {
         })
     }
 
-    fn buffer_gate_view(&self, key: impl Into<AnyBufferKey>) -> Result<BufferGateView<'_>, BufferError> {
+    fn buffer_gate_view(
+        &self,
+        key: impl Into<AnyBufferKey>,
+    ) -> Result<BufferGateView<'_>, BufferError> {
         let key: AnyBufferKey = key.into();
         let buffer_ref = self
             .get_entity(key.tag.buffer)
@@ -668,10 +665,7 @@ where
     ///
     /// This may fail to provide a mutable borrow if the buffer was already
     /// expired or if the buffer capacity was zero.
-    pub fn newest_mut_or_else(
-        &mut self,
-        f: impl FnOnce() -> T,
-    ) -> Option<&mut T> {
+    pub fn newest_mut_or_else(&mut self, f: impl FnOnce() -> T) -> Option<&mut T> {
         self.modified = true;
         self.storage.newest_mut_or_else(self.session, f)
     }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -27,7 +27,7 @@ use std::{ops::RangeBounds, sync::Arc};
 use thiserror::Error as ThisError;
 
 use crate::{
-    Builder, Chain, Gate, GateState, InputSlot, NotifyBufferUpdate, OnNewBufferValue, UnusedTarget,
+    Builder, Chain, GateState, InputSlot, NotifyBufferUpdate, OnNewBufferValue, UnusedTarget,
 };
 
 mod any_buffer;

--- a/src/buffer/buffer_gate.rs
+++ b/src/buffer/buffer_gate.rs
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2025 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+use bevy_ecs::{
+    change_detection::Mut,
+    prelude::{Commands, Entity, Query},
+    query::QueryEntityError,
+    system::SystemParam,
+};
+
+use crate::{Gate, GateState, NotifyBufferUpdate, AnyBufferKey};
+
+/// This system parameter lets you get read-only access to the gate of a buffer
+/// that exists within a workflow. Use a [`BufferKey`][1] or [`AnyBufferKey`]
+/// to unlock the access.
+///
+/// See [`BufferGateAccessMut`] for mutable access.
+///
+/// [1]: crate::BufferKey
+#[derive(SystemParam)]
+pub struct BufferGateAccess<'w, 's> {
+    query: Query<'w, 's, &'static GateState>,
+}
+
+impl<'w, 's> BufferGateAccess<'w, 's> {
+    pub fn get<'a>(&'a self, key: impl Into<AnyBufferKey>) -> Result<BufferGateView<'a>, QueryEntityError> {
+        let key: AnyBufferKey = key.into();
+        let session = key.session();
+        self.query
+            .get(key.id())
+            .map(|gate| BufferGateView { gate, session })
+    }
+}
+
+/// Access to view the gate of a buffer that exists inside a workflow.
+pub struct BufferGateView<'a> {
+    pub(crate) gate: &'a GateState,
+    pub(crate) session: Entity,
+}
+
+impl<'a> BufferGateView<'a> {
+    /// Check whether the gate of this buffer is open or closed
+    pub fn gate(&self) -> Gate {
+        // Gate buffers are open by default, so pretend it's open if a session
+        // has never touched this buffer gate.
+        self.gate
+            .map
+            .get(&self.session)
+            .copied()
+            .unwrap_or(Gate::Open)
+    }
+}
+
+/// This system parameter lets you get mutable access to the gate of a buffer
+/// that exists within a workflow. Use a [`BufferKey`][1] or [`AnyBufferKey`]
+/// to unlock the access.
+///
+/// See [`BufferGateAccess`] for read-only access.
+#[derive(SystemParam)]
+pub struct BufferGateAccessMut<'w, 's> {
+    query: Query<'w, 's, &'static mut GateState>,
+    commands: Commands<'w, 's>,
+}
+
+impl<'w, 's> BufferGateAccessMut<'w, 's> {
+    pub fn get<'a>(&'a self, key: impl Into<AnyBufferKey>) -> Result<BufferGateView<'a>, QueryEntityError> {
+        let key: AnyBufferKey = key.into();
+        let session = key.session();
+        self.query
+            .get(key.id())
+            .map(|gate| BufferGateView { gate, session })
+    }
+
+    pub fn get_mut<'a>(
+        &'a mut self,
+        key: impl Into<AnyBufferKey>,
+    ) -> Result<BufferGateMut<'w, 's, 'a>, QueryEntityError> {
+        let key: AnyBufferKey = key.into();
+        let buffer = key.id();
+        let session = key.session();
+        let accessor = key.tag.accessor;
+        self.query.get_mut(buffer).map(|gate| {
+            BufferGateMut::new(gate, buffer, session, accessor, &mut self.commands)
+        })
+    }
+}
+
+/// Access to mutate the gate of a buffer that exists inside a workflow.
+pub struct BufferGateMut<'w, 's, 'a> {
+    gate: Mut<'a, GateState>,
+    buffer: Entity,
+    session: Entity,
+    accessor: Option<Entity>,
+    commands: &'a mut Commands<'w, 's>,
+    modified: bool,
+}
+
+impl<'w, 's, 'a> BufferGateMut<'w, 's, 'a> {
+    /// See documentation of [`crate::BufferMut::allow_closed_loops`].
+    pub fn allow_closed_loops(mut self) -> Self {
+        self.accessor = None;
+        self
+    }
+
+    /// Check whether the gate of this buffer is open or closed.
+    pub fn get(&self) -> Gate {
+        self.gate
+            .map
+            .get(&self.session)
+            .copied()
+            .unwrap_or(Gate::Open)
+    }
+
+    /// Tell the buffer [`Gate`] to open.
+    pub fn open_gate(&mut self) {
+        if let Some(gate) = self.gate.map.get_mut(&self.session) {
+            if *gate != Gate::Open {
+                *gate = Gate::Open;
+                self.modified = true;
+            }
+        }
+    }
+
+    /// Tell the buffer [`Gate`] to close.
+    pub fn close_gate(&mut self) {
+        if let Some(gate) = self.gate.map.get_mut(&self.session) {
+            *gate = Gate::Closed;
+            // There is no need to to indicate that a modification happened
+            // because listeners do not get notified about gates closing.
+        }
+    }
+
+    /// Perform an action on the gate of the buffer.
+    pub fn gate_action(&mut self, action: Gate) {
+        match action {
+            Gate::Open => self.open_gate(),
+            Gate::Closed => self.close_gate(),
+        }
+    }
+
+    fn new(
+        gate: Mut<'a, GateState>,
+        buffer: Entity,
+        session: Entity,
+        accessor: Entity,
+        commands: &'a mut Commands<'w, 's>,
+    ) -> Self {
+        Self {
+            gate,
+            buffer,
+            session,
+            accessor: Some(accessor),
+            commands,
+            modified: false,
+        }
+    }
+}
+
+impl<'w, 's, 'a> Drop for BufferGateMut<'w, 's, 'a> {
+    fn drop(&mut self) {
+        if self.modified {
+            self.commands.add(NotifyBufferUpdate::new(
+                self.buffer,
+                self.session,
+                self.accessor,
+            ));
+        }
+    }
+}

--- a/src/buffer/buffer_gate.rs
+++ b/src/buffer/buffer_gate.rs
@@ -22,7 +22,7 @@ use bevy_ecs::{
     system::SystemParam,
 };
 
-use crate::{Gate, GateState, NotifyBufferUpdate, AnyBufferKey};
+use crate::{AnyBufferKey, Gate, GateState, NotifyBufferUpdate};
 
 /// This system parameter lets you get read-only access to the gate of a buffer
 /// that exists within a workflow. Use a [`BufferKey`][1] or [`AnyBufferKey`]
@@ -37,7 +37,10 @@ pub struct BufferGateAccess<'w, 's> {
 }
 
 impl<'w, 's> BufferGateAccess<'w, 's> {
-    pub fn get<'a>(&'a self, key: impl Into<AnyBufferKey>) -> Result<BufferGateView<'a>, QueryEntityError> {
+    pub fn get<'a>(
+        &'a self,
+        key: impl Into<AnyBufferKey>,
+    ) -> Result<BufferGateView<'a>, QueryEntityError> {
         let key: AnyBufferKey = key.into();
         let session = key.session();
         self.query
@@ -77,7 +80,10 @@ pub struct BufferGateAccessMut<'w, 's> {
 }
 
 impl<'w, 's> BufferGateAccessMut<'w, 's> {
-    pub fn get<'a>(&'a self, key: impl Into<AnyBufferKey>) -> Result<BufferGateView<'a>, QueryEntityError> {
+    pub fn get<'a>(
+        &'a self,
+        key: impl Into<AnyBufferKey>,
+    ) -> Result<BufferGateView<'a>, QueryEntityError> {
         let key: AnyBufferKey = key.into();
         let session = key.session();
         self.query
@@ -93,9 +99,9 @@ impl<'w, 's> BufferGateAccessMut<'w, 's> {
         let buffer = key.id();
         let session = key.session();
         let accessor = key.tag.accessor;
-        self.query.get_mut(buffer).map(|gate| {
-            BufferGateMut::new(gate, buffer, session, accessor, &mut self.commands)
-        })
+        self.query
+            .get_mut(buffer)
+            .map(|gate| BufferGateMut::new(gate, buffer, session, accessor, &mut self.commands))
     }
 }
 

--- a/src/buffer/buffer_gate.rs
+++ b/src/buffer/buffer_gate.rs
@@ -73,6 +73,8 @@ impl<'a> BufferGateView<'a> {
 /// to unlock the access.
 ///
 /// See [`BufferGateAccess`] for read-only access.
+///
+/// [1]: crate::BufferKey
 #[derive(SystemParam)]
 pub struct BufferGateAccessMut<'w, 's> {
     query: Query<'w, 's, &'static mut GateState>,

--- a/src/buffer/buffer_storage.rs
+++ b/src/buffer/buffer_storage.rs
@@ -186,6 +186,22 @@ impl<T> BufferStorage<T> {
             .and_then(|q| q.first_mut())
     }
 
+    pub(crate) fn newest_mut_or_else(
+        &mut self,
+        session: Entity,
+        f: impl FnOnce() -> T,
+    ) -> Option<&mut T> {
+        self.reverse_queues
+            .get_mut(&session)
+            .and_then(|q| {
+                if q.is_empty() {
+                    Self::impl_push(q, self.settings.retention(), f());
+                }
+
+                q.first_mut()
+            })
+    }
+
     pub(crate) fn get_mut(&mut self, session: Entity, index: usize) -> Option<&mut T> {
         let reverse_queue = self.reverse_queues.get_mut(&session)?;
         let len = reverse_queue.len();

--- a/src/buffer/buffer_storage.rs
+++ b/src/buffer/buffer_storage.rs
@@ -191,15 +191,13 @@ impl<T> BufferStorage<T> {
         session: Entity,
         f: impl FnOnce() -> T,
     ) -> Option<&mut T> {
-        self.reverse_queues
-            .get_mut(&session)
-            .and_then(|q| {
-                if q.is_empty() {
-                    Self::impl_push(q, self.settings.retention(), f());
-                }
+        self.reverse_queues.get_mut(&session).and_then(|q| {
+            if q.is_empty() {
+                Self::impl_push(q, self.settings.retention(), f());
+            }
 
-                q.first_mut()
-            })
+            q.first_mut()
+        })
     }
 
     pub(crate) fn get_mut(&mut self, session: Entity, index: usize) -> Option<&mut T> {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1309,7 +1309,8 @@ mod tests {
             builder.connect(start_test, end_test);
         });
 
-        let mut promise = context.command(|commands| commands.request((), workflow).take_response());
+        let mut promise =
+            context.command(|commands| commands.request((), workflow).take_response());
         context.run_with_conditions(&mut promise, Duration::from_secs(10));
         assert!(context.no_unhandled_errors());
         let result = promise.take().available().unwrap();
@@ -1325,23 +1326,27 @@ mod tests {
                 .connect(end_test);
         });
 
-        let mut promise = context.command(|commands| commands.request((), workflow).take_response());
+        let mut promise =
+            context.command(|commands| commands.request((), workflow).take_response());
         context.run_with_conditions(&mut promise, Duration::from_secs(10));
         assert!(context.no_unhandled_errors());
         let result = promise.take().available().unwrap();
         println!("Performance for basic connection:\n{result:#?}");
     }
 
-    fn build_benchmark_fixture(scope: Scope<(), TimeStats>, builder: &mut Builder) -> (Output<Instant>, InputSlot<Instant>) {
-        let initial_time = builder.commands().spawn_service(
-            get_initial_time.into_blocking_service()
-        );
-        let finish_time = builder.commands().spawn_service(
-            finish_time_range.into_blocking_service()
-        );
-        let collect_samples = builder.commands().spawn_service(
-            collect_samples.into_blocking_service()
-        );
+    fn build_benchmark_fixture(
+        scope: Scope<(), TimeStats>,
+        builder: &mut Builder,
+    ) -> (Output<Instant>, InputSlot<Instant>) {
+        let initial_time = builder
+            .commands()
+            .spawn_service(get_initial_time.into_blocking_service());
+        let finish_time = builder
+            .commands()
+            .spawn_service(finish_time_range.into_blocking_service());
+        let collect_samples = builder
+            .commands()
+            .spawn_service(collect_samples.into_blocking_service());
 
         let samples = builder.create_buffer(BufferSettings::keep_all());
 
@@ -1386,7 +1391,7 @@ mod tests {
     }
 
     impl TimeStats {
-        fn new(samples: impl IntoIterator<Item=TimeRange>) -> Self {
+        fn new(samples: impl IntoIterator<Item = TimeRange>) -> Self {
             let samples: Vec<_> = samples
                 .into_iter()
                 .map(|s| s.finish_time - s.initial_time)
@@ -1417,7 +1422,13 @@ mod tests {
             let std_dev = Duration::from_nanos(f64::sqrt(radicand) as u64);
             let highest = highest.unwrap();
             let lowest = lowest.unwrap();
-            TimeStats { sample_count, average, std_dev, highest, lowest }
+            TimeStats {
+                sample_count,
+                average,
+                std_dev,
+                highest,
+                lowest,
+            }
         }
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -810,6 +810,7 @@ impl CleanupWorkflowConditions {
 mod tests {
     use crate::{prelude::*, testing::*, CancellationCause};
     use smallvec::SmallVec;
+    use std::time::Instant;
 
     #[test]
     fn test_disconnected_workflow() {
@@ -1297,5 +1298,149 @@ mod tests {
             .available()
             .is_some_and(|v| v == expectation));
         assert!(context.no_unhandled_errors());
+    }
+
+    #[test]
+    fn benchmarks() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let (start_test, end_test) = build_benchmark_fixture(scope, builder);
+            builder.connect(start_test, end_test);
+        });
+
+        let mut promise = context.command(|commands| commands.request((), workflow).take_response());
+        context.run_with_conditions(&mut promise, Duration::from_secs(10));
+        assert!(context.no_unhandled_errors());
+        let result = promise.take().available().unwrap();
+        println!("Performance for basic connection:\n{result:#?}");
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let (start_test, end_test) = build_benchmark_fixture(scope, builder);
+            builder
+                .chain(start_test)
+                .then_io_scope(|scope, builder| {
+                    builder.connect(scope.input, scope.terminate);
+                })
+                .connect(end_test);
+        });
+
+        let mut promise = context.command(|commands| commands.request((), workflow).take_response());
+        context.run_with_conditions(&mut promise, Duration::from_secs(10));
+        assert!(context.no_unhandled_errors());
+        let result = promise.take().available().unwrap();
+        println!("Performance for basic connection:\n{result:#?}");
+    }
+
+    fn build_benchmark_fixture(scope: Scope<(), TimeStats>, builder: &mut Builder) -> (Output<Instant>, InputSlot<Instant>) {
+        let initial_time = builder.commands().spawn_service(
+            get_initial_time.into_blocking_service()
+        );
+        let finish_time = builder.commands().spawn_service(
+            finish_time_range.into_blocking_service()
+        );
+        let collect_samples = builder.commands().spawn_service(
+            collect_samples.into_blocking_service()
+        );
+
+        let samples = builder.create_buffer(BufferSettings::keep_all());
+
+        let initial_node = builder.create_node(initial_time);
+        let finish_node = builder.create_node(finish_time);
+
+        builder.connect(scope.input, initial_node.input);
+        builder.connect(finish_node.output, samples.input_slot());
+
+        builder
+            .listen(samples)
+            .then(collect_samples)
+            .dispose_on_none()
+            .connect(scope.terminate);
+
+        builder
+            .listen(samples)
+            .map_block(|_| ())
+            .connect(initial_node.input);
+
+        (initial_node.output, finish_node.input)
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct TimeRange {
+        initial_time: Instant,
+        finish_time: Instant,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct TimeStats {
+        #[allow(unused)]
+        sample_count: usize,
+        #[allow(unused)]
+        average: Duration,
+        #[allow(unused)]
+        std_dev: Duration,
+        #[allow(unused)]
+        highest: Duration,
+        #[allow(unused)]
+        lowest: Duration,
+    }
+
+    impl TimeStats {
+        fn new(samples: impl IntoIterator<Item=TimeRange>) -> Self {
+            let samples: Vec<_> = samples
+                .into_iter()
+                .map(|s| s.finish_time - s.initial_time)
+                .collect();
+            let sample_count = samples.len();
+
+            let mut highest = None;
+            let mut lowest = None;
+            let mut average = Duration::new(0, 0);
+            for sample in &samples {
+                average += *sample;
+                if highest.is_none_or(|h| *sample > h) {
+                    highest = Some(*sample);
+                }
+
+                if lowest.is_none_or(|l| *sample < l) {
+                    lowest = Some(*sample);
+                }
+            }
+
+            let average = average / sample_count as u32;
+            let mut radicand = 0.0;
+            for sample in samples {
+                let delta = (sample.as_nanos() as i64 - average.as_nanos() as i64) as f64;
+                radicand += f64::powf(delta, 2.0);
+            }
+
+            let std_dev = Duration::from_nanos(f64::sqrt(radicand) as u64);
+            let highest = highest.unwrap();
+            let lowest = lowest.unwrap();
+            TimeStats { sample_count, average, std_dev, highest, lowest }
+        }
+    }
+
+    fn get_initial_time(_: In<()>) -> Instant {
+        Instant::now()
+    }
+
+    fn finish_time_range(In(initial_time): In<Instant>) -> TimeRange {
+        TimeRange {
+            initial_time,
+            finish_time: Instant::now(),
+        }
+    }
+
+    fn collect_samples(
+        In(key): In<BufferKey<TimeRange>>,
+        access: BufferAccess<TimeRange>,
+    ) -> Option<TimeStats> {
+        let samples = access.get(&key).unwrap();
+        if samples.len() >= 1000 {
+            Some(TimeStats::new(samples.iter().copied()))
+        } else {
+            None
+        }
     }
 }

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -220,7 +220,6 @@ impl JsonSchema for NamespacedOperation {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case", untagged)]
 pub enum BufferSelection {
-    Single(NextOperation),
     Dict(HashMap<String, NextOperation>),
     Array(Vec<NextOperation>),
 }
@@ -228,7 +227,6 @@ pub enum BufferSelection {
 impl BufferSelection {
     pub fn is_empty(&self) -> bool {
         match self {
-            Self::Single(_) => false,
             Self::Dict(d) => d.is_empty(),
             Self::Array(a) => a.is_empty(),
         }

--- a/src/diagram/buffer_schema.rs
+++ b/src/diagram/buffer_schema.rs
@@ -532,7 +532,7 @@ mod tests {
                 },
                 "count_access": {
                     "type": "buffer_access",
-                    "buffers": "json_buffer",
+                    "buffers": ["json_buffer"],
                     "next": "count",
                 },
                 "count": {
@@ -583,7 +583,7 @@ mod tests {
                 },
                 "count_access": {
                     "type": "buffer_access",
-                    "buffers": "json_buffer",
+                    "buffers": ["json_buffer"],
                     "next": "count",
                 },
                 "count": {
@@ -639,7 +639,7 @@ mod tests {
                 "buffer": { "type": "buffer" },
                 "listen": {
                     "type": "listen",
-                    "buffers": "buffer",
+                    "buffers": ["buffer"],
                     "next": "count",
                 },
                 "count": {
@@ -723,7 +723,7 @@ mod tests {
                 "buffer": { "type": "buffer" },
                 "listen": {
                     "type": "listen",
-                    "buffers": "buffer",
+                    "buffers": ["buffer"],
                     "next": "count",
                 },
                 "count": {
@@ -751,7 +751,7 @@ mod tests {
                 "buffer": { "type": "buffer" },
                 "listen": {
                     "type": "listen",
-                    "buffers": "buffer",
+                    "buffers": ["buffer"],
                     "next": "count",
                 },
                 "count": {

--- a/src/diagram/section_schema.rs
+++ b/src/diagram/section_schema.rs
@@ -906,7 +906,7 @@ mod tests {
                 },
                 "listen": {
                     "type": "listen",
-                    "buffers": { "multiply": "buffer" },
+                    "buffers": [{ "multiply": "buffer" }],
                     "next": "pull",
                 },
                 "pull": {

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -555,11 +555,6 @@ impl<'a, 'c> DiagramContext<'a, 'c> {
         };
 
         match inputs {
-            BufferSelection::Single(op_id) => {
-                let mut buffer_map = BufferMap::with_capacity(1);
-                buffer_map.insert(BufferIdentifier::Index(0), attempt_get_buffer(op_id)?);
-                Ok(buffer_map)
-            }
             BufferSelection::Dict(mapping) => {
                 let mut buffer_map = BufferMap::with_capacity(mapping.len());
                 for (k, op_id) in mapping {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ pub mod prelude {
         AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
         BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
         BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
-        ImpulsePlugin, ImpulseAppPlugin, Section,
+        ImpulsePlugin, ImpulseAppPlugin,
     };
 
     pub use bevy_ecs::prelude::In;
@@ -396,7 +396,7 @@ pub mod prelude {
     #[cfg(feature = "diagram")]
     pub use crate::{
         buffer::{JsonBuffer, JsonBufferKey, JsonBufferMut, JsonBufferWorldAccess, JsonMessage},
-        diagram::{Diagram, DiagramElementRegistry, DiagramError, NodeBuilderOptions},
+        diagram::{Diagram, DiagramElementRegistry, DiagramError, NodeBuilderOptions, Section},
     };
 
     pub use futures::FutureExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,9 +362,9 @@ pub mod prelude {
         buffer::{
             Accessible, Accessor, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess,
             AnyMessageBox, AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferGateAccess,
-            BufferGateAccessMut, BufferKey,
-            BufferMap, BufferMapLayout, BufferSettings, BufferWorldAccess, Bufferable, Buffering,
-            IncompatibleLayout, IterBufferable, Joinable, Joined, RetentionPolicy,
+            BufferGateAccessMut, BufferKey, BufferMap, BufferMapLayout, BufferSettings,
+            BufferWorldAccess, Bufferable, Buffering, IncompatibleLayout, IterBufferable, Joinable,
+            Joined, RetentionPolicy,
         },
         builder::Builder,
         callback::{AsCallback, Callback, IntoAsyncCallback, IntoBlockingCallback},
@@ -388,7 +388,7 @@ pub mod prelude {
         AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
         BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
         BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
-        ImpulsePlugin, ImpulseAppPlugin,
+        ImpulseAppPlugin, ImpulsePlugin,
     };
 
     pub use bevy_ecs::prelude::In;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,7 +388,7 @@ pub mod prelude {
         AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
         BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
         BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
-        ImpulsePlugin, ImpulseAppPlugin,
+        ImpulsePlugin, ImpulseAppPlugin, Section,
     };
 
     pub use bevy_ecs::prelude::In;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,4 +375,6 @@ pub mod prelude {
     pub use crate::buffer::{
         JsonBuffer, JsonBufferKey, JsonBufferMut, JsonBufferWorldAccess, JsonMessage,
     };
+
+    pub use futures::FutureExt;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -339,11 +339,30 @@ impl Plugin for ImpulsePlugin {
     }
 }
 
+/// This plugin adds [`ImpulsePlugin`] plus a few more that allows plus a few
+/// more plugins that allow create a sufficient but minimal app for executing
+/// workflows.
+#[derive(Default)]
+pub struct ImpulseAppPlugin {}
+
+impl Plugin for ImpulseAppPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins((
+            ImpulsePlugin::default(),
+            bevy_core::TaskPoolPlugin::default(),
+            bevy_core::TypeRegistrationPlugin,
+            bevy_core::FrameCountPlugin,
+            bevy_app::ScheduleRunnerPlugin::default(),
+        ));
+    }
+}
+
 pub mod prelude {
     pub use crate::{
         buffer::{
             Accessible, Accessor, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess,
-            AnyMessageBox, AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferKey,
+            AnyMessageBox, AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferGateAccess,
+            BufferGateAccessMut, BufferKey,
             BufferMap, BufferMapLayout, BufferSettings, BufferWorldAccess, Bufferable, Buffering,
             IncompatibleLayout, IterBufferable, Joinable, Joined, RetentionPolicy,
         },
@@ -369,7 +388,7 @@ pub mod prelude {
         AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
         BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
         BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
-        ImpulsePlugin,
+        ImpulsePlugin, ImpulseAppPlugin,
     };
 
     pub use bevy_ecs::prelude::In;

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -404,7 +404,7 @@ impl Default for Interrupter {
 
 #[cfg(test)]
 mod tests {
-    use crate::prelude::*;
+    use crate::{prelude::*, testing::*};
 
     #[test]
     fn test_promise_flatten() {

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -404,7 +404,7 @@ impl Default for Interrupter {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*};
+    use crate::prelude::*;
 
     #[test]
     fn test_promise_flatten() {

--- a/src/re_exports.rs
+++ b/src/re_exports.rs
@@ -20,6 +20,13 @@
 
 pub use bevy_ecs::prelude::{Commands, Entity, With, World};
 
+pub use smallvec::{smallvec, SmallVec};
+
+pub use std::{
+    clone::Clone,
+    marker::Copy,
+};
+
 // The std::any implementation of this is not stable in v1.75, so we provide a
 // simple implementation in this module for the derive macros.
 pub fn type_name_of_val<T>(_: &T) -> &'static str {

--- a/src/re_exports.rs
+++ b/src/re_exports.rs
@@ -22,10 +22,7 @@ pub use bevy_ecs::prelude::{Commands, Entity, With, World};
 
 pub use smallvec::{smallvec, SmallVec};
 
-pub use std::{
-    clone::Clone,
-    marker::Copy,
-};
+pub use std::{clone::Clone, marker::Copy};
 
 // The std::any implementation of this is not stable in v1.75, so we provide a
 // simple implementation in this module for the derive macros.


### PR DESCRIPTION
This PR introduces new examples of creating workflows that use Zenoh to communicate between applications, with the behavior of each application driven by workflows.

While making the examples, I found some misbehavior in the `derive` macros that would cause the macros to fail unless the user explicitly declares additional dependencies. Those have been fixed by adding the necessary symbols to the `re_exports` module.

This PR also adds a few more items to the prelude which should streamline the making of downstream applications.