### PR TITLE
Diagram editor UI updates

### DIFF
--- a/diagram-editor/frontend/diagram-editor.tsx
+++ b/diagram-editor/frontend/diagram-editor.tsx
@@ -46,7 +46,6 @@ import {
 import ExportDiagramDialog from './export-diagram-dialog';
 import { defaultEdgeData, EditEdgeForm, EditNodeForm } from './forms';
 import EditScopeForm from './forms/edit-scope-form';
-import type { HandleId } from './handles';
 import { NodeManager, NodeManagerProvider } from './node-manager';
 import {
   type DiagramEditorNode,
@@ -531,9 +530,9 @@ function DiagramEditor() {
 
       const validEdges = getValidEdgeTypes(
         sourceNode,
-        conn.sourceHandle as HandleId,
+        conn.sourceHandle,
         targetNode,
-        conn.targetHandle as HandleId,
+        conn.targetHandle,
       );
       if (validEdges.length === 0) {
         showErrorToast(
@@ -545,9 +544,9 @@ function DiagramEditor() {
       const newEdge = {
         ...createBaseEdge(
           conn.source,
-          conn.sourceHandle as HandleId,
+          conn.sourceHandle,
           conn.target,
-          conn.targetHandle as HandleId,
+          conn.targetHandle,
           id,
         ),
         type: validEdges[0],
@@ -641,9 +640,9 @@ function DiagramEditor() {
 
           const allowedEdges = getValidEdgeTypes(
             sourceNode,
-            conn.sourceHandle as HandleId,
+            conn.sourceHandle,
             targetNode,
-            conn.targetHandle as HandleId,
+            conn.targetHandle,
           );
           return allowedEdges.length > 0;
         }}

--- a/diagram-editor/frontend/edges/create-edge.ts
+++ b/diagram-editor/frontend/edges/create-edge.ts
@@ -1,6 +1,5 @@
 import { MarkerType } from '@xyflow/react';
 import { v4 as uuidv4 } from 'uuid';
-import type { HandleId } from '../handles';
 import type { DiagramEditorEdge, EdgeOutputData } from '.';
 import type { DefaultEdge } from './default-edge';
 import type {
@@ -11,9 +10,9 @@ import type {
 
 export function createBaseEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   id?: string,
 ): Pick<
   DiagramEditorEdge,
@@ -35,9 +34,9 @@ export function createBaseEdge(
 
 export function createDefaultEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   inputSlot?: DefaultEdge['data']['input'],
 ): DiagramEditorEdge<'default'> {
   return {
@@ -49,9 +48,9 @@ export function createDefaultEdge(
 
 export function createUnzipEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   data: EdgeOutputData<'unzip'>,
 ): DiagramEditorEdge<'unzip'> {
   return {
@@ -66,9 +65,9 @@ export function createUnzipEdge(
 
 export function createForkResultOkEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
 ): DiagramEditorEdge<'forkResultOk'> {
   return {
     ...createBaseEdge(source, sourceHandle, target, targetHandle),
@@ -79,9 +78,9 @@ export function createForkResultOkEdge(
 
 export function createForkResultErrEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
 ): DiagramEditorEdge<'forkResultErr'> {
   return {
     ...createBaseEdge(source, sourceHandle, target, targetHandle),
@@ -92,9 +91,9 @@ export function createForkResultErrEdge(
 
 export function createSplitKeyEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   data: EdgeOutputData<'splitKey'>,
 ): DiagramEditorEdge<'splitKey'> {
   return {
@@ -106,9 +105,9 @@ export function createSplitKeyEdge(
 
 export function createSplitSeqEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   data: EdgeOutputData<'splitSeq'>,
 ): DiagramEditorEdge<'splitSeq'> {
   return {
@@ -120,9 +119,9 @@ export function createSplitSeqEdge(
 
 export function createSplitRemainingEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
 ): DiagramEditorEdge<'splitRemaining'> {
   return {
     ...createBaseEdge(source, sourceHandle, target, targetHandle),
@@ -133,9 +132,9 @@ export function createSplitRemainingEdge(
 
 export function createBufferEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   data:
     | BufferKeyInputSlotData
     | BufferSeqInputSlotData
@@ -150,9 +149,9 @@ export function createBufferEdge(
 
 export function createStreamOutEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   data: EdgeOutputData<'streamOut'>,
 ): DiagramEditorEdge<'streamOut'> {
   return {
@@ -164,9 +163,9 @@ export function createStreamOutEdge(
 
 export function createSectionEdge(
   source: string,
-  sourceHandle: HandleId,
+  sourceHandle: string | null | undefined,
   target: string,
-  targetHandle: HandleId,
+  targetHandle: string | null | undefined,
   data: EdgeOutputData<'section'>,
 ): DiagramEditorEdge<'section'> {
   return {

--- a/diagram-editor/frontend/forms/node-form.tsx
+++ b/diagram-editor/frontend/forms/node-form.tsx
@@ -11,9 +11,7 @@ function NodeForm(props: NodeFormProps) {
   const registry = useRegistry();
   const nodes = Object.keys(registry.nodes);
   const [configValue, setConfigValue] = useState(() =>
-    props.node.data.op.config
-      ? JSON.stringify(props.node.data.op.config)
-      : 'null',
+    props.node.data.op.config ? JSON.stringify(props.node.data.op.config) : '',
   );
   const configError = useMemo(() => {
     if (configValue === '') {
@@ -58,7 +56,7 @@ function NodeForm(props: NodeFormProps) {
           try {
             const updatedNode = { ...props.node };
             updatedNode.data.op.config =
-              ev.target.value === '' ? null : JSON.parse(ev.target.value);
+              ev.target.value === '' ? undefined : JSON.parse(ev.target.value);
             props.onChange?.({
               type: 'replace',
               id: props.node.id,

--- a/diagram-editor/frontend/handles.tsx
+++ b/diagram-editor/frontend/handles.tsx
@@ -4,7 +4,9 @@ import {
 } from '@xyflow/react';
 import { exhaustiveCheck } from './utils/exhaustive-check';
 
-export type HandleId = 'dataStream' | null | undefined;
+export enum HandleId {
+  DataStream = 'dataStream',
+}
 
 export enum HandleType {
   Data,
@@ -44,8 +46,8 @@ function variantClassName(handleType?: HandleType): string | undefined {
 }
 
 export function Handle({ variant, className, ...baseProps }: HandleProps) {
-  const handleId: HandleId =
-    variant === HandleType.DataStream ? 'dataStream' : undefined;
+  const handleId: HandleId | undefined =
+    variant === HandleType.DataStream ? HandleId.DataStream : undefined;
 
   const prependClassName = className
     ? `${variantClassName(variant)} ${className} `

--- a/diagram-editor/frontend/handles.tsx
+++ b/diagram-editor/frontend/handles.tsx
@@ -6,6 +6,8 @@ import { exhaustiveCheck } from './utils/exhaustive-check';
 
 export enum HandleId {
   DataStream = 'dataStream',
+  ForkResultOk = 'forkResultOk',
+  ForkResultErr = 'forkResultErr',
 }
 
 export enum HandleType {
@@ -16,6 +18,11 @@ export enum HandleType {
 }
 
 export interface HandleProps extends Omit<ReactFlowHandleProps, 'id'> {
+  /**
+   * Id of the handle, this affects how the validator determines if a connection is valid.
+   * For variants other than `HandleType.Data`, you probably want to assign an appropriate id.
+   */
+  id?: HandleId;
   variant: HandleType;
 }
 
@@ -45,19 +52,12 @@ function variantClassName(handleType?: HandleType): string | undefined {
   }
 }
 
-export function Handle({ variant, className, ...baseProps }: HandleProps) {
-  const handleId: HandleId | undefined =
-    variant === HandleType.DataStream ? HandleId.DataStream : undefined;
-
+export function Handle({ id, variant, className, ...baseProps }: HandleProps) {
   const prependClassName = className
     ? `${variantClassName(variant)} ${className} `
     : variantClassName(variant);
 
   return (
-    <ReactFlowHandle
-      {...baseProps}
-      id={handleId}
-      className={prependClassName}
-    />
+    <ReactFlowHandle {...baseProps} id={id} className={prependClassName} />
   );
 }

--- a/diagram-editor/frontend/nodes/base-node.tsx
+++ b/diagram-editor/frontend/nodes/base-node.tsx
@@ -6,41 +6,25 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { type NodeProps, Position } from '@xyflow/react';
-import { memo } from 'react';
-import { Handle, type HandleProps, HandleType } from '../handles';
+import type { NodeProps } from '@xyflow/react';
+import { type JSX, memo } from 'react';
 import { LAYOUT_OPTIONS } from '../utils/layout';
 
 export interface BaseNodeProps extends NodeProps {
   color?: ButtonProps['color'];
   icon?: React.JSX.Element | string;
   label: string;
-  variant: 'input' | 'output' | 'inputOutput';
-  /**
-   * defaults to `HandleType.Data`.
-   */
-  inputHandleType?: HandleType;
-  /**
-   * defaults to `HandleType.Data`.
-   */
-  outputHandleType?: HandleType;
   caption?: string;
-  extraHandles?: HandleProps[];
+  handles?: JSX.Element;
 }
 
 function BaseNode({
   color,
   icon: materialIconOrSymbol,
   label,
-  variant,
-  inputHandleType = HandleType.Data,
-  outputHandleType = HandleType.Data,
   caption,
-  extraHandles,
-  isConnectable,
+  handles,
   selected,
-  sourcePosition = Position.Bottom,
-  targetPosition = Position.Top,
 }: BaseNodeProps) {
   const icon =
     typeof materialIconOrSymbol === 'string' ? (
@@ -51,14 +35,6 @@ function BaseNode({
 
   return (
     <Paper>
-      {(variant === 'input' || variant === 'inputOutput') && (
-        <Handle
-          type="target"
-          position={targetPosition}
-          isConnectable={isConnectable}
-          variant={inputHandleType}
-        />
-      )}
       <Button
         title={label}
         color={color}
@@ -99,17 +75,7 @@ function BaseNode({
           )}
         </Stack>
       </Button>
-      {(variant === 'output' || variant === 'inputOutput') && (
-        <Handle
-          type="source"
-          position={sourcePosition}
-          isConnectable={isConnectable}
-          variant={outputHandleType}
-        />
-      )}
-      {extraHandles?.map((handleProps, i) => (
-        <Handle key={i.toString()} {...handleProps} />
-      ))}
+      {handles}
     </Paper>
   );
 }

--- a/diagram-editor/frontend/nodes/buffer-access-node.tsx
+++ b/diagram-editor/frontend/nodes/buffer-access-node.tsx
@@ -1,5 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { BufferAccessIcon } from './icons';
@@ -12,8 +12,22 @@ function BufferAccessNodeComp(
       {...props}
       icon={<BufferAccessIcon />}
       label="Buffer Access"
-      variant="inputOutput"
-      inputHandleType={HandleType.DataBuffer}
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.DataBuffer}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/buffer-node.tsx
+++ b/diagram-editor/frontend/nodes/buffer-node.tsx
@@ -1,5 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { BufferIcon } from './icons';
@@ -10,8 +10,22 @@ function BufferNodeComp(props: NodeProps<OperationNode<'buffer'>>) {
       {...props}
       icon={<BufferIcon />}
       label="Buffer"
-      variant="inputOutput"
-      outputHandleType={HandleType.Buffer}
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Buffer}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/fork-clone-node.tsx
+++ b/diagram-editor/frontend/nodes/fork-clone-node.tsx
@@ -1,4 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { ForkCloneIcon } from './icons';
@@ -9,7 +10,22 @@ function ForkCloneNodeComp(props: NodeProps<OperationNode<'fork_clone'>>) {
       {...props}
       icon={<ForkCloneIcon />}
       label="Fork Clone"
-      variant="inputOutput"
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/fork-result-node.tsx
+++ b/diagram-editor/frontend/nodes/fork-result-node.tsx
@@ -1,7 +1,18 @@
-import type { NodeProps } from '@xyflow/react';
+import { styled } from '@mui/material';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { ForkResultIcon } from './icons';
+
+const ForkResultOkHandle = styled(Handle)(({ theme }) => ({
+  left: '25%',
+  background: `linear-gradient(-45deg, ${theme.palette.success.main} 50%, var(--xy-handle-background-color-default) 50%)`,
+}));
+const ForkResultErrHandle = styled(Handle)(({ theme }) => ({
+  left: '75%',
+  background: `linear-gradient(-45deg, ${theme.palette.error.main} 50%, var(--xy-handle-background-color-default) 50%)`,
+}));
 
 function ForkResultNodeComp(props: NodeProps<OperationNode<'fork_result'>>) {
   return (
@@ -9,7 +20,34 @@ function ForkResultNodeComp(props: NodeProps<OperationNode<'fork_result'>>) {
       {...props}
       icon={<ForkResultIcon />}
       label="Fork Result"
-      variant="inputOutput"
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          {/* <ForkResultOkHandle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <ForkResultErrHandle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          /> */}
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/fork-result-node.tsx
+++ b/diagram-editor/frontend/nodes/fork-result-node.tsx
@@ -1,6 +1,6 @@
 import { styled } from '@mui/material';
 import { type NodeProps, Position } from '@xyflow/react';
-import { Handle, HandleType } from '../handles';
+import { Handle, HandleId, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { ForkResultIcon } from './icons';
@@ -28,24 +28,20 @@ function ForkResultNodeComp(props: NodeProps<OperationNode<'fork_result'>>) {
             isConnectable={props.isConnectable}
             variant={HandleType.Data}
           />
-          <Handle
-            type="source"
-            position={Position.Bottom}
-            isConnectable={props.isConnectable}
-            variant={HandleType.Data}
-          />
-          {/* <ForkResultOkHandle
+          <ForkResultOkHandle
+            id={HandleId.ForkResultOk}
             type="source"
             position={Position.Bottom}
             isConnectable={props.isConnectable}
             variant={HandleType.Data}
           />
           <ForkResultErrHandle
+            id={HandleId.ForkResultErr}
             type="source"
             position={Position.Bottom}
             isConnectable={props.isConnectable}
             variant={HandleType.Data}
-          /> */}
+          />
         </>
       }
     />

--- a/diagram-editor/frontend/nodes/join-node.tsx
+++ b/diagram-editor/frontend/nodes/join-node.tsx
@@ -1,5 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { JoinIcon } from './icons';
@@ -10,8 +10,22 @@ function JoinNodeComp(props: NodeProps<OperationNode<'join'>>) {
       {...props}
       icon={<JoinIcon />}
       label="Join"
-      variant="inputOutput"
-      inputHandleType={HandleType.Buffer}
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Buffer}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/listen-node.tsx
+++ b/diagram-editor/frontend/nodes/listen-node.tsx
@@ -1,5 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { ListenIcon } from './icons';
@@ -10,8 +10,22 @@ function ListenNodeComp(props: NodeProps<OperationNode<'listen'>>) {
       {...props}
       icon={<ListenIcon />}
       label="Listen"
-      variant="inputOutput"
-      inputHandleType={HandleType.Buffer}
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Buffer}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/node-node.tsx
+++ b/diagram-editor/frontend/nodes/node-node.tsx
@@ -1,5 +1,5 @@
 import { type NodeProps, Position } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { Handle, HandleId, HandleType } from '../handles';
 import { useRegistry } from '../registry-provider';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
@@ -20,15 +20,29 @@ function NodeNodeComp(props: NodeProps<OperationNode<'node'>>) {
       icon={<NodeIcon />}
       label={label || 'Select Builder'}
       caption={props.data.op.builder}
-      variant="inputOutput"
-      outputHandleType={HandleType.Data}
-      extraHandles={[
-        {
-          position: Position.Right,
-          type: 'source',
-          variant: HandleType.DataStream,
-        },
-      ]}
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            id={HandleId.DataStream}
+            type="source"
+            position={Position.Right}
+            isConnectable={props.isConnectable}
+            variant={HandleType.DataStream}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/scope-node.tsx
+++ b/diagram-editor/frontend/nodes/scope-node.tsx
@@ -1,6 +1,6 @@
 import { Box, useTheme } from '@mui/material';
 import { type NodeProps, Position } from '@xyflow/react';
-import { Handle, HandleType } from '../handles';
+import { Handle, HandleId, HandleType } from '../handles';
 import type { OperationNode } from '.';
 
 function ScopeNodeComp({
@@ -37,6 +37,7 @@ function ScopeNodeComp({
         variant={HandleType.Data}
       />
       <Handle
+        id={HandleId.DataStream}
         type="source"
         position={Position.Right}
         variant={HandleType.DataStream}

--- a/diagram-editor/frontend/nodes/section-node.tsx
+++ b/diagram-editor/frontend/nodes/section-node.tsx
@@ -1,5 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import { useRegistry } from '../registry-provider';
 import type { NextOperation } from '../types/api';
 import type { Node } from '../types/react-flow';
@@ -64,8 +64,22 @@ export function SectionNodeComp(props: NodeProps<OperationNode<'section'>>) {
       icon={<SectionIcon />}
       label={label}
       caption={caption}
-      variant="inputOutput"
-      inputHandleType={HandleType.DataBuffer}
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.DataBuffer}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }
@@ -84,8 +98,15 @@ export function SectionInputNodeComp(props: NodeProps<SectionInputNode>) {
       color="secondary"
       icon={<SectionInputIcon />}
       label="Section Input"
-      variant="output"
       caption={props.data.remappedId}
+      handles={
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          isConnectable={props.isConnectable}
+          variant={HandleType.Data}
+        />
+      }
     />
   );
 }
@@ -97,8 +118,15 @@ export function SectionOutputNodeComp(props: NodeProps<SectionOutputNode>) {
       color="secondary"
       icon={<SectionOutputIcon />}
       label="Section Output"
-      variant="input"
       caption={props.data.outputId}
+      handles={
+        <Handle
+          type="target"
+          position={Position.Top}
+          isConnectable={props.isConnectable}
+          variant={HandleType.Data}
+        />
+      }
     />
   );
 }
@@ -110,9 +138,15 @@ export function SectionBufferNodeComp(props: NodeProps<SectionBufferNode>) {
       color="secondary"
       icon={<SectionBufferIcon />}
       label="Section Buffer"
-      variant="output"
       caption={props.data.remappedId}
-      outputHandleType={HandleType.Buffer}
+      handles={
+        <Handle
+          type="source"
+          position={Position.Bottom}
+          isConnectable={props.isConnectable}
+          variant={HandleType.Buffer}
+        />
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/serialized-join-node.tsx
+++ b/diagram-editor/frontend/nodes/serialized-join-node.tsx
@@ -1,4 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { SerializedJoinIcon } from './icons';
@@ -11,7 +12,22 @@ function SerializedJoinNodeComp(
       {...props}
       icon={<SerializedJoinIcon />}
       label="Serialized Join"
-      variant="inputOutput"
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Buffer}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/split-node.tsx
+++ b/diagram-editor/frontend/nodes/split-node.tsx
@@ -1,4 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { SplitIcon } from './icons';
@@ -9,7 +10,22 @@ function SplitNodeComp(props: NodeProps<OperationNode<'split'>>) {
       {...props}
       icon={<SplitIcon />}
       label="Split"
-      variant="inputOutput"
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/start-node.tsx
+++ b/diagram-editor/frontend/nodes/start-node.tsx
@@ -1,6 +1,7 @@
 import { Button, Paper } from '@mui/material';
 import type { NodeProps } from '@xyflow/react';
-import { Handle, Position } from '@xyflow/react';
+import { Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import { LAYOUT_OPTIONS } from '../utils/layout';
 import type { BuiltinNode } from '.';
 
@@ -25,6 +26,7 @@ function StartNodeComp({
         type="source"
         position={sourcePosition}
         isConnectable={isConnectable}
+        variant={HandleType.Data}
       />
     </Paper>
   );

--- a/diagram-editor/frontend/nodes/stream-out-node.tsx
+++ b/diagram-editor/frontend/nodes/stream-out-node.tsx
@@ -1,5 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
-import { HandleType } from '../handles';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleId, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { StreamOutIcon } from './icons';
@@ -10,9 +10,16 @@ function StreamOutNodeComp(props: NodeProps<OperationNode<'stream_out'>>) {
       {...props}
       icon={<StreamOutIcon />}
       label="StreamOut"
-      variant="input"
       caption={props.data.op.name}
-      inputHandleType={HandleType.DataStream}
+      handles={
+        <Handle
+          id={HandleId.DataStream}
+          type="target"
+          position={Position.Top}
+          isConnectable={props.isConnectable}
+          variant={HandleType.DataStream}
+        />
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/terminate-node.tsx
+++ b/diagram-editor/frontend/nodes/terminate-node.tsx
@@ -1,5 +1,6 @@
 import { Button, Paper } from '@mui/material';
-import { Handle, type NodeProps, Position } from '@xyflow/react';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import { LAYOUT_OPTIONS } from '../utils/layout';
 import type { BuiltinNode } from '.';
 
@@ -13,6 +14,7 @@ function TerminateNodeComp({
         type="target"
         position={targetPosition}
         isConnectable={isConnectable}
+        variant={HandleType.Data}
       />
       <Button
         fullWidth

--- a/diagram-editor/frontend/nodes/transform-node.tsx
+++ b/diagram-editor/frontend/nodes/transform-node.tsx
@@ -1,4 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { TransformIcon } from './icons';
@@ -9,7 +10,22 @@ function TransformNodeComp(props: NodeProps<OperationNode<'transform'>>) {
       {...props}
       icon={<TransformIcon />}
       label="Transform"
-      variant="inputOutput"
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/nodes/unzip-node.tsx
+++ b/diagram-editor/frontend/nodes/unzip-node.tsx
@@ -1,4 +1,5 @@
-import type { NodeProps } from '@xyflow/react';
+import { type NodeProps, Position } from '@xyflow/react';
+import { Handle, HandleType } from '../handles';
 import type { OperationNode } from '.';
 import BaseNode from './base-node';
 import { UnzipIcon } from './icons';
@@ -9,7 +10,22 @@ function UnzipNodeComp(props: NodeProps<OperationNode<'unzip'>>) {
       {...props}
       icon={<UnzipIcon />}
       label="Unzip"
-      variant="inputOutput"
+      handles={
+        <>
+          <Handle
+            type="target"
+            position={Position.Top}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+          <Handle
+            type="source"
+            position={Position.Bottom}
+            isConnectable={props.isConnectable}
+            variant={HandleType.Data}
+          />
+        </>
+      }
     />
   );
 }

--- a/diagram-editor/frontend/types/react-flow.ts
+++ b/diagram-editor/frontend/types/react-flow.ts
@@ -2,7 +2,6 @@ import type {
   Edge as ReactFlowEdge,
   Node as ReactFlowNode,
 } from '@xyflow/react';
-import type { HandleId } from '../handles';
 
 export type Node<
   D extends Record<string, unknown>,
@@ -14,7 +13,4 @@ export type Edge<
   I extends { type: string },
   T extends string,
 > = ReactFlowEdge<{ output: O; input: I }, T> &
-  Pick<Required<ReactFlowEdge>, 'type' | 'data'> & {
-    sourceHandle?: HandleId;
-    targetHandle?: HandleId;
-  };
+  Pick<Required<ReactFlowEdge>, 'type' | 'data'>;

--- a/diagram-editor/frontend/utils/connection.test.ts
+++ b/diagram-editor/frontend/utils/connection.test.ts
@@ -5,6 +5,7 @@ import {
   createForkResultOkEdge,
   type DiagramEditorEdge,
 } from '../edges';
+import { HandleId } from '../handles';
 import { NodeManager } from '../node-manager';
 import {
   createOperationNode,
@@ -359,7 +360,7 @@ describe('validate edges', () => {
     }
   });
 
-  test('"fork_result" operation only allows 2 outputs', () => {
+  test('"fork_result" operation only allows 1 outputs for each of the output handles', () => {
     const forkResultNode = createOperationNode(
       ROOT_NAMESPACE,
       undefined,
@@ -375,12 +376,18 @@ describe('validate edges', () => {
     const nodeManager = new NodeManager([forkResultNode, terminateNode]);
 
     {
+      // existing "ok" edge, try to add a "err" edge.
       const existingEdges = [
-        createForkResultOkEdge(forkResultNode.id, null, terminateNode.id, null),
+        createForkResultOkEdge(
+          forkResultNode.id,
+          HandleId.ForkResultOk,
+          terminateNode.id,
+          null,
+        ),
       ];
       const newEdge = createForkResultErrEdge(
         forkResultNode.id,
-        null,
+        HandleId.ForkResultErr,
         terminateNode.id,
         null,
       );
@@ -389,18 +396,44 @@ describe('validate edges', () => {
     }
 
     {
+      // existing "err" edge, try to add a "ok" edge.
       const existingEdges = [
-        createForkResultOkEdge(forkResultNode.id, null, terminateNode.id, null),
         createForkResultErrEdge(
           forkResultNode.id,
-          null,
+          HandleId.ForkResultErr,
           terminateNode.id,
           null,
         ),
       ];
-      const newEdge = createForkResultErrEdge(
+      const newEdge = createForkResultOkEdge(
         forkResultNode.id,
+        HandleId.ForkResultOk,
+        terminateNode.id,
         null,
+      );
+      const result = validateEdgeSimple(newEdge, nodeManager, existingEdges);
+      expect(result.valid).toBe(true);
+    }
+
+    {
+      // exisiting "ok" and "err" edge, try to add a "ok" edge.
+      const existingEdges = [
+        createForkResultOkEdge(
+          forkResultNode.id,
+          HandleId.ForkResultOk,
+          terminateNode.id,
+          null,
+        ),
+        createForkResultErrEdge(
+          forkResultNode.id,
+          HandleId.ForkResultErr,
+          terminateNode.id,
+          null,
+        ),
+      ];
+      const newEdge = createForkResultOkEdge(
+        forkResultNode.id,
+        HandleId.ForkResultOk,
         terminateNode.id,
         null,
       );

--- a/diagram-editor/frontend/utils/connection.ts
+++ b/diagram-editor/frontend/utils/connection.ts
@@ -138,9 +138,7 @@ function getOutputCardinality(
     case 'split': {
       return CardinalityType.Many;
     }
-    case 'fork_result': {
-      return CardinalityType.Pair;
-    }
+    case 'fork_result':
     case 'node':
     case 'buffer_access':
     case 'join':

--- a/diagram-editor/frontend/utils/connection.ts
+++ b/diagram-editor/frontend/utils/connection.ts
@@ -55,10 +55,14 @@ const ALLOWED_INPUT_EDGE_CATEGORIES: Record<NodeTypes, EdgeCategory[]> = {
 
 const ALLOWED_HANDLE_OUTPUT_EDGES: Record<string, EdgeTypes[]> = {
   dataStream: ['streamOut'],
+  forkResultOk: ['forkResultOk'],
+  forkResultErr: ['forkResultErr'],
 } satisfies Record<HandleId, EdgeTypes[]>;
 
 const ALLOWED_HANDLE_INPUT_EDGE_CATEGORIES: Record<string, EdgeCategory[]> = {
   dataStream: [EdgeCategory.Data],
+  forkResultOk: [],
+  forkResultErr: [],
 } satisfies Record<HandleId, EdgeCategory[]>;
 
 function arrayIntersection<T>(a: T[], b: T[]): T[] {

--- a/diagram-editor/frontend/utils/operation.ts
+++ b/diagram-editor/frontend/utils/operation.ts
@@ -11,7 +11,7 @@ import {
   createUnzipEdge,
   type DiagramEditorEdge,
 } from '../edges';
-import type { HandleId } from '../handles';
+import { HandleId } from '../handles';
 import { NodeManager } from '../node-manager';
 import {
   type DiagramEditorNode,
@@ -53,10 +53,8 @@ function createStreamOutEdges(
     );
     if (targetNode) {
       const target = targetNode.id;
-      const targetHandle: HandleId =
-        targetNode.type === 'stream_out' ? 'dataStream' : null;
       edges.push(
-        createStreamOutEdge(node.id, 'dataStream', target, targetHandle, {
+        createStreamOutEdge(node.id, HandleId.DataStream, target, null, {
           streamId,
         }),
       );


### PR DESCRIPTION
* Show empty string by default instead of `null`.
* `fork_result` node separates the `ok` and `err` outputs into different handle.

<img width="618" height="177" alt="image" src="https://github.com/user-attachments/assets/d24d0e86-f3e9-4155-b04d-fcdd9cf9edb1" />
