### PR TITLE
Migrate to edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossflow"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 authors = ["Grey <mxgrey@intrinsic.ai>"]
 license = "Apache-2.0"
 description = "Reactive programming and workflow engine in bevy"

--- a/diagram-editor/Cargo.toml
+++ b/diagram-editor/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossflow_diagram_editor"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 authors = ["Teo Koon Peng <koonpeng@intrinsic.ai>"]
 license = "Apache-2.0"
 description = "Frontend for crossflow diagrams"

--- a/diagram-editor/build.rs
+++ b/diagram-editor/build.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "frontend")]
 mod frontend {
-    use flate2::{write::GzEncoder, Compression};
+    use flate2::{Compression, write::GzEncoder};
     use std::fs::File;
     use std::io::{BufReader, Read};
     use std::path::{Path, PathBuf};
@@ -115,7 +115,9 @@ mod frontend {
                 break;
             }
             if a.is_none() || b.is_none() || a.unwrap().unwrap() != b.unwrap().unwrap() {
-                println!("cargo::error=Frontend has changed, run `BUILD_FRONTEND=1 cargo build` to update it");
+                println!(
+                    "cargo::error=Frontend has changed, run `BUILD_FRONTEND=1 cargo build` to update it"
+                );
                 return;
             }
         }

--- a/diagram-editor/server/api/executor.rs
+++ b/diagram-editor/server/api/executor.rs
@@ -1,18 +1,18 @@
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+    response::{self, Response},
+};
+#[cfg(feature = "router")]
+use axum::{Router, routing::post};
 #[cfg(feature = "debug")]
 use axum::{
     extract::ws,
     routing::{self},
 };
-use axum::{
-    extract::State,
-    http::StatusCode,
-    response::{self, Response},
-    Json,
-};
-#[cfg(feature = "router")]
-use axum::{routing::post, Router};
 use bevy_ecs::{prelude::Entity, schedule::IntoScheduleConfigs};
