### PR TITLE
Allow trace information to be attributed to a request

### DIFF
--- a/src/flush.rs
+++ b/src/flush.rs
@@ -226,7 +226,7 @@ fn collect_from_channels(
     for e in add_finish {
         // Add a Finished impulse to the unused target of a detached impulse
         // chain.
-        AddImpulse::new(e, Finished).apply(world);
+        AddImpulse::new(None, e, Finished).apply(world);
     }
 
     for target in drop_targets.drain(..) {

--- a/src/input.rs
+++ b/src/input.rs
@@ -20,6 +20,7 @@ use bevy_ecs::{
     system::Command,
     world::{EntityRef, EntityWorldMut, World},
 };
+use bevy_hierarchy::Parent;
 
 use smallvec::SmallVec;
 
@@ -297,9 +298,19 @@ impl<'w> ManageInput for EntityWorldMut<'w> {
                             }
                         };
 
+                        let world = self.world();
+                        let mut session_stack = SmallVec::new();
+                        session_stack.push(input.session);
+                        let mut session = input.session;
+                        while let Some(next_session) = world.get::<Parent>(session) {
+                            session = next_session.get();
+                            session_stack.push(session);
+                        }
+                        session_stack.reverse();
+
                         let started = OperationStarted {
                             operation: self.id(),
-                            session: input.session,
+                            session_stack,
                             info: Arc::clone(trace.info()),
                             message,
                         };

--- a/src/map_once.rs
+++ b/src/map_once.rs
@@ -75,6 +75,7 @@ where
 
     fn connect(self, _: Option<Entity>, source: Entity, target: Entity, commands: &mut Commands) {
         commands.add(AddImpulse::new(
+            None,
             source,
             ImpulseBlockingMap::new(target, self.def),
         ));
@@ -184,6 +185,7 @@ where
 
     fn connect(self, _: Option<Entity>, source: Entity, target: Entity, commands: &mut Commands) {
         commands.add(AddImpulse::new(
+            None,
             source,
             ImpulseAsyncMap::new(target, self.def),
         ));

--- a/src/operation/injection.rs
+++ b/src/operation/injection.rs
@@ -88,7 +88,7 @@ where
         let finish = world
             .spawn((InputBundle::<Response>::new(), InjectionSource(source)))
             .id();
-        AddImpulse::new(finish, InjectionFinish::<Response>::new()).apply(world);
+        AddImpulse::new(None, finish, InjectionFinish::<Response>::new()).apply(world);
 
         let task = world
             .spawn((

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -37,7 +37,7 @@ use bevy_ecs::{
     prelude::{Commands, Component, Entity, World},
     system::Command,
 };
-use bevy_hierarchy::{BuildChildren, DespawnRecursiveExt};
+use bevy_hierarchy::{BuildChildren, BuildWorldChildren, DespawnRecursiveExt};
 
 use smallvec::SmallVec;
 
@@ -49,7 +49,9 @@ use std::{
 
 use thiserror::Error as ThisError;
 
-#[derive(Component)]
+// TODO(@mxgrey): Consider whether ParentSession is now redundant with the
+// built-in Parent since we are now using Parent to link sessions together.
+#[derive(Component, Deref)]
 pub struct ParentSession(Entity);
 
 impl ParentSession {
@@ -363,6 +365,7 @@ fn dyn_begin_scope<Request: 'static + Send + Sync>(
 
     let scoped_session = world
         .spawn((ParentSession(input.session), SessionStatus::Active))
+        .set_parent(input.session)
         .id();
 
     begin_scope(
@@ -1523,6 +1526,7 @@ where
 
         let cancellation_session = world
             .spawn((ParentSession(scoped_session), SessionStatus::Active))
+            .set_parent(scoped_session)
             .id();
         world
             .get_entity_mut(target)

--- a/src/service/workflow.rs
+++ b/src/service/workflow.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 use bevy_ecs::prelude::{Component, Entity, World};
-use bevy_hierarchy::prelude::DespawnRecursiveExt;
+use bevy_hierarchy::prelude::{BuildWorldChildren, DespawnRecursiveExt};
 
 pub(crate) struct WorkflowHooks {}
 
@@ -120,6 +120,7 @@ where
         } = source_mut.take_input::<Request>()?;
         let scoped_session = world
             .spawn((ParentSession::new(session), SessionStatus::Active))
+            .set_parent(session)
             .id();
 
         let result = serve_workflow_impl::<Request, Response, Streams>(

--- a/src/stream/anonymous_stream.rs
+++ b/src/stream/anonymous_stream.rs
@@ -118,7 +118,7 @@ impl<S: StreamEffect> StreamPack for AnonymousStream<S> {
             .id();
 
         map.add_anonymous::<S::Output>(target, commands);
-        commands.add(AddImpulse::new(target, TakenStream::new(sender)));
+        commands.add(AddImpulse::new(None, target, TakenStream::new(sender)));
 
         receiver
     }
@@ -131,6 +131,7 @@ impl<S: StreamEffect> StreamPack for AnonymousStream<S> {
     ) {
         let redirect = commands.spawn(()).set_parent(source).id();
         commands.add(AddImpulse::new(
+            None,
             redirect,
             Push::<S::Output>::new(target, true),
         ));

--- a/src/stream/dynamically_named_stream.rs
+++ b/src/stream/dynamically_named_stream.rs
@@ -114,7 +114,7 @@ impl<S: StreamEffect> StreamPack for DynamicallyNamedStream<S> {
             .id();
 
         map.add_anonymous::<NamedValue<S::Output>>(target, commands);
-        commands.add(AddImpulse::new(target, TakenStream::new(sender)));
+        commands.add(AddImpulse::new(None, target, TakenStream::new(sender)));
 
         receiver
     }
@@ -127,6 +127,7 @@ impl<S: StreamEffect> StreamPack for DynamicallyNamedStream<S> {
     ) {
         let redirect = commands.spawn(()).set_parent(source).id();
         commands.add(AddImpulse::new(
+            None,
             redirect,
             Push::<NamedValue<S::Output>>::new(target, true),
         ));

--- a/src/stream/named_stream.rs
+++ b/src/stream/named_stream.rs
@@ -94,7 +94,7 @@ impl<S: StreamEffect> NamedStream<S> {
         let target = commands.spawn(()).set_parent(source).id();
 
         map.add_named::<S::Output>(name.into(), target, commands);
-        commands.add(AddImpulse::new(target, TakenStream::new(sender)));
+        commands.add(AddImpulse::new(None, target, TakenStream::new(sender)));
 
         receiver
     }
@@ -109,6 +109,7 @@ impl<S: StreamEffect> NamedStream<S> {
         let name = name.into();
         let redirect = commands.spawn(()).set_parent(source).id();
         commands.add(AddImpulse::new(
+            None,
             redirect,
             Push::<S::Output>::new(target, true).with_name(name.clone()),
         ));

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -22,6 +22,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{any::Any, borrow::Cow, sync::Arc};
 use thiserror::Error as ThisError;
+use smallvec::SmallVec;
 
 /// A component attached to workflow operation entities in order to trace their
 /// activities.
@@ -98,8 +99,17 @@ pub enum GetValueError {
 pub struct OperationStarted {
     /// The entity of the operation that was triggered.
     pub operation: Entity,
-    /// The entity of the workflow session that triggered the operation.
-    pub session: Entity,
+    /// The stack of session IDs that triggered the operation. The first entry
+    /// is the root session. Each subsequent entry is a child session of the
+    /// previous. There are two common ways to get a child session:
+    /// * In an impulse chain, earlier sessions in the chain are children of later
+    ///   sessions in the chain, so the last session of the chain is the root of
+    ///   the entire chain.
+    /// * When a scope operation is triggered, a new session is created. Its parent
+    ///   is the session of the message that triggered the scope operation. Every
+    ///   time a workflow is triggered it creates a new scope, and therefore also
+    ///   creates a child session.
+    pub session_stack: SmallVec<[Entity; 8]>,
     /// Information about the operation that was triggered.
     pub info: Arc<OperationInfo>,
     /// The message that triggered the operation, if serialization is enabled
@@ -161,11 +171,11 @@ mod tests {
         trace::OperationStarted,
     };
     use bevy_app::{App, PostUpdate};
-    use bevy_ecs::prelude::{EventReader, ResMut, Resource};
+    use bevy_ecs::prelude::{EventReader, ResMut, Resource, Entity};
     use serde_json::json;
     use std::{sync::Arc, time::Duration};
 
-    #[derive(Resource, Default, Debug)]
+    #[derive(Clone, Resource, Default, Debug)]
     struct TraceRecorder {
         record: Vec<OperationStarted>,
     }
@@ -331,9 +341,9 @@ mod tests {
         fixture: &mut DiagramTestFixture,
         route: &[&str],
     ) {
-        let mut promise = fixture
+        let Recipient { response: mut promise, session, .. } = fixture
             .context
-            .command(|commands| commands.request(value, panchinko).take_response());
+            .command(|commands| commands.request(value, panchinko).take());
 
         fixture
             .context
@@ -342,28 +352,41 @@ mod tests {
         let result = promise.take().available().unwrap();
         assert_eq!(value, result);
 
-        let mut recorder = fixture.context.app.world.resource_mut::<TraceRecorder>();
-        confirm_trace(&*recorder, route);
+        let recorder = fixture.context.app.world.resource_mut::<TraceRecorder>().clone();
+        confirm_trace(&recorder, route, session);
 
         // Clear the record so these results do not interfere with the next test
-        recorder.record.clear();
+        fixture.context.app.world.resource_mut::<TraceRecorder>().record.clear();
     }
 
-    fn confirm_trace(recorder: &TraceRecorder, expectation: &[&str]) {
+    fn confirm_trace(
+        recorder: &TraceRecorder,
+        expectation: &[&str],
+        expected_root_session: Entity,
+    ) {
         let mut actual = recorder.record.clone();
-        for next in expectation {
-            let name: Arc<str> = (*next).into();
+        for next_op_name in expectation {
+            let name: Arc<str> = (*next_op_name).into();
             let expected_op = OperationRef::Named((&name).into());
-            let actual_op = actual.first().unwrap().info.id.as_ref().unwrap();
+            let next_actual = actual.first().unwrap();
+            let actual_op = next_actual.info.id.as_ref().unwrap();
             assert_eq!(expected_op, *actual_op);
+
+            let actual_root_session = *next_actual.session_stack.first().unwrap();
+            assert_eq!(expected_root_session, actual_root_session);
+
             actual.remove(0);
         }
 
         let expected_op = OperationRef::Terminate(NamespaceList::default());
-        let actual_op = actual.first().unwrap().info.id.as_ref().unwrap();
+        let next_actual = actual.first().unwrap();
+        let actual_op = next_actual.info.id.as_ref().unwrap();
         assert_eq!(expected_op, *actual_op);
-        actual.remove(0);
 
+        let actual_root_session = *next_actual.session_stack.first().unwrap();
+        assert_eq!(expected_root_session, actual_root_session);
+
+        actual.remove(0);
         assert!(actual.is_empty());
     }
 }


### PR DESCRIPTION
This PR makes it possible to attribute trace events to the specific request that triggered the activity.

The key changes here are:
* `Impulse` now has a `.session_id()` method that allows you to check the session identifier of any entry in a chain of impulses
* `Recipient` provides `session` information which provides a root session for the entire impulse chain. Every service and workflow session produced as part of the requested impulse chain will be a descendant of this session.
* The `OperationStarted` event now shows the whole stack of sessions that led to the operation.
* The tracing test now validates the the root session reported by `OperationStarted` is equal to the recipient session of the impulse chain.