### PR TITLE
Skip testing documentation for deps

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -65,5 +65,5 @@ jobs:
         rm -rf target/debug/build
 
     - name: Build docs
-      run: cargo doc --all-features
+      run: cargo doc --no-deps --all-features
 


### PR DESCRIPTION
There have been some CI errors for weekly tests where the virtual machine runs out of disk space while building docs. Most likely this is because the doc test was building documentation for all the dependencies instead of only for crossflow. This PR uses the `--no-deps` flag to avoid that excessive work.