-use crossflow::{trace, Diagram, DiagramElementRegistry, OperationStarted, Promise, RequestExt};
+use crossflow::{Diagram, DiagramElementRegistry, OperationStarted, Promise, RequestExt, trace};
 use serde::{Deserialize, Serialize};
 use std::{
     error::Error,
@@ -477,7 +477,7 @@ mod tests {
     use axum::extract::ws;
     use axum::{
         body,
-        http::{header, Request},
+        http::{Request, header},
     };
     use crossflow::{CrossflowExecutorApp, NodeBuilderOptions};
     #[cfg(feature = "debug")]

--- a/diagram-editor/server/api/mod.rs
+++ b/diagram-editor/server/api/mod.rs
@@ -3,12 +3,12 @@ pub mod executor;
 #[cfg(feature = "debug")]
 mod websocket;
 
+#[cfg(feature = "router")]
+use axum::{Router, routing::get};
 use axum::{
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
-#[cfg(feature = "router")]
-use axum::{routing::get, Router};
 use crossflow::DiagramElementRegistry;
 use mime_guess::mime;
 
@@ -74,7 +74,7 @@ pub fn api_router(
 mod tests {
     use axum::{
         body::{self, Body},
-        http::{header, Request, StatusCode},
+        http::{Request, StatusCode, header},
     };
     use crossflow::NodeBuilderOptions;
     use mime_guess::mime;

--- a/diagram-editor/server/api/websocket.rs
+++ b/diagram-editor/server/api/websocket.rs
@@ -2,7 +2,7 @@
 use axum::extract::ws::{Message, Utf8Bytes};
 #[cfg(feature = "router")]
 use futures_util::{Sink, SinkExt, Stream, StreamExt};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 #[cfg(feature = "router")]
 use std::fmt::Display;
 use std::ops::Deref;

--- a/diagram-editor/server/basic_executor.rs
+++ b/diagram-editor/server/basic_executor.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::{new_router, ServerOptions};
+use crate::{ServerOptions, new_router};
 use bevy_app;
 use clap::Parser;
 use crossflow::{

--- a/diagram-editor/server/bin/print_schema.rs
+++ b/diagram-editor/server/bin/print_schema.rs
@@ -1,6 +1,6 @@
 use crossflow_diagram_editor::api::{
-    executor::{DebugSessionMessage, PostRunRequest},
     RegistryResponse,
+    executor::{DebugSessionMessage, PostRunRequest},
 };
 use indexmap::IndexMap;
 use schemars::SchemaGenerator;

--- a/diagram-editor/server/frontend.rs
+++ b/diagram-editor/server/frontend.rs
@@ -1,10 +1,10 @@
 use axum::{
+    Router,
     body::Body,
     extract::Path,
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
     routing::get,
-    Router,
 };
 use flate2::read::GzDecoder;
 use std::{collections::HashMap, io::Read};
@@ -100,7 +100,7 @@ mod tests {
     use super::*;
     use axum::{
         body::Body,
-        http::{header, Request, StatusCode},
+        http::{Request, StatusCode, header},
         response::Response,
     };
     use tower::Service;

--- a/diagram-editor/server/router.rs
+++ b/diagram-editor/server/router.rs
@@ -1,4 +1,4 @@
-use crate::api::{api_router, ApiOptions};
+use crate::api::{ApiOptions, api_router};
 #[cfg(feature = "frontend")]
 use crate::frontend;
 use axum::Router;

--- a/diagram-editor/wasm/Cargo.toml
+++ b/diagram-editor/wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossflow_diagram_editor_wasm"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 authors = ["Teo Koon Peng <koonpeng@intrinsic.ai>"]
 license = "Apache-2.0"
 description = "Webassembly backend for crossflow diagram editor"

--- a/diagram-editor/wasm/src/executor.rs
+++ b/diagram-editor/wasm/src/executor.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, task::Poll};
 
-use axum::{extract::State, Json};
+use axum::{Json, extract::State};
 use crossflow_diagram_editor::api::{self, executor::PostRunRequest};
 use futures::task::noop_waker;
 use wasm_bindgen::prelude::*;

--- a/diagram-editor/wasm/src/globals.rs
+++ b/diagram-editor/wasm/src/globals.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use crossflow::DiagramElementRegistry;
 
 pub use crossflow_diagram_editor::api::executor::ExecutorOptions;
-use crossflow_diagram_editor::api::executor::{setup_bevy_app_wasm, ExecutorState};
+use crossflow_diagram_editor::api::executor::{ExecutorState, setup_bevy_app_wasm};
 
 static EXECUTOR_STATE: Mutex<Option<ExecutorState>> = Mutex::new(None);
 static BEVY_APP: Mutex<Option<bevy_app::SubApp>> = Mutex::new(None);

--- a/diagram-editor/wasm/src/test_utils.rs
+++ b/diagram-editor/wasm/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crossflow::{CrossflowExecutorApp, DiagramElementRegistry, NodeBuilderOptions};
 use crossflow_diagram_editor::api::executor::ExecutorOptions;
 
-use super::{init_wasm, setup_wasm, InitOptions};
+use super::{InitOptions, init_wasm, setup_wasm};
 
 init_wasm! {
     let mut app = bevy_app::SubApp::new();

--- a/examples/diagram/calculator/Cargo.toml
+++ b/examples/diagram/calculator/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "calculator"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 crossflow_diagram_editor = { path = "../../../diagram-editor", features = ["basic_executor"] }
 calculator_ops_catalog = { path = "../calculator_ops_catalog" }
 
 [dev-dependencies]
-assert_cmd = "2.0.16"
+assert_cmd = "2.1.2"

--- a/examples/diagram/calculator/tests/e2e.rs
+++ b/examples/diagram/calculator/tests/e2e.rs
@@ -1,9 +1,8 @@
-use assert_cmd::Command;
+use assert_cmd::{Command, cargo};
 
 #[test]
 fn multiply_by_3() {
-    Command::cargo_bin("calculator")
-        .unwrap()
+    Command::new(cargo::cargo_bin!("calculator"))
         .args(["run", "diagrams/multiply_by_3.json", "4"])
         .assert()
         .stdout("12.0\n");

--- a/examples/diagram/calculator_ops_catalog/Cargo.toml
+++ b/examples/diagram/calculator_ops_catalog/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "calculator_ops_catalog"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 description = "catalog of reusable calculator operations"
 
 [dependencies]

--- a/examples/diagram/calculator_ops_catalog/src/lib.rs
+++ b/examples/diagram/calculator_ops_catalog/src/lib.rs
@@ -5,7 +5,7 @@ use crossflow::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Number, Value};
+use serde_json::{Number, Value, json};
 
 #[derive(Clone, Copy, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/examples/diagram/calculator_wasm/Cargo.toml
+++ b/examples/diagram/calculator_wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "calculator_wasm"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/diagram/calculator_wasm/src/lib.rs
+++ b/examples/diagram/calculator_wasm/src/lib.rs
@@ -1,5 +1,5 @@
 use crossflow::{CrossflowExecutorApp, DiagramElementRegistry};
-use crossflow_diagram_editor_wasm::{init_wasm, setup_wasm, ExecutorOptions, InitOptions};
+use crossflow_diagram_editor_wasm::{ExecutorOptions, InitOptions, init_wasm, setup_wasm};
 
 init_wasm! {
     wasm_logger::init(wasm_logger::Config::default());

--- a/examples/handbook_snippets/Cargo.toml
+++ b/examples/handbook_snippets/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "handbook_snippets"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 description = "Example code used for in the crossflow handbook"
 
 [[bin]]

--- a/examples/handbook_snippets/src/native-snippets.rs
+++ b/examples/handbook_snippets/src/native-snippets.rs
@@ -1328,7 +1328,7 @@ use std::future::Future;
 fn fetch_page_title(
     In(srv): AsyncServiceInput<Entity>,
     url: Query<&Url>,
-) -> impl Future<Output = Result<String, ()>> {
+) -> impl Future<Output = Result<String, ()>> + use<> {
     // Use a query to get the Url component of this entity
     let url = url.get(srv.request).cloned();
 
@@ -1442,7 +1442,7 @@ struct NavigationRequest {
 fn navigate(
     In(input): AsyncServiceInput<NavigationRequest, NavigationStreams>,
     nav_graph: Res<NavigationGraph>,
-) -> impl Future<Output = Result<(), NavigationError>> {
+) -> impl Future<Output = Result<(), NavigationError>> + use<> {
     // Clone the nevigation graph resource so we can move the clone into the
     // async block.
     let nav_graph = (*nav_graph).clone();
@@ -1855,7 +1855,7 @@ struct Url(String);
 fn get_page_element(
     In(element): In<String>,
     url: Res<Url>,
-) -> impl Future<Output = Option<String>> {
+) -> impl Future<Output = Option<String>> + use<> {
     let url = (**url).clone();
     async move {
         let content = fetch_content_from_url(url).await?;

--- a/examples/native/Cargo.toml
+++ b/examples/native/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossflow-native-api-examples"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "delivery-instructions"

--- a/examples/native/src/async_service_example.rs
+++ b/examples/native/src/async_service_example.rs
@@ -95,7 +95,7 @@ fn update_page_title(
     In(srv): AsyncServiceInput<Entity>,
     url: Query<&Url>,
     runtime: Res<TokioRuntime>,
-) -> impl Future<Output = Result<(), ()>> {
+) -> impl Future<Output = Result<(), ()>> + use<> {
     // Use a query to get the Url component of this entity
     let url = url.get(srv.request).cloned();
     let rt = Arc::clone(&**runtime);

--- a/examples/zenoh-examples/Cargo.toml
+++ b/examples/zenoh-examples/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zenoh-examples"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 
 [[bin]]
 name = "door-manager"

--- a/examples/zenoh-examples/src/door_manager.rs
+++ b/examples/zenoh-examples/src/door_manager.rs
@@ -25,7 +25,7 @@ use tracing::error;
 use zenoh_examples::protos;
 
 use zenoh_examples::{
-    zenoh_publisher_node, zenoh_subscription_node, ArcError, ZenohCrossflowPlugin,
+    ArcError, ZenohCrossflowPlugin, zenoh_publisher_node, zenoh_subscription_node,
 };
 
 fn main() {

--- a/examples/zenoh-examples/src/lib.rs
+++ b/examples/zenoh-examples/src/lib.rs
@@ -142,7 +142,7 @@ pub fn zenoh_publisher_node<T: 'static + Send + Sync + Message + std::fmt::Debug
 fn get_zenoh_publisher(
     In(topic_name): In<Arc<str>>,
     session: Res<ZenohSession>,
-) -> impl Future<Output = Result<Arc<AdvancedPublisher<'static>>, ArcError>> {
+) -> impl Future<Output = Result<Arc<AdvancedPublisher<'static>>, ArcError>> + use<> {
     let session_promise = session.promise.clone();
 
     async move {

--- a/examples/zenoh-examples/src/use_door.rs
+++ b/examples/zenoh-examples/src/use_door.rs
@@ -27,7 +27,7 @@ use tracing::error;
 use uuid::Uuid;
 use zenoh_examples::protos;
 
-use zenoh_examples::{zenoh_publisher_node, zenoh_subscription_node, ZenohCrossflowPlugin};
+use zenoh_examples::{ZenohCrossflowPlugin, zenoh_publisher_node, zenoh_subscription_node};
 
 #[derive(Parser)]
 struct Args {

--- a/handbook/src/spawn-async-services.md
+++ b/handbook/src/spawn-async-services.md
@@ -196,7 +196,7 @@ from an async function.
 > fn my_async_service(
 >     In(srv): AsyncServiceInput<Request>,
 >     /* ... Bevy System Params Go Here ... */
-> ) -> impl Future<Output = Response> {
+> ) -> impl Future<Output = Response> + use<> {
 >     /* ... Use Bevy System params, cloning data as needed ... */
 >     async move {
 >         /* ... Perform async operations ... */

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "crossflow_derive"
 version = "0.0.4"
-edition = "2021"
+edition = "2024"
 authors = ["Grey <mxgrey@intrinsic.ai>"]
 license = "Apache-2.0"
 description = "Procedural macros for crossflow"

--- a/macros/src/derive_buffer.rs
+++ b/macros/src/derive_buffer.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{
-    parse_quote, Field, Generics, Ident, ImplGenerics, ItemStruct, Type, TypeGenerics, TypePath,
-    Visibility, WhereClause,
+    Field, Generics, Ident, ImplGenerics, ItemStruct, Type, TypeGenerics, TypePath, Visibility,
+    WhereClause, parse_quote,
 };
 
 use crate::Result;
@@ -56,7 +56,7 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
         impl_buffer_map_layout(&buffer_struct, &field_ident, &field_config)?;
     let impl_joined = impl_joined(&buffer_struct, &input_struct, &field_ident)?;
 
-    let gen = quote! {
+    let tokens = quote! {
         impl #impl_generics ::crossflow::Joined for #struct_ident #ty_generics #where_clause {
             type Buffers = #buffer_struct_ident #ty_generics;
         }
@@ -72,7 +72,7 @@ pub(crate) fn impl_joined_value(input_struct: &ItemStruct) -> Result<TokenStream
         #impl_joined
     };
 
-    Ok(gen.into())
+    Ok(tokens.into())
 }
 
 pub(crate) fn impl_buffer_key_map(input_struct: &ItemStruct) -> Result<TokenStream> {
@@ -121,7 +121,7 @@ pub(crate) fn impl_buffer_key_map(input_struct: &ItemStruct) -> Result<TokenStre
         impl_buffer_map_layout(&buffer_struct, &field_ident, &field_config)?;
     let impl_accessed = impl_accessed(&buffer_struct, &input_struct, &field_ident, &field_type)?;
 
-    let gen = quote! {
+    let tokens = quote! {
         impl #impl_generics ::crossflow::Accessor for #struct_ident #ty_generics #where_clause {
             type Buffers = #buffer_struct_ident #ty_generics;
         }
@@ -137,7 +137,7 @@ pub(crate) fn impl_buffer_key_map(input_struct: &ItemStruct) -> Result<TokenStre
         #impl_accessed
     };
 
-    Ok(gen.into())
+    Ok(tokens.into())
 }
 
 /// Code that are currently unused but could be used in the future, move them out of this mod if

--- a/macros/src/derive_section.rs
+++ b/macros/src/derive_section.rs
@@ -19,7 +19,7 @@ use std::iter::zip;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::{parse_quote_spanned, spanned::Spanned, Field, Ident, ItemStruct, Member, Type};
+use syn::{Field, Ident, ItemStruct, Member, Type, parse_quote_spanned, spanned::Spanned};
 
 use crate::Result;
 
@@ -60,7 +60,7 @@ pub(crate) fn impl_section(input_struct: &ItemStruct) -> Result<TokenStream> {
         })
         .collect();
 
-    let gen = quote! {
+    let tokens = quote! {
         impl #impl_generics ::crossflow::Section for #struct_ident #ty_generics #where_clause {
             fn into_slots(
                 self: Box<Self>,
@@ -111,7 +111,7 @@ pub(crate) fn impl_section(input_struct: &ItemStruct) -> Result<TokenStream> {
         }
     };
 
-    Ok(gen)
+    Ok(tokens)
 }
 
 struct FieldConfig {

--- a/macros/src/derive_stream_pack.rs
+++ b/macros/src/derive_stream_pack.rs
@@ -17,7 +17,7 @@
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned};
-use syn::{spanned::Spanned, Generics, Ident, ItemStruct};
+use syn::{Generics, Ident, ItemStruct, spanned::Spanned};
 
 // Top-level attr for StreamPack
 const STREAM_ATTR_TAG: &'static str = "stream";

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -29,7 +29,7 @@ use derive_stream_pack::impl_stream_pack;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, ItemStruct};
+use syn::{DeriveInput, ItemStruct, parse_macro_input};
 
 #[proc_macro_derive(Stream)]
 pub fn derive_stream(item: TokenStream) -> TokenStream {

--- a/src/async_execution/single_threaded_execution.rs
+++ b/src/async_execution/single_threaded_execution.rs
@@ -20,7 +20,7 @@ use bevy_ecs::prelude::World;
 use async_task::Runnable;
 pub(crate) use bevy_tasks::{Task as TaskHandle, TaskPool};
 use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+    UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender, unbounded_channel,
 };
 
 use std::{future::Future, pin::Pin};

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -923,7 +923,7 @@ pub enum BufferError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, AddBufferToMap, Gate};
+    use crate::{AddBufferToMap, Gate, prelude::*, testing::*};
     use std::future::Future;
 
     #[test]
@@ -1001,10 +1001,12 @@ mod tests {
             context.command(|commands| commands.request((2.0, 3.0), workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(2));
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|value| value.is_err_and(|n| n == 5.0)));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|value| value.is_err_and(|n| n == 5.0))
+        );
         assert!(context.no_unhandled_errors());
 
         // Same as previous test, but using Builder::create_buffer_access instead
@@ -1038,10 +1040,12 @@ mod tests {
             context.command(|commands| commands.request((2.0, 3.0), workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(2));
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|value| value.is_err_and(|n| n == 5.0)));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|value| value.is_err_and(|n| n == 5.0))
+        );
         assert!(context.no_unhandled_errors());
     }
 
@@ -1180,10 +1184,12 @@ mod tests {
 
         context.run_while_pending(&mut promise);
         if expect_success {
-            assert!(promise
-                .take()
-                .available()
-                .is_some_and(|r| r.finished_with(initial_value)));
+            assert!(
+                promise
+                    .take()
+                    .available()
+                    .is_some_and(|r| r.finished_with(initial_value))
+            );
         } else {
             assert!(promise.take().is_cancelled());
         }
@@ -1250,7 +1256,7 @@ mod tests {
 
     fn async_decrement_register(
         In(input): In<AsyncCallback<(Register, BufferKey<Register>)>>,
-    ) -> impl Future<Output = Option<Register>> {
+    ) -> impl Future<Output = Option<Register>> + use<> {
         async move {
             input
                 .channel
@@ -1262,7 +1268,7 @@ mod tests {
 
     fn async_decrement_register_and_pass_keys(
         In(input): In<AsyncCallback<(Register, BufferKey<Register>)>>,
-    ) -> impl Future<Output = Option<(Register, BufferKey<Register>)>> {
+    ) -> impl Future<Output = Option<(Register, BufferKey<Register>)>> + use<> {
         async move {
             input
                 .channel

--- a/src/buffer/any_buffer.rs
+++ b/src/buffer/any_buffer.rs
@@ -19,7 +19,7 @@
 
 use std::{
     any::{Any, TypeId},
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     ops::RangeBounds,
     sync::{Mutex, OnceLock},
 };
@@ -34,13 +34,12 @@ use thiserror::Error as ThisError;
 use smallvec::SmallVec;
 
 use crate::{
-    add_listener_to_source, Accessing, Accessor, Buffer, BufferAccessMut, BufferAccessors,
-    BufferError, BufferIdentifier, BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag,
-    BufferLocation, BufferMap, BufferMapLayout, BufferStorage, Bufferable, Buffering, Builder,
-    CloneFromBuffer, DrainBuffer, FetchFromBuffer, Gate, GateState, IncompatibleLayout,
-    InspectBuffer, Joining, ManageBuffer, MessageTypeHint, MessageTypeHintEvaluation,
-    MessageTypeHintMap, NotifyBufferUpdate, OperationError, OperationResult, OperationRoster,
-    OrBroken, TypeInfo,
+    Accessing, Accessor, Buffer, BufferAccessMut, BufferAccessors, BufferError, BufferIdentifier,
+    BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferMap,
+    BufferMapLayout, BufferStorage, Bufferable, Buffering, Builder, CloneFromBuffer, DrainBuffer,
+    FetchFromBuffer, Gate, GateState, IncompatibleLayout, InspectBuffer, Joining, ManageBuffer,
+    MessageTypeHint, MessageTypeHintEvaluation, MessageTypeHintMap, NotifyBufferUpdate,
+    OperationError, OperationResult, OperationRoster, OrBroken, TypeInfo, add_listener_to_source,
 };
 
 /// A [`Buffer`] whose message type has been anonymized. Joining with this buffer
@@ -106,8 +105,8 @@ impl AnyBuffer {
     }
 
     /// Get the [`AnyBufferAccessInterface`] for a concrete message type.
-    pub fn interface_for<T: 'static + Send + Sync>(
-    ) -> &'static (dyn AnyBufferAccessInterface + Send + Sync) {
+    pub fn interface_for<T: 'static + Send + Sync>()
+    -> &'static (dyn AnyBufferAccessInterface + Send + Sync) {
         static INTERFACE_MAP: OnceLock<
             Mutex<HashMap<TypeId, &'static (dyn AnyBufferAccessInterface + Send + Sync)>>,
         > = OnceLock::new();
@@ -628,7 +627,7 @@ trait AnyBufferViewing {
 trait AnyBufferManagement: AnyBufferViewing {
     fn any_push(&mut self, session: Entity, value: AnyMessageBox) -> AnyMessagePushResult;
     fn any_push_as_oldest(&mut self, session: Entity, value: AnyMessageBox)
-        -> AnyMessagePushResult;
+    -> AnyMessagePushResult;
     fn any_pull(&mut self, session: Entity) -> Option<AnyMessageBox>;
     fn any_pull_newest(&mut self, session: Entity) -> Option<AnyMessageBox>;
     fn any_oldest_mut<'a>(&'a mut self, session: Entity) -> Option<AnyMessageMut<'a>>;

--- a/src/buffer/buffer_access_lifecycle.rs
+++ b/src/buffer/buffer_access_lifecycle.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc::UnboundedSender as TokioSender;
 
 use std::sync::Arc;
 
-use crate::{emit_disposal, BufferKeyBuilder, ChannelItem, Disposal, OperationRoster};
+use crate::{BufferKeyBuilder, ChannelItem, Disposal, OperationRoster, emit_disposal};
 
 /// This is used as a field inside of [`crate::BufferKey`] which keeps track of
 /// when a key that was sent out into the world gets fully dropped from use. We

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -27,10 +27,10 @@ use smallvec::SmallVec;
 use bevy_ecs::prelude::{Entity, World};
 
 use crate::{
-    add_listener_to_source, Accessing, AnyBuffer, AnyBufferKey, AnyMessageBox, AsAnyBuffer, Buffer,
-    BufferKeyBuilder, BufferKeyLifecycle, Bufferable, Buffering, Builder, Chain, CloneFromBuffer,
-    FetchFromBuffer, Gate, GateState, Joining, Node, OperationError, OperationResult,
-    OperationRoster, TypeInfo,
+    Accessing, AnyBuffer, AnyBufferKey, AnyMessageBox, AsAnyBuffer, Buffer, BufferKeyBuilder,
+    BufferKeyLifecycle, Bufferable, Buffering, Builder, Chain, CloneFromBuffer, FetchFromBuffer,
+    Gate, GateState, Joining, Node, OperationError, OperationResult, OperationRoster, TypeInfo,
+    add_listener_to_source,
 };
 
 pub use crossflow_derive::{Accessor, Joined};
@@ -856,7 +856,7 @@ impl<B: 'static + Send + Sync + AsAnyBuffer + Clone, const N: usize> BufferMapLa
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, AddBufferToMap, BufferMap};
+    use crate::{AddBufferToMap, BufferMap, prelude::*, testing::*};
 
     #[derive(Joined)]
     struct TestJoinedValue<T: Send + Sync + 'static + Clone> {

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -29,20 +29,20 @@ use bevy_ecs::{
     system::SystemState,
 };
 
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 pub use serde_json::Value as JsonMessage;
 
 use smallvec::SmallVec;
 
 use crate::{
-    add_listener_to_source, Accessing, Accessor, AnyBuffer, AnyBufferAccessInterface, AnyBufferKey,
-    AnyRange, AsAnyBuffer, Buffer, BufferAccessMut, BufferAccessors, BufferError, BufferIdentifier,
-    BufferKey, BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferMap,
-    BufferMapLayout, BufferMapStruct, BufferStorage, Bufferable, Buffering, Builder,
-    CloneFromBuffer, DrainBuffer, Gate, GateState, IncompatibleLayout, InspectBuffer, JoinBehavior,
-    Joined, Joining, ManageBuffer, MessageTypeHint, MessageTypeHintEvaluation, MessageTypeHintMap,
-    NotifyBufferUpdate, OperationError, OperationResult, OrBroken,
+    Accessing, Accessor, AnyBuffer, AnyBufferAccessInterface, AnyBufferKey, AnyRange, AsAnyBuffer,
+    Buffer, BufferAccessMut, BufferAccessors, BufferError, BufferIdentifier, BufferKey,
+    BufferKeyBuilder, BufferKeyLifecycle, BufferKeyTag, BufferLocation, BufferMap, BufferMapLayout,
+    BufferMapStruct, BufferStorage, Bufferable, Buffering, Builder, CloneFromBuffer, DrainBuffer,
+    Gate, GateState, IncompatibleLayout, InspectBuffer, JoinBehavior, Joined, Joining,
+    ManageBuffer, MessageTypeHint, MessageTypeHintEvaluation, MessageTypeHintMap,
+    NotifyBufferUpdate, OperationError, OperationResult, OrBroken, add_listener_to_source,
 };
 
 /// A [`Buffer`] whose message type has been anonymized, but which is known to
@@ -641,7 +641,7 @@ trait JsonBufferViewing {
 trait JsonBufferManagement: JsonBufferViewing {
     fn json_push(&mut self, session: Entity, value: JsonMessage) -> JsonMessagePushResult;
     fn json_push_as_oldest(&mut self, session: Entity, value: JsonMessage)
-        -> JsonMessagePushResult;
+    -> JsonMessagePushResult;
     fn json_pull(&mut self, session: Entity) -> JsonMessageViewResult;
     fn json_pull_newest(&mut self, session: Entity) -> JsonMessageViewResult;
     fn json_oldest_mut<'a>(
@@ -1364,7 +1364,7 @@ impl Joining for HashMap<BufferIdentifier<'static>, JsonBuffer> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, AddBufferToMap};
+    use crate::{AddBufferToMap, prelude::*, testing::*};
     use bevy_ecs::prelude::World;
     use serde::{Deserialize, Serialize};
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -22,15 +22,15 @@ use std::future::Future;
 use smallvec::SmallVec;
 
 use crate::{
-    make_option_branching, make_result_branching, Accessible, Accessing, Accessor, AddOperation,
-    AsMap, Buffer, BufferKeys, BufferLocation, BufferMap, BufferSettings, Bufferable, Buffering,
-    Chain, Collect, ForkClone, ForkCloneOutput, ForkOptionOutput, ForkResultOutput,
-    ForkTargetStorage, Gate, GateRequest, IncompatibleLayout, Injection, InputSlot, IntoAsyncMap,
-    IntoBlockingMap, Joinable, Joined, Node, OperateBuffer, OperateCancel, OperateDynamicGate,
-    OperateQuietCancel, OperateScope, OperateSplit, OperateStaticGate, Output, Provider,
-    RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints, ScopeSettings, ScopeSettingsStorage,
-    Sendish, ServiceInstructions, SplitOutputs, Splittable, StreamPack, StreamTargetMap,
-    StreamsOfMap, Trim, TrimBranch, UnusedTarget, Unzippable,
+    Accessible, Accessing, Accessor, AddOperation, AsMap, Buffer, BufferKeys, BufferLocation,
+    BufferMap, BufferSettings, Bufferable, Buffering, Chain, Collect, ForkClone, ForkCloneOutput,
+    ForkOptionOutput, ForkResultOutput, ForkTargetStorage, Gate, GateRequest, IncompatibleLayout,
+    Injection, InputSlot, IntoAsyncMap, IntoBlockingMap, Joinable, Joined, Node, OperateBuffer,
+    OperateCancel, OperateDynamicGate, OperateQuietCancel, OperateScope, OperateSplit,
+    OperateStaticGate, Output, Provider, RequestOfMap, ResponseOfMap, Scope, ScopeEndpoints,
+    ScopeSettings, ScopeSettingsStorage, Sendish, ServiceInstructions, SplitOutputs, Splittable,
+    StreamPack, StreamTargetMap, StreamsOfMap, Trim, TrimBranch, UnusedTarget, Unzippable,
+    make_option_branching, make_result_branching,
 };
 
 pub(crate) mod connect;
@@ -808,7 +808,7 @@ impl CleanupWorkflowConditions {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, CancellationCause};
+    use crate::{CancellationCause, prelude::*, testing::*};
     use smallvec::SmallVec;
     use std::time::Instant;
 
@@ -879,10 +879,12 @@ mod tests {
             context.command(|commands| commands.request((), workflow).take_response());
 
         context.run_with_conditions(&mut promise, flush_cycles);
-        assert!(promise
-            .take()
-            .cancellation()
-            .is_some_and(|c| matches!(*c.cause, CancellationCause::Unreachable(_))));
+        assert!(
+            promise
+                .take()
+                .cancellation()
+                .is_some_and(|c| matches!(*c.cause, CancellationCause::Unreachable(_)))
+        );
         assert!(context.no_unhandled_errors());
     }
 
@@ -1196,10 +1198,12 @@ mod tests {
             context.command(|commands| commands.request([1, 2, 3, 4, 5], workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(5));
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|v| &v[..] == [1, 2, 3, 4]));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|v| &v[..] == [1, 2, 3, 4])
+        );
         assert!(context.no_unhandled_errors());
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
@@ -1294,9 +1298,11 @@ mod tests {
             context.command(|commands| commands.request(input, workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(2));
-        assert!(Promise::take(&mut promise)
-            .available()
-            .is_some_and(|v| v == expectation));
+        assert!(
+            Promise::take(&mut promise)
+                .available()
+                .is_some_and(|v| v == expectation)
+        );
         assert!(context.no_unhandled_errors());
     }
 

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -16,10 +16,11 @@
 */
 
 use crate::{
+    AddOperation, AsyncCallback, BlockingCallback, Channel, ChannelQueue, Input, ManageDisposal,
+    ManageInput, OperateCallback, OperateTask, OperationError, OperationRoster, OrBroken,
+    ProvideOnce, Provider, Sendish, StreamPack, UnusedStreams,
     async_execution::{spawn_task, task_cancel_sender},
-    make_stream_buffers_from_world, AddOperation, AsyncCallback, BlockingCallback, Channel,
-    ChannelQueue, Input, ManageDisposal, ManageInput, OperateCallback, OperateTask, OperationError,
-    OperationRoster, OrBroken, ProvideOnce, Provider, Sendish, StreamPack, UnusedStreams,
+    make_stream_buffers_from_world,
 };
 
 use bevy_ecs::{
@@ -70,7 +71,7 @@ use std::{
 /// fn add_integer_async(
 ///     In(input): In<AsyncCallback<i32>>,
 ///     integer: Res<Integer>,
-/// ) -> impl Future<Output = i32> {
+/// ) -> impl Future<Output = i32> + use<> {
 ///     let value = integer.value;
 ///     async move { input.request + value }
 /// }
@@ -121,7 +122,7 @@ use std::{
 /// fn add_integer(
 ///     In(input): In<i32>,
 ///     integer: Res<Integer>,
-/// ) -> impl Future<Output = i32> {
+/// ) -> impl Future<Output = i32> + use<> {
 ///     let value = integer.value;
 ///     async move { input + value }
 /// }

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -24,13 +24,13 @@ use smallvec::SmallVec;
 use std::error::Error;
 
 use crate::{
-    make_option_branching, make_result_branching, Accessing, AddOperation, AsMap, Buffer,
-    BufferKey, BufferKeys, Bufferable, Buffering, Builder, Collect, CreateCancelFilter,
-    CreateDisposalFilter, ForkTargetStorage, Gate, GateRequest, InputSlot, IntoAsyncMap,
-    IntoBlockingCallback, IntoBlockingMap, Node, Noop, OperateBufferAccess, OperateCancel,
-    OperateDynamicGate, OperateQuietCancel, OperateSplit, OperateStaticGate, Output, ProvideOnce,
-    Provider, Scope, ScopeSettings, Sendish, ServiceInstructions, Spread, StreamPack,
-    StreamTargetMap, Trim, TrimBranch, UnusedTarget,
+    Accessing, AddOperation, AsMap, Buffer, BufferKey, BufferKeys, Bufferable, Buffering, Builder,
+    Collect, CreateCancelFilter, CreateDisposalFilter, ForkTargetStorage, Gate, GateRequest,
+    InputSlot, IntoAsyncMap, IntoBlockingCallback, IntoBlockingMap, Node, Noop,
+    OperateBufferAccess, OperateCancel, OperateDynamicGate, OperateQuietCancel, OperateSplit,
+    OperateStaticGate, Output, ProvideOnce, Provider, Scope, ScopeSettings, Sendish,
+    ServiceInstructions, Spread, StreamPack, StreamTargetMap, Trim, TrimBranch, UnusedTarget,
+    make_option_branching, make_result_branching,
 };
 
 pub mod fork_clone_builder;
@@ -1451,10 +1451,12 @@ mod tests {
         let mut promise = context.command(|commands| commands.request(7, workflow).take_response());
 
         context.run_with_conditions(&mut promise, 1);
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|v| { v.len() == 7 && v.iter().find(|a| **a != 7).is_none() }));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|v| { v.len() == 7 && v.iter().find(|a| **a != 7).is_none() })
+        );
         assert!(context.no_unhandled_errors());
     }
 
@@ -1498,10 +1500,12 @@ mod tests {
         let mut promise = context.command(|commands| commands.request(8, workflow).take_response());
 
         context.run_with_conditions(&mut promise, 1);
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|v| { v.len() == 8 && v.iter().find(|a| **a != 8).is_none() }));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|v| { v.len() == 8 && v.iter().find(|a| **a != 8).is_none() })
+        );
         assert!(context.no_unhandled_errors());
 
         let workflow =
@@ -1553,10 +1557,12 @@ mod tests {
         let mut promise = context.command(|commands| commands.request(2, workflow).take_response());
 
         context.run_with_conditions(&mut promise, Duration::from_secs(2));
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|v| v.len() == 1 && v.iter().find(|a| **a != 2).is_none()));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|v| v.len() == 1 && v.iter().find(|a| **a != 2).is_none())
+        );
         assert!(context.no_unhandled_errors());
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
@@ -1578,10 +1584,12 @@ mod tests {
         let mut promise = context.command(|commands| commands.request(5, workflow).take_response());
 
         context.run_with_conditions(&mut promise, 1);
-        assert!(promise
-            .take()
-            .available()
-            .is_some_and(|v| v.len() == 1 && v.iter().find(|a| **a != 5).is_none()));
+        assert!(
+            promise
+                .take()
+                .available()
+                .is_some_and(|v| v.len() == 1 && v.iter().find(|a| **a != 5).is_none())
+        );
         assert!(context.no_unhandled_errors());
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -22,7 +22,7 @@ use bevy_ecs::{
 };
 
 use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+    UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender, unbounded_channel,
 };
 
 use std::sync::Arc;

--- a/src/diagram.rs
+++ b/src/diagram.rs
@@ -69,16 +69,17 @@ use std::{
 
 pub use crate::type_info::TypeInfo;
 use crate::{
-    is_default, BufferIdentifier, Builder, IncompatibleLayout, IncrementalScopeError, JsonMessage,
+    BufferIdentifier, Builder, IncompatibleLayout, IncrementalScopeError, JsonMessage,
     MessageTypeHint, Scope, Service, SpawnWorkflowExt, SplitConnectionError, StreamPack,
+    is_default,
 };
 
-use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
+use schemars::{JsonSchema, Schema, SchemaGenerator, json_schema};
 
 use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
     de::{Error, Visitor},
     ser::SerializeMap,
-    Deserialize, Deserializer, Serialize, Serializer,
 };
 
 use thiserror::Error as ThisError;
@@ -831,7 +832,9 @@ pub enum DiagramErrorCode {
     #[error("Operation [{0}] attempted to instantiate a duplicate buffer.")]
     DuplicateBuffersCreated(OperationRef),
 
-    #[error("Missing a connection to start or terminate. A workflow cannot run with a valid connection to each.")]
+    #[error(
+        "Missing a connection to start or terminate. A workflow cannot run with a valid connection to each."
+    )]
     MissingStartOrTerminate,
 
     #[error("Serialization was not registered for the target message type.")]
@@ -846,7 +849,9 @@ pub enum DiagramErrorCode {
     #[error("The target message type does not support unzipping. Type: {0}")]
     NotUnzippable(TypeInfo),
 
-    #[error("The number of elements in the unzip expected by the diagram [{expected}] is different from the real number [{actual}]")]
+    #[error(
+        "The number of elements in the unzip expected by the diagram [{expected}] is different from the real number [{actual}]"
+    )]
     UnzipMismatch {
         expected: usize,
         actual: usize,
@@ -858,7 +863,9 @@ pub enum DiagramErrorCode {
     )]
     CannotForkResult(TypeInfo),
 
-    #[error("Response cannot be split. Make sure to use .with_split() when building the node. Type: {0}")]
+    #[error(
+        "Response cannot be split. Make sure to use .with_split() when building the node. Type: {0}"
+    )]
     NotSplittable(TypeInfo),
 
     #[error(
@@ -875,7 +882,9 @@ pub enum DiagramErrorCode {
         available: Vec<BufferIdentifier<'static>>,
     },
 
-    #[error("Target type cannot be determined from [next] and [target_node] is not provided or cannot be inferred from.")]
+    #[error(
+        "Target type cannot be determined from [next] and [target_node] is not provided or cannot be inferred from."
+    )]
     UnknownTarget,
 
     #[error("There was an attempt to connect to an unknown operation: [{0}]")]
@@ -905,7 +914,9 @@ pub enum DiagramErrorCode {
     #[error("inconsistent type hints for the buffer message: {}", format_list(&.0))]
     InconsistentBufferHints(Vec<MessageTypeHint>),
 
-    #[error("This error should not happen, it means the implementation of buffer hints is broken. Identifier of missing hint: {0}")]
+    #[error(
+        "This error should not happen, it means the implementation of buffer hints is broken. Identifier of missing hint: {0}"
+    )]
     BrokenBufferMessageTypeHint(BufferIdentifier<'static>),
 
     #[error(transparent)]

--- a/src/diagram/buffer_schema.rs
+++ b/src/diagram/buffer_schema.rs
@@ -328,10 +328,10 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        diagram::testing::DiagramTestFixture, Accessor, AnyBufferKey, AnyBufferWorldAccess,
-        BufferAccess, BufferAccessMut, BufferKey, BufferWorldAccess, Diagram, DiagramErrorCode,
-        IntoBlockingCallback, JsonBufferKey, JsonBufferWorldAccess, JsonMessage, Node,
-        NodeBuilderOptions,
+        Accessor, AnyBufferKey, AnyBufferWorldAccess, BufferAccess, BufferAccessMut, BufferKey,
+        BufferWorldAccess, Diagram, DiagramErrorCode, IntoBlockingCallback, JsonBufferKey,
+        JsonBufferWorldAccess, JsonMessage, Node, NodeBuilderOptions,
+        diagram::testing::DiagramTestFixture,
     };
 
     /// create a new [`DiagramTestFixture`] with some extra builders.

--- a/src/diagram/fork_clone_schema.rs
+++ b/src/diagram/fork_clone_schema.rs
@@ -21,9 +21,9 @@ use serde::{Deserialize, Serialize};
 use crate::{Builder, CloneFromBuffer, ForkCloneOutput};
 
 use super::{
-    supported::*, BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode,
-    DynInputSlot, DynOutput, MessageOperation, NextOperation, OperationName, TraceInfo,
-    TraceSettings, TypeInfo,
+    BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode, DynInputSlot, DynOutput,
+    MessageOperation, NextOperation, OperationName, TraceInfo, TraceSettings, TypeInfo,
+    supported::*,
 };
 
 /// If the request is cloneable, clone it into multiple responses that can
@@ -182,7 +182,7 @@ mod tests {
     use serde_json::json;
     use test_log::test;
 
-    use crate::{diagram::testing::DiagramTestFixture, Diagram, JsonMessage};
+    use crate::{Diagram, JsonMessage, diagram::testing::DiagramTestFixture};
 
     use super::*;
 

--- a/src/diagram/fork_result_schema.rs
+++ b/src/diagram/fork_result_schema.rs
@@ -19,9 +19,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    supported::*, BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode,
-    DynInputSlot, DynOutput, MessageRegistration, MessageRegistry, NextOperation, OperationName,
-    RegisterClone, SerializeMessage, TraceInfo, TraceSettings, TypeInfo,
+    BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode, DynInputSlot, DynOutput,
+    MessageRegistration, MessageRegistry, NextOperation, OperationName, RegisterClone,
+    SerializeMessage, TraceInfo, TraceSettings, TypeInfo, supported::*,
 };
 
 pub struct DynForkResult {
@@ -140,7 +140,7 @@ mod tests {
     use test_log::test;
 
     use crate::{
-        diagram::testing::DiagramTestFixture, Builder, Diagram, JsonMessage, NodeBuilderOptions,
+        Builder, Diagram, JsonMessage, NodeBuilderOptions, diagram::testing::DiagramTestFixture,
     };
 
     #[test]

--- a/src/diagram/generate_schema.rs
+++ b/src/diagram/generate_schema.rs
@@ -38,7 +38,9 @@ mod diagram {
             if cur_schema_json.len() != new_schema_json.len()
                 || zip(cur_schema_json, new_schema_json).any(|(a, b)| a != b)
             {
-                return Err(String::from("There are changes in the json schema, please run `cargo run -F=diagram generate_schema` to regenerate it"));
+                return Err(String::from(
+                    "There are changes in the json schema, please run `cargo run -F=diagram generate_schema` to regenerate it",
+                ));
             }
             Ok(())
         }
@@ -53,7 +55,9 @@ mod diagram {
             if cur_schema_json.len() != new_schema_json.len()
                 || zip(cur_schema_json, new_schema_json).any(|(a, b)| a != b)
             {
-                return Err(String::from("There are changes in the json schema, please run `cargo run -F=diagram generate_schema` to regenerate it"));
+                return Err(String::from(
+                    "There are changes in the json schema, please run `cargo run -F=diagram generate_schema` to regenerate it",
+                ));
             }
             Ok(())
         }

--- a/src/diagram/grpc.rs
+++ b/src/diagram/grpc.rs
@@ -32,7 +32,7 @@ use anyhow::anyhow;
 
 use http::uri::PathAndQuery;
 
-use futures::{stream::once, FutureExt, Stream as FutureStream};
+use futures::{FutureExt, Stream as FutureStream, stream::once};
 use futures_lite::future::race;
 
 use prost::Message;
@@ -40,11 +40,11 @@ use prost_reflect::{
     DescriptorPool, DynamicMessage, MessageDescriptor, MethodDescriptor, SerializeOptions,
 };
 use tonic::{
+    Code, Request, Status,
     client::Grpc as Client,
     codec::{Codec, DecodeBuf, Decoder, EncodeBuf, Encoder},
     codegen::tokio_stream::wrappers::UnboundedReceiverStream,
     transport::Channel,
-    Code, Request, Status,
 };
 
 use schemars::JsonSchema;
@@ -52,7 +52,7 @@ use serde::{Deserialize, Serialize};
 
 use tokio::{
     runtime::Runtime,
-    sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender},
+    sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     task::JoinHandle,
 };
 
@@ -483,19 +483,19 @@ mod tests {
     use futures::channel::oneshot::{self, Sender as OneShotSender};
     use prost_reflect::Kind;
     use protos::{
+        FibonacciReply, FibonacciRequest, NavigationGoal, NavigationUpdate,
         fibonacci_server::{Fibonacci, FibonacciServer},
         navigation_server::{Navigation, NavigationServer},
-        FibonacciReply, FibonacciRequest, NavigationGoal, NavigationUpdate,
     };
     use serde_json::json;
     use std::sync::Arc;
     use tokio::{
         runtime::Runtime,
-        sync::mpsc::{error::TryRecvError, unbounded_channel, UnboundedReceiver, UnboundedSender},
+        sync::mpsc::{UnboundedReceiver, UnboundedSender, error::TryRecvError, unbounded_channel},
     };
     use tonic::{
-        codegen::tokio_stream::wrappers::UnboundedReceiverStream, transport::Server, Request,
-        Response, Status, Streaming,
+        Request, Response, Status, Streaming,
+        codegen::tokio_stream::wrappers::UnboundedReceiverStream, transport::Server,
     };
 
     #[test]

--- a/src/diagram/join_schema.rs
+++ b/src/diagram/join_schema.rs
@@ -22,7 +22,7 @@ use super::{
     BufferSelection, BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode,
     JsonMessage, NextOperation, OperationName,
 };
-use crate::{default_as_false, is_default, is_false, BufferIdentifier, TraceSettings};
+use crate::{BufferIdentifier, TraceSettings, default_as_false, is_default, is_false};
 
 /// Wait for exactly one item to be available in each buffer listed in
 /// `buffers`, then join each of those items into a single output message
@@ -156,8 +156,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        diagram::testing::DiagramTestFixture, Diagram, DiagramElementRegistry, DiagramErrorCode,
-        NodeBuilderOptions,
+        Diagram, DiagramElementRegistry, DiagramErrorCode, NodeBuilderOptions,
+        diagram::testing::DiagramTestFixture,
     };
 
     fn foo(_: serde_json::Value) -> String {

--- a/src/diagram/node_schema.rs
+++ b/src/diagram/node_schema.rs
@@ -20,8 +20,8 @@ use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, sync::Arc};
 
 use super::{
-    is_default, BuildDiagramOperation, BuildStatus, BuilderId, DiagramContext, DiagramErrorCode,
-    JsonMessage, MissingStream, NextOperation, OperationName, TraceInfo, TraceSettings,
+    BuildDiagramOperation, BuildStatus, BuilderId, DiagramContext, DiagramErrorCode, JsonMessage,
+    MissingStream, NextOperation, OperationName, TraceInfo, TraceSettings, is_default,
 };
 
 /// Create an operation that that takes an input message and produces an

--- a/src/diagram/operation_ref.rs
+++ b/src/diagram/operation_ref.rs
@@ -21,11 +21,11 @@ use std::{borrow::Cow, sync::Arc};
 
 use super::{BuiltinTarget, NamespacedOperation, NextOperation, OperationName};
 
-use smallvec::{smallvec, SmallVec};
+use smallvec::{SmallVec, smallvec};
 
 use serde::{Deserialize, Serialize};
 
-use schemars::{json_schema, JsonSchema};
+use schemars::{JsonSchema, json_schema};
 
 /// This enum allows every operation within a workflow to have a unique key,
 /// even if it is nested inside other operations.

--- a/src/diagram/registration.rs
+++ b/src/diagram/registration.rs
@@ -16,7 +16,7 @@
 */
 
 use std::{
-    any::{type_name, Any},
+    any::{Any, type_name},
     borrow::{Borrow, Cow},
     cell::RefCell,
     collections::{HashMap, HashSet},
@@ -40,17 +40,17 @@ use crate::{
 #[cfg(feature = "trace")]
 use crate::Trace;
 
-use schemars::{generate::SchemaSettings, json_schema, JsonSchema, Schema, SchemaGenerator};
-use serde::{de::DeserializeOwned, ser::SerializeMap, Deserialize, Serialize};
+use schemars::{JsonSchema, Schema, SchemaGenerator, generate::SchemaSettings, json_schema};
+use serde::{Deserialize, Serialize, de::DeserializeOwned, ser::SerializeMap};
 use serde_json::json;
 
 use super::{
+    BuilderId, DeserializeMessage, DiagramErrorCode, DynForkClone, DynForkResult, DynSplit,
+    DynType, JsonRegistration, RegisterJson, RegisterSplit, Section, SectionMetadata,
+    SectionMetadataProvider, SerializeMessage, SplitSchema, TransformError, TypeInfo,
     buffer_schema::BufferAccessRequest, fork_clone_schema::RegisterClone,
     fork_result_schema::RegisterForkResult, register_json, supported::*,
-    unzip_schema::PerformUnzip, BuilderId, DeserializeMessage, DiagramErrorCode, DynForkClone,
-    DynForkResult, DynSplit, DynType, JsonRegistration, RegisterJson, RegisterSplit, Section,
-    SectionMetadata, SectionMetadataProvider, SerializeMessage, SplitSchema, TransformError,
-    TypeInfo,
+    unzip_schema::PerformUnzip,
 };
 
 #[derive(Serialize, JsonSchema)]
@@ -202,8 +202,8 @@ impl<'a, DeserializeImpl, SerializeImpl, Cloneable>
         mut self,
         options: NodeBuilderOptions,
         mut f: impl FnMut(&mut Builder, Config) -> Result<Node<Request, Response, Streams>, Anyhow>
-            + Send
-            + 'static,
+        + Send
+        + 'static,
     ) -> NodeRegistrationBuilder<'a, Request, Response, Streams>
     where
         Config: JsonSchema + DeserializeOwned,
@@ -1467,8 +1467,8 @@ impl DiagramElementRegistry {
         &mut self,
         options: NodeBuilderOptions,
         builder: impl FnMut(&mut Builder, Config) -> Result<Node<Request, Response, Streams>, Anyhow>
-            + Send
-            + 'static,
+        + Send
+        + 'static,
     ) -> NodeRegistrationBuilder<'_, Request, Response, Streams>
     where
         Config: JsonSchema + DeserializeOwned,
@@ -1527,8 +1527,8 @@ impl DiagramElementRegistry {
         &mut self,
         options: SectionBuilderOptions,
         mut section_builder: impl FnMut(&mut Builder, Config) -> Result<SectionT, Anyhow>
-            + Send
-            + 'static,
+        + Send
+        + 'static,
     ) where
         SectionT: Section + SectionMetadataProvider + 'static,
         Config: DeserializeOwned + JsonSchema,
@@ -1903,12 +1903,14 @@ mod tests {
                 move |builder: &mut Builder, _config: ()| builder.create_map_block(vec_resp),
             )
             .with_split();
-        assert!(registry
-            .messages
-            .get::<Vec<i64>>()
-            .unwrap()
-            .operations
-            .splittable());
+        assert!(
+            registry
+                .messages
+                .get::<Vec<i64>>()
+                .unwrap()
+                .operations
+                .splittable()
+        );
 
         let map_resp = |_: ()| -> HashMap<String, i64> { HashMap::new() };
         registry
@@ -1917,12 +1919,14 @@ mod tests {
                 move |builder: &mut Builder, _config: ()| builder.create_map_block(map_resp),
             )
             .with_split();
-        assert!(registry
-            .messages
-            .get::<HashMap<String, i64>>()
-            .unwrap()
-            .operations
-            .splittable());
+        assert!(
+            registry
+                .messages
+                .get::<HashMap<String, i64>>()
+                .unwrap()
+                .operations
+                .splittable()
+        );
 
         registry.register_node_builder(
             NodeBuilderOptions::new("not_splittable").with_default_display_text("Test Name"),
@@ -1930,12 +1934,14 @@ mod tests {
         );
         // even though we didn't register with `with_split`, it is still splittable because we
         // previously registered another splittable node with the same response type.
-        assert!(registry
-            .messages
-            .get::<HashMap<String, i64>>()
-            .unwrap()
-            .operations
-            .splittable());
+        assert!(
+            registry
+                .messages
+                .get::<HashMap<String, i64>>()
+                .unwrap()
+                .operations
+                .splittable()
+        );
     }
 
     #[test]
@@ -1998,9 +2004,11 @@ mod tests {
                 },
             )
             .with_deserialize_request();
-        assert!(registry
-            .get_node_registration("opaque_response_map")
-            .is_ok());
+        assert!(
+            registry
+                .get_node_registration("opaque_response_map")
+                .is_ok()
+        );
         let req_ops = &registry.messages.get::<()>().unwrap().operations;
         let resp_ops = &registry
             .messages
@@ -2023,9 +2031,11 @@ mod tests {
                     builder.create_map_block(opaque_req_resp_map)
                 },
             );
-        assert!(registry
-            .get_node_registration("opaque_req_resp_map")
-            .is_ok());
+        assert!(
+            registry
+                .get_node_registration("opaque_req_resp_map")
+                .is_ok()
+        );
         let req_ops = &registry
             .messages
             .get::<NonSerializableRequest>()

--- a/src/diagram/scope_schema.rs
+++ b/src/diagram/scope_schema.rs
@@ -26,10 +26,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    standard_input_connection, BuildDiagramOperation, BuildStatus, ConnectIntoTarget,
-    DiagramContext, DiagramErrorCode, DynOutput, IncrementalScopeBuilder, IncrementalScopeRequest,
-    IncrementalScopeResponse, InferMessageType, NamespaceList, NextOperation, OperationName,
-    OperationRef, Operations, ScopeSettings, StreamOutRef, TraceSettings,
+    BuildDiagramOperation, BuildStatus, ConnectIntoTarget, DiagramContext, DiagramErrorCode,
+    DynOutput, IncrementalScopeBuilder, IncrementalScopeRequest, IncrementalScopeResponse,
+    InferMessageType, NamespaceList, NextOperation, OperationName, OperationRef, Operations,
+    ScopeSettings, StreamOutRef, TraceSettings, standard_input_connection,
 };
 
 /// Create a scope which will function like its own encapsulated workflow

--- a/src/diagram/section_schema.rs
+++ b/src/diagram/section_schema.rs
@@ -447,10 +447,10 @@ mod tests {
     use serde_json::json;
 
     use crate::{
-        diagram::{testing::*, DiagramErrorCode, SectionError},
+        SectionBuilderOptions, TypeInfo,
+        diagram::{DiagramErrorCode, SectionError, testing::*},
         prelude::*,
         testing::*,
-        SectionBuilderOptions, TypeInfo,
     };
 
     #[derive(Section)]

--- a/src/diagram/serialization.rs
+++ b/src/diagram/serialization.rs
@@ -17,16 +17,16 @@
 
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     sync::Arc,
 };
 
 use schemars::{JsonSchema, Schema, SchemaGenerator};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 use super::{
-    supported::*, DiagramContext, DiagramErrorCode, DynForkResult, DynInputSlot, DynOutput,
-    JsonMessage, MessageRegistration, MessageRegistry, TypeInfo, TypeMismatch,
+    DiagramContext, DiagramErrorCode, DynForkResult, DynInputSlot, DynOutput, JsonMessage,
+    MessageRegistration, MessageRegistry, TypeInfo, TypeMismatch, supported::*,
 };
 use crate::JsonBuffer;
 
@@ -37,7 +37,7 @@ pub trait DynType {
     /// Returns the type name of the request. Note that the type name must be unique.
     fn type_name() -> Cow<'static, str>;
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema;
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema;
 }
 
 impl<T> DynType for T
@@ -48,8 +48,8 @@ where
         <T>::schema_name()
     }
 
-    fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        gen.subschema_for::<T>()
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        generator.subschema_for::<T>()
     }
 }
 

