### PR TITLE
remove unused `$key$` field

### DIFF
--- a/registry.schema.json
+++ b/registry.schema.json
@@ -111,9 +111,6 @@
     "NodeRegistration": {
       "type": "object",
       "properties": {
-        "$key$": {
-          "type": "string"
-        },
         "config_schema": {
           "$ref": "#/$defs/Schema"
         },
@@ -128,7 +125,6 @@
         }
       },
       "required": [
-        "$key$",
         "name",
         "request",
         "response",

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -37,7 +37,6 @@ use crate::{
 use schemars::{generate::SchemaSettings, json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Serialize};
 use serde_json::json;
-use tracing::debug;
 
 use super::{
     buffer_schema::BufferAccessRequest, fork_clone_schema::PerformForkClone,
@@ -50,8 +49,6 @@ use super::{
 
 #[derive(Serialize, JsonSchema)]
 pub struct NodeRegistration {
-    #[serde(rename = "$key$")]
-    pub(super) id: BuilderId,
     pub(super) name: Arc<str>,
     pub(super) request: TypeInfo,
     pub(super) response: TypeInfo,
@@ -69,10 +66,6 @@ impl NodeRegistration {
         config: serde_json::Value,
     ) -> Result<DynNode, DiagramErrorCode> {
         let n = (self.create_node_impl.borrow_mut())(builder, config)?;
-        debug!(
-            "created node of {}, output: {:?}, input: {:?}",
-            self.id, n.output, n.input
-        );
         Ok(n)
     }
 }
@@ -171,7 +164,6 @@ impl<'a, DeserializeImpl, SerializeImpl, Cloneable>
         self.impl_register_message::<Response>();
 
         let registration = NodeRegistration {
-            id: options.id.clone(),
             name: options.name.unwrap_or(options.id.clone()),
             request: TypeInfo::of::<Request>(),
             response: TypeInfo::of::<Response>(),

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -50,7 +50,7 @@ use super::{
 
 #[derive(Serialize, JsonSchema)]
 pub struct NodeRegistration {
-    #[serde(rename = "$key$")]
+    #[serde(skip)]
     pub(super) id: BuilderId,
     pub(super) name: Arc<str>,
     pub(super) request: TypeInfo,

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -37,6 +37,7 @@ use crate::{
 use schemars::{generate::SchemaSettings, json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Serialize};
 use serde_json::json;
+use tracing::debug;
 
 use super::{
     buffer_schema::BufferAccessRequest, fork_clone_schema::PerformForkClone,
@@ -49,6 +50,8 @@ use super::{
 
 #[derive(Serialize, JsonSchema)]
 pub struct NodeRegistration {
+    #[serde(rename = "$key$")]
+    pub(super) id: BuilderId,
     pub(super) name: Arc<str>,
     pub(super) request: TypeInfo,
     pub(super) response: TypeInfo,
@@ -66,6 +69,10 @@ impl NodeRegistration {
         config: serde_json::Value,
     ) -> Result<DynNode, DiagramErrorCode> {
         let n = (self.create_node_impl.borrow_mut())(builder, config)?;
+        debug!(
+            "created node of {}, output: {:?}, input: {:?}",
+            self.id, n.output, n.input
+        );
         Ok(n)
     }
 }
@@ -164,6 +171,7 @@ impl<'a, DeserializeImpl, SerializeImpl, Cloneable>
         self.impl_register_message::<Response>();
 
         let registration = NodeRegistration {
+            id: options.id.clone(),
             name: options.name.unwrap_or(options.id.clone()),
             request: TypeInfo::of::<Request>(),
             response: TypeInfo::of::<Response>(),

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -41,7 +41,6 @@ use serde::{
     Deserialize, Serialize,
 };
 use serde_json::json;
-use tracing::debug;
 
 use super::{
     buffer_schema::BufferAccessRequest, fork_clone_schema::PerformForkClone,
@@ -54,8 +53,6 @@ use super::{
 
 #[derive(Serialize, JsonSchema)]
 pub struct NodeRegistration {
-    #[serde(rename = "$key$")]
-    pub(super) id: BuilderId,
     pub(super) name: Arc<str>,
     pub(super) request: TypeInfo,
     pub(super) response: TypeInfo,
@@ -73,10 +70,6 @@ impl NodeRegistration {
         config: serde_json::Value,
     ) -> Result<DynNode, DiagramErrorCode> {
         let n = (self.create_node_impl.borrow_mut())(builder, config)?;
-        debug!(
-            "created node of {}, output: {:?}, input: {:?}",
-            self.id, n.output, n.input
-        );
         Ok(n)
     }
 }
@@ -175,7 +168,6 @@ impl<'a, DeserializeImpl, SerializeImpl, Cloneable>
         self.impl_register_message::<Response>();
 
         let registration = NodeRegistration {
-            id: options.id.clone(),
             name: options.name.unwrap_or(options.id.clone()),
             request: TypeInfo::of::<Request>(),
             response: TypeInfo::of::<Response>(),

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -50,7 +50,7 @@ use super::{
 
 #[derive(Serialize, JsonSchema)]
 pub struct NodeRegistration {
-    #[serde(skip)]
+    #[serde(rename = "$key$")]
     pub(super) id: BuilderId,
     pub(super) name: Arc<str>,
     pub(super) request: TypeInfo,


### PR DESCRIPTION
The field is a leftover from when https://docs.rs/serde_with/latest/serde_with/struct.KeyValueMap.html is used. Now that we are no longer using it, it results in an extra field in the serialized json.