### PR TITLE
Clear entire target directory before building maximal features

### DIFF
--- a/.github/workflows/ci_linux.yaml
+++ b/.github/workflows/ci_linux.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         rust-version: [stable]
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
There has been an ongoing struggle with the GitHub Actions CI, which seems to keep running out of disk space earlier and earlier in the testing workflow for `ubuntu-latest`: https://github.com/open-rmf/crossflow/pull/143 https://github.com/open-rmf/crossflow/pull/152

Now the disk space is running out during the maximal feature test. This PR completely clears out the `target` directory before attempting to build the maximal feature tests. This will clear out any compiled `.rlib` files that aren't directly relevant to the maximal feature build, as well as any other build artifacts that could be taking up unnecessary space.

This will cause the maximal feature test to take longer to run, but I don't see any other clear option for obtaining enough disk space.