--- a/src/diagram/split_schema.rs
+++ b/src/diagram/split_schema.rs
@@ -22,14 +22,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{
-    is_default, Builder, ForRemaining, FromSequential, FromSpecific, ListSplitKey, MapSplitKey,
-    OperationResult, SplitDispatcher, Splittable,
+    Builder, ForRemaining, FromSequential, FromSpecific, ListSplitKey, MapSplitKey,
+    OperationResult, SplitDispatcher, Splittable, is_default,
 };
 
 use super::{
-    supported::*, BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode,
-    DynInputSlot, DynOutput, MessageRegistration, MessageRegistry, NextOperation, OperationName,
-    RegisterClone, SerializeMessage, TraceInfo, TraceSettings, TypeInfo,
+    BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode, DynInputSlot, DynOutput,
+    MessageRegistration, MessageRegistry, NextOperation, OperationName, RegisterClone,
+    SerializeMessage, TraceInfo, TraceSettings, TypeInfo, supported::*,
 };
 
 /// If the input message is a list-like or map-like object, split it into

--- a/src/diagram/testing.rs
+++ b/src/diagram/testing.rs
@@ -2,11 +2,11 @@ use std::error::Error;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Number, Value};
+use serde_json::{Number, Value, json};
 
 use crate::{
-    testing::TestingContext, Builder, ConfigExample, JsonMessage, RequestExt,
-    RunCommandsOnWorldExt, Service, StreamPack,
+    Builder, ConfigExample, JsonMessage, RequestExt, RunCommandsOnWorldExt, Service, StreamPack,
+    testing::TestingContext,
 };
 
 pub use crate::testing::FlushConditions;

