### PR TITLE
Add badges for documentation to make it easy to find crates io documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 [![ci_linux](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_linux.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_linux.yaml)
 [![ci_windows](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_windows.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_windows.yaml)
 [![ci_web](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_web.yaml/badge.svg)](https://github.com/open-rmf/bevy_impulse/actions/workflows/ci_web.yaml)
+![Crates.io Version](https://img.shields.io/crates/v/bevy_impulse)
+![Crates.io Bevy Impulse Derive Version](https://img.shields.io/crates/v/bevy_impulse_derive)
+
 
 # Reactive Programming for Bevy
 


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Add small badges to the readme to make the documentation a little more discoverable.

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
