### PR TITLE
add missing feature in `bevy_impulse_derive`

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -14,6 +14,6 @@ categories = ["science::robotics", "asynchronous", "concurrency", "game-developm
 proc-macro = true
 
 [dependencies]
-syn = "2.0"
+syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0.93"


### PR DESCRIPTION
The feature is required to build `bevy_impulse_derive` independently.