--- a/src/diagram/transform_schema.rs
+++ b/src/diagram/transform_schema.rs
@@ -149,7 +149,7 @@ mod tests {
     use serde_json::json;
     use test_log::test;
 
-    use crate::{diagram::testing::DiagramTestFixture, Diagram, JsonMessage};
+    use crate::{Diagram, JsonMessage, diagram::testing::DiagramTestFixture};
 
     #[test]
     fn test_transform_node_response() {

--- a/src/diagram/unzip_schema.rs
+++ b/src/diagram/unzip_schema.rs
@@ -22,9 +22,9 @@ use variadics_please::all_tuples_with_size;
 use crate::Builder;
 
 use super::{
-    supported::*, BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode,
-    DynInputSlot, DynOutput, MessageRegistry, NextOperation, OperationName, RegisterClone,
-    SerializeMessage, TraceInfo, TraceSettings, TypeInfo,
+    BuildDiagramOperation, BuildStatus, DiagramContext, DiagramErrorCode, DynInputSlot, DynOutput,
+    MessageRegistry, NextOperation, OperationName, RegisterClone, SerializeMessage, TraceInfo,
+    TraceSettings, TypeInfo, supported::*,
 };
 
 /// If the input message is a tuple of (T1, T2, T3, ...), unzip it into
@@ -191,7 +191,7 @@ mod tests {
     use serde_json::json;
     use test_log::test;
 
-    use crate::{diagram::testing::DiagramTestFixture, Diagram, DiagramErrorCode, JsonMessage};
+    use crate::{Diagram, DiagramErrorCode, JsonMessage, diagram::testing::DiagramTestFixture};
 
     #[test]
     fn test_unzip_not_unzippable() {

--- a/src/diagram/workflow_builder.rs
+++ b/src/diagram/workflow_builder.rs
@@ -17,13 +17,13 @@
 
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
     sync::Arc,
 };
 
 use crate::{
-    dyn_node::DynStreamInputPack, AnyBuffer, BufferIdentifier, BufferMap, Builder,
-    BuilderScopeContext, JsonMessage, MessageTypeHint, MessageTypeHintMap, Scope, StreamPack,
+    AnyBuffer, BufferIdentifier, BufferMap, Builder, BuilderScopeContext, JsonMessage,
+    MessageTypeHint, MessageTypeHintMap, Scope, StreamPack, dyn_node::DynStreamInputPack,
 };
 
 #[cfg(feature = "trace")]
@@ -1257,9 +1257,9 @@ impl ConnectIntoTarget for RedirectConnection {
             // This DynOutput has been redirected by this connector before, so
             // we have a circular connection, making it impossible for the
             // output to ever really be connected to anything.
-            return Err(DiagramErrorCode::CircularRedirect(vec![self
-                .redirect_to
-                .clone()]));
+            return Err(DiagramErrorCode::CircularRedirect(vec![
+                self.redirect_to.clone(),
+            ]));
         }
         Ok(())
     }

--- a/src/diagram/zenoh.rs
+++ b/src/diagram/zenoh.rs
@@ -19,10 +19,10 @@ use super::*;
 use crate::{prelude::*, utils::*};
 
 use ::zenoh::{
+    Session,
     bytes::{Encoding, ZBytes},
     qos::{CongestionControl, Priority},
     sample::{Locality, Sample},
-    Session,
 };
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
@@ -31,7 +31,7 @@ use bevy_ecs::{
 };
 use futures::future::Shared;
 use prost_reflect::{
-    prost::Message, DescriptorPool, DynamicMessage, MessageDescriptor, SerializeOptions,
+    DescriptorPool, DynamicMessage, MessageDescriptor, SerializeOptions, prost::Message,
 };
 use std::{error::Error, future::Future, sync::Mutex};
 use thiserror::Error as ThisError;

--- a/src/diagram/zenoh/register_zenoh_publisher.rs
+++ b/src/diagram/zenoh/register_zenoh_publisher.rs
@@ -21,7 +21,7 @@ use bevy_ecs::prelude::{In, Res};
 use futures::channel::oneshot::{self, Receiver as OneShotReceiver, Sender as OneShotSender};
 use std::time::Duration;
 use thiserror::Error as ThisError;
-use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
+use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 use zenoh_ext::{AdvancedPublisherBuilderExt, CacheConfig, MissDetectionConfig, RepliesConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq)]

--- a/src/disposal.rs
+++ b/src/disposal.rs
@@ -33,8 +33,8 @@ use smallvec::SmallVec;
 use thiserror::Error as ThisError;
 
 use crate::{
-    operation::ScopeStorage, Cancel, Cancellation, DisposalFailure, OperationResult,
-    OperationRoster, OrBroken, SeriesMarker, UnhandledErrors, UnusedTarget,
+    Cancel, Cancellation, DisposalFailure, OperationResult, OperationRoster, OrBroken,
+    SeriesMarker, UnhandledErrors, UnusedTarget, operation::ScopeStorage,
 };
 
 #[derive(ThisError, Debug, Clone)]

--- a/src/flush.rs
+++ b/src/flush.rs
@@ -31,11 +31,11 @@ use backtrace::Backtrace;
 use std::sync::Arc;
 
 use crate::{
-    awaken_task, dispose_for_despawned_service, execute_operation, AddExecution, ChannelQueue,
-    Detached, DisposalNotice, Finished, FlushWarning, MiscellaneousFailure, OperationError,
-    OperationRequest, OperationRoster, SeriesLifecycleChannel, ServiceHook, ServiceLifecycle,
-    ServiceLifecycleChannel, UnhandledErrors, UnusedTarget, UnusedTargetDrop,
-    ValidateScopeReachability, ValidationRequest, WakeQueue,
+    AddExecution, ChannelQueue, Detached, DisposalNotice, Finished, FlushWarning,
+    MiscellaneousFailure, OperationError, OperationRequest, OperationRoster,
+    SeriesLifecycleChannel, ServiceHook, ServiceLifecycle, ServiceLifecycleChannel,
+    UnhandledErrors, UnusedTarget, UnusedTargetDrop, ValidateScopeReachability, ValidationRequest,
+    WakeQueue, awaken_task, dispose_for_despawned_service, execute_operation,
 };
 
 #[cfg(feature = "single_threaded_async")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -391,6 +391,10 @@ impl Plugin for CrossflowExecutorApp {
 
 pub mod prelude {
     pub use crate::{
+        AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
+        BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
+        BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
+        CrossflowExecutorApp, CrossflowPlugin,
         buffer::{
             Accessible, Accessor, AnyBuffer, AnyBufferKey, AnyBufferMut, AnyBufferWorldAccess,
             AnyMessageBox, AsAnyBuffer, Buffer, BufferAccess, BufferAccessMut, BufferGateAccess,
@@ -410,17 +414,13 @@ pub mod prelude {
         request::{RequestExt, RunCommandsOnWorldExt},
         series::{Recipient, Series},
         service::{
-            traits::*, AddContinuousServicesExt, AddServicesExt, AsDeliveryInstructions,
-            DeliveryInstructions, DeliveryLabel, DeliveryLabelId, IntoAsyncService,
-            IntoBlockingService, Service, ServiceDiscovery, ServiceInstructions, SpawnServicesExt,
+            AddContinuousServicesExt, AddServicesExt, AsDeliveryInstructions, DeliveryInstructions,
+            DeliveryLabel, DeliveryLabelId, IntoAsyncService, IntoBlockingService, Service,
+            ServiceDiscovery, ServiceInstructions, SpawnServicesExt, traits::*,
         },
         stream::{DynamicallyNamedStream, NamedValue, Stream, StreamFilter, StreamOf, StreamPack},
         trim::{TrimBranch, TrimPoint},
         workflow::{DeliverySettings, Scope, ScopeSettings, SpawnWorkflowExt, WorkflowSettings},
-        AsyncCallback, AsyncCallbackInput, AsyncMap, AsyncService, AsyncServiceInput,
-        BlockingCallback, BlockingCallbackInput, BlockingMap, BlockingService,
-        BlockingServiceInput, ContinuousQuery, ContinuousService, ContinuousServiceInput,
-        CrossflowExecutorApp, CrossflowPlugin,
     };
 
     pub use bevy_ecs::prelude::{In, World};

--- a/src/node/dyn_node.rs
+++ b/src/node/dyn_node.rs
@@ -19,12 +19,12 @@ use bevy_ecs::prelude::Entity;
 use std::{
     any::Any,
     borrow::Cow,
-    collections::{hash_map::Keys as HashMapKeys, HashMap},
+    collections::{HashMap, hash_map::Keys as HashMapKeys},
 };
 use thiserror::Error as ThisError;
 
 use crate::{
-    type_info::TypeInfo, AnyBuffer, Builder, Connect, InputSlot, Node, Output, StreamPack,
+    AnyBuffer, Builder, Connect, InputSlot, Node, Output, StreamPack, type_info::TypeInfo,
 };
 
 /// A type erased [`Node`]

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -16,8 +16,8 @@
 */
 
 use crate::{
-    try_emit_broken, Broken, Cancel, DeliveryLabelId, InspectInput, SetupFailure, StreamTargetMap,
-    UnhandledErrors,
+    Broken, Cancel, DeliveryLabelId, InspectInput, SetupFailure, StreamTargetMap, UnhandledErrors,
+    try_emit_broken,
 };
 
 use bevy_derive::Deref;
@@ -28,7 +28,7 @@ use bevy_ecs::{
 
 use backtrace::Backtrace;
 
-use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque, hash_map::Entry};
 
 use smallvec::SmallVec;
 

--- a/src/operation/collect.rs
+++ b/src/operation/collect.rs
@@ -22,10 +22,10 @@ use std::collections::HashMap;
 use smallvec::SmallVec;
 
 use crate::{
-    emit_disposal, is_downstream_of, Disposal, DisposalListener, DisposalUpdate, Input,
-    InputBundle, ManageInput, Operation, OperationCleanup, OperationReachability, OperationRequest,
-    OperationResult, OperationRoster, OperationSetup, OrBroken, ReachabilityResult,
-    SingleInputStorage, SingleTargetStorage,
+    Disposal, DisposalListener, DisposalUpdate, Input, InputBundle, ManageInput, Operation,
+    OperationCleanup, OperationReachability, OperationRequest, OperationResult, OperationRoster,
+    OperationSetup, OrBroken, ReachabilityResult, SingleInputStorage, SingleTargetStorage,
+    emit_disposal, is_downstream_of,
 };
 
 pub(crate) struct Collect<T, const N: usize> {

--- a/src/operation/injection.rs
+++ b/src/operation/injection.rs
@@ -16,12 +16,12 @@
 */
 
 use crate::{
-    dispatch_service, ActiveTasksStorage, AddExecution, Cleanup, CleanupContents,
-    DisposeForUnavailableService, Executable, FinalizeCleanup, FinalizeCleanupRequest, Input,
-    InputBundle, ManageDisposal, ManageInput, OperateService, Operation, OperationCleanup,
-    OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
-    ProviderStorage, ReachabilityResult, ScopeStorage, ServiceInstructions, ServiceRequest,
-    SingleInputStorage, SingleTargetStorage, StreamPack, StreamTargetMap,
+    ActiveTasksStorage, AddExecution, Cleanup, CleanupContents, DisposeForUnavailableService,
+    Executable, FinalizeCleanup, FinalizeCleanupRequest, Input, InputBundle, ManageDisposal,
+    ManageInput, OperateService, Operation, OperationCleanup, OperationReachability,
+    OperationRequest, OperationResult, OperationSetup, OrBroken, ProviderStorage,
+    ReachabilityResult, ScopeStorage, ServiceInstructions, ServiceRequest, SingleInputStorage,
+    SingleTargetStorage, StreamPack, StreamTargetMap, dispatch_service,
 };
 
 use bevy_ecs::prelude::{Command, Component, Entity};

--- a/src/operation/listen.rs
+++ b/src/operation/listen.rs
@@ -18,10 +18,10 @@
 use bevy_ecs::prelude::Entity;
 
 use crate::{
-    buffer_key_usage, get_access_keys, Accessing, BufferAccessStorage, BufferKeyUsage,
-    FunnelInputStorage, Input, InputBundle, ManageInput, Operation, OperationCleanup,
-    OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
-    ReachabilityResult, SingleInputStorage, SingleTargetStorage,
+    Accessing, BufferAccessStorage, BufferKeyUsage, FunnelInputStorage, Input, InputBundle,
+    ManageInput, Operation, OperationCleanup, OperationReachability, OperationRequest,
+    OperationResult, OperationSetup, OrBroken, ReachabilityResult, SingleInputStorage,
+    SingleTargetStorage, buffer_key_usage, get_access_keys,
 };
 
 pub(crate) struct Listen<B> {

--- a/src/operation/operate_buffer_access.rs
+++ b/src/operation/operate_buffer_access.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::{Component, Entity, World};
 
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
     sync::Arc,
 };
 

--- a/src/operation/operate_callback.rs
+++ b/src/operation/operate_callback.rs
@@ -16,10 +16,10 @@
 */
 
 use crate::{
-    try_emit_broken, ActiveTasksStorage, Callback, CallbackRequest, InputBundle, Operation,
-    OperationCleanup, OperationError, OperationReachability, OperationRequest, OperationResult,
-    OperationSetup, OrBroken, PendingCallbackRequest, ReachabilityResult, SingleInputStorage,
-    SingleTargetStorage, StreamPack,
+    ActiveTasksStorage, Callback, CallbackRequest, InputBundle, Operation, OperationCleanup,
+    OperationError, OperationReachability, OperationRequest, OperationResult, OperationSetup,
+    OrBroken, PendingCallbackRequest, ReachabilityResult, SingleInputStorage, SingleTargetStorage,
+    StreamPack, try_emit_broken,
 };
 
 use bevy_ecs::prelude::{Component, Entity};

--- a/src/operation/operate_gate.rs
+++ b/src/operation/operate_gate.rs
@@ -18,9 +18,9 @@
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    emit_disposal, Buffering, Disposal, Gate, GateRequest, Input, InputBundle, ManageInput,
-    Operation, OperationCleanup, OperationReachability, OperationRequest, OperationResult,
-    OperationSetup, OrBroken, ReachabilityResult, SingleInputStorage, SingleTargetStorage,
+    Buffering, Disposal, Gate, GateRequest, Input, InputBundle, ManageInput, Operation,
+    OperationCleanup, OperationReachability, OperationRequest, OperationResult, OperationSetup,
+    OrBroken, ReachabilityResult, SingleInputStorage, SingleTargetStorage, emit_disposal,
 };
 
 #[derive(Component)]

--- a/src/operation/operate_map.rs
+++ b/src/operation/operate_map.rs
@@ -20,12 +20,13 @@ use bevy_ecs::prelude::{Bundle, Component, Entity};
 use std::future::Future;
 
 use crate::{
+    ActiveTasksStorage, AsyncMap, BlockingMap, CallAsyncMap, CallBlockingMap, Channel,
+    ChannelQueue, Input, InputBundle, ManageDisposal, ManageInput, OperateTask, Operation,
+    OperationCleanup, OperationReachability, OperationRequest, OperationResult, OperationSetup,
+    OrBroken, ReachabilityResult, Sendish, SingleInputStorage, SingleTargetStorage, StreamPack,
+    UnusedStreams,
     async_execution::{spawn_task, task_cancel_sender},
-    make_stream_buffers_from_world, ActiveTasksStorage, AsyncMap, BlockingMap, CallAsyncMap,
-    CallBlockingMap, Channel, ChannelQueue, Input, InputBundle, ManageDisposal, ManageInput,
-    OperateTask, Operation, OperationCleanup, OperationReachability, OperationRequest,
-    OperationResult, OperationSetup, OrBroken, ReachabilityResult, Sendish, SingleInputStorage,
-    SingleTargetStorage, StreamPack, UnusedStreams,
+    make_stream_buffers_from_world,
 };
 
 #[derive(Bundle)]

--- a/src/operation/operate_service.rs
+++ b/src/operation/operate_service.rs
@@ -16,11 +16,11 @@
 */
 
 use crate::{
-    dispatch_service, ActiveContinuousSessions, ActiveTasksStorage, Delivery, DeliveryInstructions,
-    Disposal, DisposalFailure, Input, InputBundle, ManageDisposal, ManageInput, Operation,
-    OperationCleanup, OperationReachability, OperationRequest, OperationResult, OperationRoster,
-    OperationSetup, OrBroken, ReachabilityResult, ServiceInstructions, ServiceRequest,
-    SingleInputStorage, SingleTargetStorage, UnhandledErrors, WorkflowHooks,
+    ActiveContinuousSessions, ActiveTasksStorage, Delivery, DeliveryInstructions, Disposal,
+    DisposalFailure, Input, InputBundle, ManageDisposal, ManageInput, Operation, OperationCleanup,
+    OperationReachability, OperationRequest, OperationResult, OperationRoster, OperationSetup,
+    OrBroken, ReachabilityResult, ServiceInstructions, ServiceRequest, SingleInputStorage,
+    SingleTargetStorage, UnhandledErrors, WorkflowHooks, dispatch_service,
 };
 
 use bevy_ecs::{

--- a/src/operation/operate_task.rs
+++ b/src/operation/operate_task.rs
@@ -22,20 +22,21 @@ use bevy_ecs::{
 
 use std::{future::Future, pin::Pin, sync::Arc, task::Context, task::Poll};
 
-use futures::task::{waker_ref, ArcWake};
+use futures::task::{ArcWake, waker_ref};
 
 use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+    UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender, unbounded_channel,
 };
 
 use smallvec::SmallVec;
 
 use crate::{
-    async_execution::{task_cancel_sender, CancelSender, TaskHandle},
-    emit_disposal, AddOperation, Blocker, Broken, ChannelItem, ChannelQueue, Cleanup, Disposal,
-    ManageInput, Operation, OperationCleanup, OperationError, OperationReachability,
-    OperationRequest, OperationResult, OperationRoster, OperationSetup, OrBroken,
-    ReachabilityResult, ScopeStorage, StreamPack, UnhandledErrors,
+    AddOperation, Blocker, Broken, ChannelItem, ChannelQueue, Cleanup, Disposal, ManageInput,
+    Operation, OperationCleanup, OperationError, OperationReachability, OperationRequest,
+    OperationResult, OperationRoster, OperationSetup, OrBroken, ReachabilityResult, ScopeStorage,
+    StreamPack, UnhandledErrors,
+    async_execution::{CancelSender, TaskHandle, task_cancel_sender},
+    emit_disposal,
 };
 
 struct JobWaker {

--- a/src/operation/operate_trim.rs
+++ b/src/operation/operate_trim.rs
@@ -19,14 +19,14 @@ use bevy_ecs::prelude::{Component, Entity, World};
 
 use smallvec::SmallVec;
 
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::collections::{HashMap, HashSet, hash_map::Entry};
 
 use crate::{
-    emit_disposal, immediately_downstream_of, Cancellation, CleanupContents, Disposal,
-    FinalizeCleanup, FinalizeCleanupRequest, Input, InputBundle, ManageCancellation, ManageInput,
-    Operation, OperationCleanup, OperationError, OperationReachability, OperationRequest,
-    OperationResult, OperationSetup, OrBroken, ReachabilityResult, ScopeEntryStorage, ScopeStorage,
-    SingleInputStorage, SingleTargetStorage, TrimBranch, TrimPoint, TrimPolicy,
+    Cancellation, CleanupContents, Disposal, FinalizeCleanup, FinalizeCleanupRequest, Input,
+    InputBundle, ManageCancellation, ManageInput, Operation, OperationCleanup, OperationError,
+    OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
+    ReachabilityResult, ScopeEntryStorage, ScopeStorage, SingleInputStorage, SingleTargetStorage,
+    TrimBranch, TrimPoint, TrimPolicy, emit_disposal, immediately_downstream_of,
 };
 
 pub(crate) struct Trim<T> {

--- a/src/operation/scope.rs
+++ b/src/operation/scope.rs
@@ -16,21 +16,22 @@
 */
 
 use crate::{
-    check_reachability, execute_operation, is_downstream_of, Accessing, AddOperation, Blocker,
-    BufferKeyBuilder, Cancel, Cancellable, Cancellation, Cleanup, CleanupContents, ClearBufferFn,
-    CollectMarker, DisposalListener, DisposalUpdate, FinalizeCleanup, FinalizeCleanupRequest,
-    Input, InputBundle, InspectDisposals, ManageCancellation, ManageInput, NamedTarget, NamedValue,
-    Operation, OperationCancel, OperationCleanup, OperationError, OperationReachability,
-    OperationRequest, OperationResult, OperationRoster, OperationSetup, OrBroken,
-    ReachabilityResult, ScopeSettings, SingleInputStorage, SingleTargetStorage, StreamEffect,
-    StreamRequest, StreamTargetMap, UnhandledErrors, Unreachability, UnusedTarget,
+    Accessing, AddOperation, Blocker, BufferKeyBuilder, Cancel, Cancellable, Cancellation, Cleanup,
+    CleanupContents, ClearBufferFn, CollectMarker, DisposalListener, DisposalUpdate,
+    FinalizeCleanup, FinalizeCleanupRequest, Input, InputBundle, InspectDisposals,
+    ManageCancellation, ManageInput, NamedTarget, NamedValue, Operation, OperationCancel,
+    OperationCleanup, OperationError, OperationReachability, OperationRequest, OperationResult,
+    OperationRoster, OperationSetup, OrBroken, ReachabilityResult, ScopeSettings,
+    SingleInputStorage, SingleTargetStorage, StreamEffect, StreamRequest, StreamTargetMap,
+    UnhandledErrors, Unreachability, UnusedTarget, check_reachability, execute_operation,
+    is_downstream_of,
 };
 
 #[cfg(feature = "diagram")]
 use crate::{
+    Broken, Builder, BuilderScopeContext,
     dyn_node::{DynInputSlot, DynOutput},
     type_info::TypeInfo,
-    Broken, Builder, BuilderScopeContext,
 };
 
 use backtrace::Backtrace;
@@ -48,7 +49,7 @@ use smallvec::SmallVec;
 
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
 };
 
 #[cfg(feature = "diagram")]

--- a/src/operation/spread.rs
+++ b/src/operation/spread.rs
@@ -16,9 +16,9 @@
 */
 
 use crate::{
-    emit_disposal, Disposal, Input, InputBundle, ManageInput, Operation, OperationCleanup,
-    OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
-    ReachabilityResult, SingleInputStorage, SingleTargetStorage,
+    Disposal, Input, InputBundle, ManageInput, Operation, OperationCleanup, OperationReachability,
+    OperationRequest, OperationResult, OperationSetup, OrBroken, ReachabilityResult,
+    SingleInputStorage, SingleTargetStorage, emit_disposal,
 };
 
 use bevy_ecs::prelude::Entity;

--- a/src/promise.rs
+++ b/src/promise.rs
@@ -20,8 +20,8 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
     },
     task::{Context, Poll},
 };

--- a/src/promise/private.rs
+++ b/src/promise/private.rs
@@ -19,8 +19,8 @@ use crate::{Cancellation, CancellationCause, Promise, PromiseState};
 
 use std::{
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc, Condvar, Mutex, MutexGuard, Weak,
+        atomic::{AtomicBool, Ordering},
     },
     task::Waker,
 };

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -171,7 +171,7 @@ mod tests {
     ) {
     }
 
-    fn async_exclusive_system(In(_): In<i32>, _: &mut World) -> impl Future<Output = ()> {
+    fn async_exclusive_system(In(_): In<i32>, _: &mut World) -> impl Future<Output = ()> + use<> {
         async {}
     }
 
@@ -179,14 +179,14 @@ mod tests {
         In(_): In<i32>,
         _: &mut World,
         _: &mut QueryState<&mut TestComponent>,
-    ) -> impl Future<Output = ()> {
+    ) -> impl Future<Output = ()> + use<> {
         async {}
     }
 
     fn async_exclusive_service(
         In(_): AsyncServiceInput<i32>,
         _: &mut World,
-    ) -> impl Future<Output = ()> {
+    ) -> impl Future<Output = ()> + use<> {
         async {}
     }
 
@@ -194,14 +194,14 @@ mod tests {
         In(_): AsyncServiceInput<i32>,
         _: &mut World,
         _: &mut QueryState<&mut TestComponent>,
-    ) -> impl Future<Output = ()> {
+    ) -> impl Future<Output = ()> + use<> {
         async {}
     }
 
     fn async_exclusive_callback(
         In(_): AsyncCallbackInput<i32>,
         _: &mut World,
-    ) -> impl Future<Output = ()> {
+    ) -> impl Future<Output = ()> + use<> {
         async {}
     }
 
@@ -209,7 +209,7 @@ mod tests {
         In(_): AsyncCallbackInput<i32>,
         _: &mut World,
         _: &mut QueryState<&mut TestComponent>,
-    ) -> impl Future<Output = ()> {
+    ) -> impl Future<Output = ()> + use<> {
         async {}
     }
 

--- a/src/re_exports.rs
+++ b/src/re_exports.rs
@@ -20,7 +20,7 @@
 
 pub use bevy_ecs::prelude::{Commands, Entity, With, World};
 
-pub use smallvec::{smallvec, SmallVec};
+pub use smallvec::{SmallVec, smallvec};
 
 pub use std::{clone::Clone, marker::Copy};
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -24,8 +24,8 @@ use bevy_ecs::{
 use std::future::Future;
 
 use crate::{
-    cancel_execution, Cancellable, Detached, InputCommand, IntoAsyncMap, IntoBlockingMapOnce,
-    ProvideOnce, Series, SeriesMarker, SessionStatus, StreamPack, UnusedTarget,
+    Cancellable, Detached, InputCommand, IntoAsyncMap, IntoBlockingMapOnce, ProvideOnce, Series,
+    SeriesMarker, SessionStatus, StreamPack, UnusedTarget, cancel_execution,
 };
 
 /// Extensions for creating a series of execution by making a request to a provider or

--- a/src/series.rs
+++ b/src/series.rs
@@ -376,7 +376,7 @@ impl<T> Default for Collection<T> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, ContinuousQueueView};
+    use crate::{ContinuousQueueView, prelude::*, testing::*};
     use smallvec::SmallVec;
     use std::{
         sync::{Arc, Mutex},
@@ -410,9 +410,11 @@ mod tests {
         context.run(1);
         assert_eq!(detached_receiver.try_recv().unwrap(), "HELLO");
         assert!(attached_receiver.try_recv().is_err());
-        assert!(context
-            .get_unhandled_errors()
-            .is_some_and(|e| e.unused_targets.len() == 1));
+        assert!(
+            context
+                .get_unhandled_errors()
+                .is_some_and(|e| e.unused_targets.len() == 1)
+        );
     }
 
     #[test]

--- a/src/series/insert.rs
+++ b/src/series/insert.rs
@@ -18,8 +18,8 @@
 use bevy_ecs::prelude::{Bundle, Component, Entity};
 
 use crate::{
-    add_lifecycle_dependency, Executable, Input, InputBundle, ManageInput, OperationRequest,
-    OperationResult, OperationSetup, OrBroken,
+    Executable, Input, InputBundle, ManageInput, OperationRequest, OperationResult, OperationSetup,
+    OrBroken, add_lifecycle_dependency,
 };
 
 #[derive(Component)]

--- a/src/series/internal.rs
+++ b/src/series/internal.rs
@@ -20,7 +20,7 @@ use bevy_ecs::prelude::{ChildOf, Command, Component, Entity, Resource, World};
 use backtrace::Backtrace;
 
 use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+    UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender, unbounded_channel,
 };
 
 use smallvec::SmallVec;

--- a/src/series/map.rs
+++ b/src/series/map.rs
@@ -20,11 +20,12 @@ use bevy_ecs::prelude::{Bundle, Component, Entity};
 use std::future::Future;
 
 use crate::{
+    ActiveTasksStorage, AsyncMap, BlockingMap, CallAsyncMapOnce, CallBlockingMapOnce, Channel,
+    ChannelQueue, Executable, Input, InputBundle, ManageInput, OperateTask, OperationRequest,
+    OperationResult, OperationSetup, OrBroken, Sendish, SingleTargetStorage, StreamPack,
+    UnusedStreams,
     async_execution::{spawn_task, task_cancel_sender},
-    make_stream_buffers_from_world, ActiveTasksStorage, AsyncMap, BlockingMap, CallAsyncMapOnce,
-    CallBlockingMapOnce, Channel, ChannelQueue, Executable, Input, InputBundle, ManageInput,
-    OperateTask, OperationRequest, OperationResult, OperationSetup, OrBroken, Sendish,
-    SingleTargetStorage, StreamPack, UnusedStreams,
+    make_stream_buffers_from_world,
 };
 
 /// The key difference between this and [`crate::OperateBlockingMap`] is that

--- a/src/series/push.rs
+++ b/src/series/push.rs
@@ -20,8 +20,8 @@ use std::borrow::Cow;
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    add_lifecycle_dependency, Collection, Executable, Input, InputBundle, ManageInput, NamedValue,
-    OperationRequest, OperationResult, OperationSetup, OrBroken, Storage,
+    Collection, Executable, Input, InputBundle, ManageInput, NamedValue, OperationRequest,
+    OperationResult, OperationSetup, OrBroken, Storage, add_lifecycle_dependency,
 };
 
 pub(crate) struct Push<T> {

--- a/src/series/store.rs
+++ b/src/series/store.rs
@@ -18,8 +18,8 @@
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    add_lifecycle_dependency, Executable, Input, InputBundle, ManageInput, OperationRequest,
-    OperationResult, OperationSetup, OrBroken, Storage,
+    Executable, Input, InputBundle, ManageInput, OperationRequest, OperationResult, OperationSetup,
+    OrBroken, Storage, add_lifecycle_dependency,
 };
 
 #[derive(Component)]

--- a/src/series/taken.rs
+++ b/src/series/taken.rs
@@ -20,9 +20,9 @@ use bevy_ecs::prelude::Component;
 use tokio::sync::mpsc::UnboundedSender as Sender;
 
 use crate::{
-    promise::private::Sender as PromiseSender, Executable, Input, InputBundle, ManageInput,
-    OnTerminalCancelled, OperationCancel, OperationRequest, OperationResult, OperationSetup,
-    OrBroken, SeriesLifecycleChannel,
+    Executable, Input, InputBundle, ManageInput, OnTerminalCancelled, OperationCancel,
+    OperationRequest, OperationResult, OperationSetup, OrBroken, SeriesLifecycleChannel,
+    promise::private::Sender as PromiseSender,
 };
 
 #[derive(Component)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -791,7 +791,7 @@ impl<Request, Response, Streams> Provider for ServiceInstructions<Request, Respo
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, ServiceMarker};
+    use crate::{ServiceMarker, prelude::*, testing::*};
     use bevy_app::{PostUpdate, PreUpdate, Startup};
     use bevy_ecs::{
         prelude::*,
@@ -903,7 +903,7 @@ mod tests {
     fn sys_async_service(
         In(AsyncService { request, .. }): AsyncServiceInput<String>,
         people: Query<&TestPeople>,
-    ) -> impl Future<Output = u64> {
+    ) -> impl Future<Output = u64> + use<> {
         let mut matching_people = Vec::new();
         for person in &people {
             if person.name == request {

--- a/src/service/async_srv.rs
+++ b/src/service/async_srv.rs
@@ -16,14 +16,14 @@
 */
 
 use crate::{
-    async_execution::{spawn_task, task_cancel_sender},
-    dispose_for_despawned_service, emit_disposal, insert_new_order, pop_next_delivery,
-    service::service_builder::{ParallelChosen, SerialChosen},
     AsyncService, AsyncServiceInput, Blocker, Channel, ChannelQueue, ChooseAsyncServiceDelivery,
     Deliver, Delivery, DeliveryOrder, DeliveryUpdate, Disposal, Input, IntoService, ManageInput,
     OperateTask, OperationError, OperationRequest, OperationResult, OperationRoster, OrBroken,
     Sendish, ServiceBuilder, ServiceBundle, ServiceRequest, ServiceTrait, SingleTargetStorage,
     StopTask, StopTaskFailure, StreamPack, UnhandledErrors,
+    async_execution::{spawn_task, task_cancel_sender},
+    dispose_for_despawned_service, emit_disposal, insert_new_order, pop_next_delivery,
+    service::service_builder::{ParallelChosen, SerialChosen},
 };
 
 use bevy_ecs::{

--- a/src/service/blocking.rs
+++ b/src/service/blocking.rs
@@ -22,10 +22,10 @@ use bevy_ecs::{
 };
 
 use crate::{
-    dispose_for_despawned_service, make_stream_buffers_from_world,
-    service::service_builder::BlockingChosen, BlockingService, BlockingServiceInput, Input,
-    IntoService, ManageDisposal, ManageInput, OperationError, OperationRequest, OrBroken,
-    ServiceBundle, ServiceRequest, ServiceTrait, StreamPack, UnusedStreams,
+    BlockingService, BlockingServiceInput, Input, IntoService, ManageDisposal, ManageInput,
+    OperationError, OperationRequest, OrBroken, ServiceBundle, ServiceRequest, ServiceTrait,
+    StreamPack, UnusedStreams, dispose_for_despawned_service, make_stream_buffers_from_world,
+    service::service_builder::BlockingChosen,
 };
 
 pub struct Blocking<M>(std::marker::PhantomData<fn(M)>);

--- a/src/service/continuous.rs
+++ b/src/service/continuous.rs
@@ -28,13 +28,13 @@ use smallvec::SmallVec;
 use std::collections::HashMap;
 
 use crate::{
-    dispose_for_despawned_service, emit_disposal, insert_new_order, pop_next_delivery, Blocker,
-    Broken, ContinuousService, ContinuousServiceInput, DeferredRoster, Deliver, Delivery,
+    Blocker, Broken, ContinuousService, ContinuousServiceInput, DeferredRoster, Deliver, Delivery,
     DeliveryOrder, DeliveryUpdate, Disposal, Input, IntoContinuousService, IntoServiceBuilder,
     ManageInput, OperationCleanup, OperationError, OperationReachability, OperationRequest,
     OperationResult, OperationRoster, OrBroken, ProviderStorage, ReachabilityResult, ScopeStorage,
     ServiceBuilder, ServiceBundle, ServiceRequest, ServiceTrait, SingleTargetStorage, StreamOf,
-    StreamPack, StreamTargetMap, UnhandledErrors,
+    StreamPack, StreamTargetMap, UnhandledErrors, dispose_for_despawned_service, emit_disposal,
+    insert_new_order, pop_next_delivery,
 };
 
 pub use bevy_ecs::schedule::ScheduleConfigs;

--- a/src/service/discovery.rs
+++ b/src/service/discovery.rs
@@ -122,7 +122,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{prelude::*, testing::*, Require};
+    use crate::{Require, prelude::*, testing::*};
     use bevy_ecs::prelude::With;
 
     type NumberStreams = (StreamOf<u32>, StreamOf<i32>, StreamOf<f32>);

--- a/src/service/internal.rs
+++ b/src/service/internal.rs
@@ -18,7 +18,7 @@
 use bevy_ecs::prelude::{Bundle, Component, Entity, Resource, World};
 
 use tokio::sync::mpsc::{
-    unbounded_channel, UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender,
+    UnboundedReceiver as TokioReceiver, UnboundedSender as TokioSender, unbounded_channel,
 };
 
 use anyhow::anyhow;
@@ -26,8 +26,8 @@ use anyhow::anyhow;
 use std::{collections::VecDeque, sync::Arc};
 
 use crate::{
-    dispose_for_despawned_service, DeliveryInstructions, MiscellaneousFailure, OperationError,
-    OperationRequest, OperationRoster, PendingOperationRequest, ServiceTrait, UnhandledErrors,
+    DeliveryInstructions, MiscellaneousFailure, OperationError, OperationRequest, OperationRoster,
+    PendingOperationRequest, ServiceTrait, UnhandledErrors, dispose_for_despawned_service,
 };
 
 pub struct ServiceRequest<'a> {

--- a/src/service/service_builder.rs
+++ b/src/service/service_builder.rs
@@ -15,7 +15,7 @@
  *
 */
 
-use crate::{stream::*, Delivery, IntoContinuousService, IntoService, Service};
+use crate::{Delivery, IntoContinuousService, IntoService, Service, stream::*};
 
 use bevy_app::prelude::App;
 use bevy_ecs::{

--- a/src/service/traits.rs
+++ b/src/service/traits.rs
@@ -16,8 +16,8 @@
 */
 
 use crate::{
-    service::service_builder::{ParallelChosen, SerialChosen},
     OperationResult, Service, ServiceBuilder, ServiceRequest,
+    service::service_builder::{ParallelChosen, SerialChosen},
 };
 
 use bevy_app::prelude::App;
@@ -50,7 +50,7 @@ pub trait IntoContinuousService<M> {
     type Streams;
 
     fn into_system_config(self, entity_mut: &mut EntityWorldMut)
-        -> ScheduleConfigs<ScheduleSystem>;
+    -> ScheduleConfigs<ScheduleSystem>;
 }
 
 /// This trait allows service systems to be converted into a builder that

--- a/src/service/workflow.rs
+++ b/src/service/workflow.rs
@@ -16,12 +16,12 @@
 */
 
 use crate::{
-    begin_scope, dispose_for_despawned_service, emit_disposal, insert_new_order, pop_next_delivery,
     Blocker, Cancel, Cancellation, Deliver, Delivery, DeliveryOrder, DeliveryUpdate, Disposal,
     ExitTarget, ExitTargetStorage, Input, ManageInput, OperationCleanup, OperationError,
     OperationReachability, OperationRequest, OperationResult, OperationRoster, OrBroken,
     ParentSession, ProviderStorage, ReachabilityResult, Service, ServiceRequest, ServiceTrait,
-    SessionStatus, SingleTargetStorage, StreamPack,
+    SessionStatus, SingleTargetStorage, StreamPack, begin_scope, dispose_for_despawned_service,
+    emit_disposal, insert_new_order, pop_next_delivery,
 };
 
 use bevy_ecs::prelude::{ChildOf, Component, Entity, World};

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -230,11 +230,13 @@ pub(crate) mod tests {
         let mut recipient = context.command(|commands| commands.request(10, provider).take());
 
         context.run_with_conditions(&mut recipient.response, Duration::from_secs(2));
-        assert!(recipient
-            .response
-            .take()
-            .available()
-            .is_some_and(|v| v == 10));
+        assert!(
+            recipient
+                .response
+                .take()
+                .available()
+                .is_some_and(|v| v == 10)
+        );
 
         let mut stream: Vec<u32> = Vec::new();
         while let Ok(r) = recipient.streams.try_recv() {
@@ -1079,7 +1081,7 @@ pub(crate) mod tests {
 
     fn validate_dynamically_named_streams(
         provider: impl Provider<Request = NamedInputs, Response = (), Streams = TestDynamicNamedStreams>
-            + Clone,
+        + Clone,
         context: &mut TestingContext,
     ) {
         let expected_values_u32 = vec![

--- a/src/stream/anonymous_stream.rs
+++ b/src/stream/anonymous_stream.rs
@@ -20,18 +20,18 @@ use bevy_ecs::{
     system::Command,
 };
 
-use tokio::sync::mpsc::unbounded_channel;
 pub use tokio::sync::mpsc::UnboundedReceiver as Receiver;
+use tokio::sync::mpsc::unbounded_channel;
 
 use std::{rc::Rc, sync::Arc};
 
 use crate::{
-    dyn_node::{DynStreamInputPack, DynStreamOutputPack},
     AddExecution, AddOperation, AnonymousStreamRedirect, Builder, DefaultStreamBufferContainer,
     DeferredRoster, InnerChannel, InputSlot, OperationError, OperationResult, OperationRoster,
     OrBroken, Output, Push, RedirectScopeStream, RedirectWorkflowStream, ReportUnhandled,
     SingleInputStorage, StreamAvailability, StreamBuffer, StreamChannel, StreamEffect, StreamPack,
     StreamRequest, StreamTargetMap, TakenStream, UnusedStreams, UnusedTarget,
+    dyn_node::{DynStreamInputPack, DynStreamOutputPack},
 };
 
 /// A wrapper to turn any [`StreamEffect`] into an anonymous (unnamed) stream.

--- a/src/stream/dynamically_named_stream.rs
+++ b/src/stream/dynamically_named_stream.rs
@@ -21,13 +21,13 @@ use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tokio::sync::mpsc::unbounded_channel;
 
 use crate::{
+    AddExecution, AddOperation, Builder, DefaultStreamBufferContainer, InnerChannel, InputSlot,
+    NamedStreamRedirect, NamedStreamTargets, NamedTarget, NamedValue, OperationResult,
+    OperationRoster, OrBroken, Output, Push, Receiver, RedirectScopeStream, RedirectWorkflowStream,
+    ReportUnhandled, SendNamedStreams, SingleInputStorage, StreamAvailability, StreamEffect,
+    StreamPack, StreamRequest, StreamTargetMap, TakenStream, UnusedStreams, UnusedTarget,
     dyn_node::{DynStreamInputPack, DynStreamOutputPack},
-    send_named_stream, AddExecution, AddOperation, Builder, DefaultStreamBufferContainer,
-    InnerChannel, InputSlot, NamedStreamRedirect, NamedStreamTargets, NamedTarget, NamedValue,
-    OperationResult, OperationRoster, OrBroken, Output, Push, Receiver, RedirectScopeStream,
-    RedirectWorkflowStream, ReportUnhandled, SendNamedStreams, SingleInputStorage,
-    StreamAvailability, StreamEffect, StreamPack, StreamRequest, StreamTargetMap, TakenStream,
-    UnusedStreams, UnusedTarget,
+    send_named_stream,
 };
 
 /// A wrapper to turn any stream type into a named stream. Each item that moves

--- a/src/stream/stream_availability.rs
+++ b/src/stream/stream_availability.rs
@@ -19,7 +19,7 @@ use bevy_ecs::prelude::Component;
 
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap, HashSet},
+    collections::{HashMap, HashSet, hash_map::Entry},
 };
 
 use crate::{MissingStreamsError, NamedValue, TypeInfo};

--- a/src/stream/stream_pack.rs
+++ b/src/stream/stream_pack.rs
@@ -21,9 +21,9 @@ use variadics_please::all_tuples;
 use std::sync::Arc;
 
 use crate::{
-    dyn_node::{DynStreamInputPack, DynStreamOutputPack},
     Builder, InnerChannel, OperationError, OperationResult, OperationRoster, StreamAvailability,
     StreamTargetMap, UnusedStreams,
+    dyn_node::{DynStreamInputPack, DynStreamOutputPack},
 };
 
 /// The `StreamPack` trait defines the interface for a pack of one or more streams.

--- a/src/stream/stream_target_map.rs
+++ b/src/stream/stream_target_map.rs
@@ -20,7 +20,7 @@ use bevy_ecs::prelude::{Commands, Component, Entity, World};
 use std::{
     any::TypeId,
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
+    collections::{HashMap, hash_map::Entry},
 };
 
 use crate::{DuplicateStream, NamedTarget, NamedValue, UnhandledErrors};

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -467,7 +467,7 @@ pub fn say_hello(
 pub fn repeat_service(
     In(input): AsyncServiceInput<RepeatRequest>,
     mut run_count: Query<Option<&mut RunCount>>,
-) -> impl std::future::Future<Output = ()> + 'static + Send + Sync {
+) -> impl std::future::Future<Output = ()> + use<> + 'static + Send + Sync {
     if let Ok(Some(mut count)) = run_count.get_mut(input.provider) {
         count.0 += 1;
     }

--- a/src/type_info.rs
+++ b/src/type_info.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "diagram")]
 use std::borrow::Cow;
 use std::{
-    any::{type_name, Any, TypeId},
+    any::{Any, TypeId, type_name},
     fmt::Display,
     hash::Hash,
 };


### PR DESCRIPTION
This migrates the codebase to Rust edition 2024.

Importantly, there are some syntax changes needed for async services and callbacks to work correctly in edition 2024. By migrating this codebase forward, those syntax changes will be reflected in the code examples of the handbook. This should make it easier for new users to get started with crossflow.