### PR TITLE
Tuple and HashMap accessors

### DIFF
--- a/macros/src/derive_buffer.rs
+++ b/macros/src/derive_buffer.rs
@@ -879,6 +879,9 @@ fn impl_joined(
         quote! {
             impl #impl_generics ::crossflow::Joined for #joined_struct_ident #ty_generics #where_clause {
                 type Buffers = #buffers_struct_ident #ty_generics;
+                fn from_item(item: <Self::Buffers as ::crossflow::Joining>::Item) -> Self {
+                    item
+                }
             }
         }
         .into()

--- a/src/buffer/accessor.rs
+++ b/src/buffer/accessor.rs
@@ -562,7 +562,8 @@ where
 impl<K, A: AccessKey> Accessor for HashMap<K, A>
 where
     K: 'static + Send + Sync + Clone + Eq + Hash,
-    HashMap<K, A::Buffers>: 'static + BufferMapLayout + Accessing<Key = HashMap<K, A>> + Send + Sync,
+    HashMap<K, A::Buffers>:
+        'static + BufferMapLayout + Accessing<Key = HashMap<K, A>> + Send + Sync,
 {
     type Buffers = HashMap<K, A::Buffers>;
 
@@ -627,7 +628,7 @@ where
             match key.join(req, world) {
                 Ok(Some(value)) => {
                     fetched.insert(k.clone(), value);
-                },
+                }
                 Ok(None) => {
                     // Note: THis can't happen unless there's a flaw in the
                     // implementation of can_join
@@ -635,7 +636,7 @@ where
                 }
                 Err(err) => {
                     errors.push(err);
-                },
+                }
             }
         }
 
@@ -686,7 +687,7 @@ where
                     // right now. We only need mutability for the tracing to be
                     // performed. After that all access is read-only.
                     world_cell.world_mut()
-                })?
+                })?,
             );
         }
 
@@ -1290,18 +1291,9 @@ mod tests {
         });
 
         let mut values = HashMap::new();
-        values.insert(
-            String::from("alice"),
-            42,
-        );
-        values.insert(
-            String::from("bob"),
-            67,
-        );
-        values.insert(
-            String::from("chris"),
-            88,
-        );
+        values.insert(String::from("alice"), 42);
+        values.insert(String::from("bob"), 67);
+        values.insert(String::from("chris"), 88);
 
         let resolved = context.resolve_request(values.clone(), workflow);
         assert_eq!(resolved, values);

--- a/src/buffer/accessor.rs
+++ b/src/buffer/accessor.rs
@@ -405,7 +405,7 @@ where
             return Err(OverlapError { duplicates });
         }
 
-        return Ok(());
+        Ok(())
     }
 
     fn can_join(&self, world: &World) -> Result<bool, AccessError> {
@@ -527,12 +527,12 @@ where
         let r = {
             let mut params = Vec::new();
             for state in &mut states {
-                let accessor = A::get_param(state, unsafe {
+                let param = A::get_param(state, unsafe {
                     // SAFETY: Same rationale as earlier in this function.
                     world_cell.world_mut()
                 });
 
-                params.push(accessor);
+                params.push(param);
             }
 
             let mut accesses = Vec::new();
@@ -549,6 +549,212 @@ where
         };
 
         for state in &mut states {
+            A::apply_state(state, unsafe {
+                // SAFETY: Same rationale as earlier in this function
+                world_cell.world_mut()
+            });
+        }
+
+        Ok(r)
+    }
+}
+
+impl<K, A: AccessKey> Accessor for HashMap<K, A>
+where
+    K: 'static + Send + Sync + Clone + Eq + Hash,
+    HashMap<K, A::Buffers>: 'static + BufferMapLayout + Accessing<Key = HashMap<K, A>> + Send + Sync,
+{
+    type Buffers = HashMap<K, A::Buffers>;
+
+    async fn wait_for_change(&mut self) {
+        let futures: Vec<_> = self.values_mut().map(|a| a.wait_for_change()).collect();
+        futures.race().await;
+    }
+
+    type Seen = HashMap<K, A::Seen>;
+    fn seen(&mut self, seen: Self::Seen) {
+        for (k, seen) in seen {
+            if let Some(key) = self.get_mut(&k) {
+                key.seen(seen);
+            }
+        }
+    }
+
+    fn make_seen(&self, world: &mut World) -> Self::Seen {
+        let mut seen = HashMap::new();
+        for (k, key) in self {
+            seen.insert(k.clone(), key.make_seen(world));
+        }
+
+        seen
+    }
+
+    fn is_disjoint(&self) -> Result<(), OverlapError> {
+        let mut duplicates = HashMap::new();
+        let mut is_disjoint = true;
+        for key in self.values() {
+            is_disjoint &= key.validate_disjoint(&mut duplicates);
+        }
+
+        if !is_disjoint {
+            duplicates.retain(|_, count| *count > 1);
+            return Err(OverlapError { duplicates });
+        }
+
+        Ok(())
+    }
+
+    fn can_join(&self, world: &World) -> Result<bool, AccessError> {
+        self.is_disjoint()?;
+        for key in self.values() {
+            if !key.can_join(world)? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
+    }
+
+    type Joined = HashMap<K, A::Joined>;
+    fn join(&self, req: RequestId, world: &mut World) -> Result<Option<Self::Joined>, AccessError> {
+        if !self.can_join(world)? {
+            return Ok(None);
+        }
+
+        let mut errors = Vec::new();
+        let mut fetched = HashMap::new();
+        for (k, key) in self {
+            match key.join(req, world) {
+                Ok(Some(value)) => {
+                    fetched.insert(k.clone(), value);
+                },
+                Ok(None) => {
+                    // Note: THis can't happen unless there's a flaw in the
+                    // implementation of can_join
+                    return Ok(None);
+                }
+                Err(err) => {
+                    errors.push(err);
+                },
+            }
+        }
+
+        AccessError::from_list(errors)?;
+        Ok(Some(fetched))
+    }
+
+    /// The values to be distributed will be matched up to a corresponding
+    /// buffer in the Accessor hash map. If there is no buffer in the hash map
+    /// that corresponds to the key of a value that's being distributed, that
+    /// value be will dropped. Or if there is no value whose key corresponding
+    /// to one of the buffers in the hash map, that buffer will receive no value.
+    ///
+    /// Also if the hash map of the Accessor is not disjoint (meaning the same
+    /// buffer appears multiple times) then that buffer may receive multiple values.
+    fn distribute(
+        &self,
+        values: Self::Joined,
+        req: RequestId,
+        world: &mut World,
+    ) -> Result<(), AccessError> {
+        let mut errors = Vec::new();
+        for (k, value) in values {
+            if let Some(buffer) = self.get(&k) {
+                if let Err(err) = buffer.distribute(value, req, world) {
+                    errors.push(err);
+                }
+            }
+        }
+
+        AccessError::from_list(errors)
+    }
+
+    type View<'a> = HashMap<K, A::View<'a>>;
+    fn view<'a>(
+        &self,
+        req: RequestId,
+        world: &'a mut World,
+    ) -> Result<Self::View<'a>, BufferError> {
+        let mut views = HashMap::new();
+        let world_cell = world.as_unsafe_world_cell();
+        for (k, key) in self {
+            views.insert(
+                k.clone(),
+                key.view(req, unsafe {
+                    // SAFETY: We require a &mut World as input to this function,
+                    // so we know that nothing else is interacting with the world
+                    // right now. We only need mutability for the tracing to be
+                    // performed. After that all access is read-only.
+                    world_cell.world_mut()
+                })?
+            );
+        }
+
+        Ok(views)
+    }
+
+    fn view_untraced<'a>(&self, world: &'a World) -> Result<Self::View<'a>, BufferError> {
+        let mut views = HashMap::new();
+        for (k, key) in self {
+            views.insert(k.clone(), key.view_untraced(world)?);
+        }
+
+        Ok(views)
+    }
+
+    type Access<'w, 's, 'a> = HashMap<K, A::Access<'w, 's, 'a>>;
+    fn access<U>(
+        &self,
+        req: RequestId,
+        world: &mut World,
+        f: impl FnOnce(HashMap<K, A::Access<'_, '_, '_>>) -> U,
+    ) -> Result<U, AccessError> {
+        self.is_disjoint()?;
+
+        let mut states = HashMap::new();
+        let world_cell = world.as_unsafe_world_cell();
+        for (k, key) in self {
+            let state = key.get_state(unsafe {
+                // SAFETY: We make sure the accessor is disjoint at the start
+                // of the function. After that there is no overlap in the mutable
+                // world access needed by the system states. Their commands will
+                // be flushed serially at the end of this function.
+                world_cell.world_mut()
+            });
+            states.insert(k.clone(), state);
+        }
+
+        let r = {
+            let mut params = HashMap::new();
+            for (k, state) in &mut states {
+                let param = A::get_param(state, unsafe {
+                    // SAFETY: Same rationale as earlier in this function.
+                    world_cell.world_mut()
+                });
+
+                params.insert(k.clone(), param);
+            }
+
+            let mut accesses = HashMap::new();
+            let mut errors = Vec::new();
+            for (k, param) in &mut params {
+                if let Some(key) = self.get(k) {
+                    match A::get_mut(key, req, param) {
+                        Ok(access) => {
+                            accesses.insert(k.clone(), access);
+                        }
+                        Err(err) => {
+                            errors.push(err.into());
+                        }
+                    }
+                }
+            }
+
+            AccessError::from_list(errors)?;
+            f(accesses)
+        };
+
+        for state in states.values_mut() {
             A::apply_state(state, unsafe {
                 // SAFETY: Same rationale as earlier in this function
                 world_cell.world_mut()
@@ -749,6 +955,7 @@ all_tuples!(impl_accessor_for_tuple, 1, 12, A, a, b, c, d);
 #[cfg(test)]
 mod tests {
     use crate::{prelude::*, testing::*};
+    use std::collections::HashMap;
 
     #[derive(Clone, Accessor)]
     // #[accessor(buffers_struct_name = SameTypeBuffers)]
@@ -1052,6 +1259,52 @@ mod tests {
         assert_eq!(resolved_values.0, values.0);
         assert_eq!(resolved_values.1, values.1);
         assert_eq!(resolved_values.2, values.2);
+    }
+
+    #[test]
+    fn test_access_hashmap_join() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let mut buffers = HashMap::new();
+            buffers.insert(
+                String::from("alice"),
+                builder.create_buffer(Default::default()),
+            );
+            buffers.insert(
+                String::from("bob"),
+                builder.create_buffer(Default::default()),
+            );
+            buffers.insert(
+                String::from("chris"),
+                builder.create_buffer(Default::default()),
+            );
+
+            builder
+                .chain(scope.start)
+                .with_access(buffers.clone())
+                .then(distribute_to_buffers.into_callback())
+                .with_access(buffers.clone())
+                .then(join_from_buffers.into_callback())
+                .connect(scope.terminate);
+        });
+
+        let mut values = HashMap::new();
+        values.insert(
+            String::from("alice"),
+            42,
+        );
+        values.insert(
+            String::from("bob"),
+            67,
+        );
+        values.insert(
+            String::from("chris"),
+            88,
+        );
+
+        let resolved = context.resolve_request(values.clone(), workflow);
+        assert_eq!(resolved, values);
     }
 
     #[cfg(feature = "diagram")]

--- a/src/buffer/accessor.rs
+++ b/src/buffer/accessor.rs
@@ -15,6 +15,8 @@
  *
 */
 
+use variadics_please::all_tuples;
+
 use std::{collections::HashMap, hash::Hash};
 
 use thiserror::Error as ThisError;
@@ -534,11 +536,15 @@ where
             }
 
             let mut accesses = Vec::new();
+            let mut errors = Vec::new();
             for (key, param) in self.iter().zip(params.iter_mut()) {
-                let access = A::get_mut(key, req, param)?;
-                accesses.push(access);
+                match A::get_mut(key, req, param) {
+                    Ok(access) => accesses.push(access),
+                    Err(err) => errors.push(err.into()),
+                }
             }
 
+            AccessError::from_list(errors)?;
             f(accesses)
         };
 
@@ -552,6 +558,193 @@ where
         Ok(r)
     }
 }
+
+macro_rules! impl_accessor_for_tuple {
+    ($(($A:ident, $a:ident, $b:ident, $c:ident, $d:ident)),*) => {
+        #[allow(non_snake_case)]
+        impl<$($A: AccessKey),*> Accessor for ($($A,)*)
+        where
+            ($($A::Buffers,)*): 'static + BufferMapLayout + Accessing<Key = Self> + Send + Sync,
+        {
+            type Buffers = ($($A::Buffers,)*);
+
+            async fn wait_for_change(&mut self) {
+                let ($($A,)*) = self;
+                let ($($a,)*) = ($($A.wait_for_change(),)*);
+                ($($a,)*).race().await;
+            }
+
+            type Seen = ($($A::Seen,)*);
+            fn seen(&mut self, seen: Self::Seen) {
+                let ($($A,)*) = self;
+                let ($($a,)*) = seen;
+                $(
+                    $A.seen($a);
+                )*
+            }
+
+            fn make_seen(&self, world: &mut World) -> Self::Seen {
+                let ($($A,)*) = self;
+                ($(
+                    $A.make_seen(world),
+                )*)
+            }
+
+            fn is_disjoint(&self) -> Result<(), OverlapError> {
+                let mut duplicates = HashMap::new();
+                let mut is_disjoint = true;
+                let ($($A,)*) = self;
+
+                $(
+                    is_disjoint &= $A.validate_disjoint(&mut duplicates);
+                )*
+
+                if !is_disjoint {
+                    duplicates.retain(|_, count| *count > 1);
+                    return Err(OverlapError { duplicates });
+                }
+
+                return Ok(());
+            }
+
+            fn can_join(&self, world: &World) -> Result<bool, AccessError> {
+                self.is_disjoint()?;
+                let ($($A,)*) = self;
+                $(
+                    if !$A.can_join(world)? {
+                        return Ok(false);
+                    }
+                )*
+
+                Ok(true)
+            }
+
+            type Joined = ($($A::Joined,)*);
+            fn join(&self, req: RequestId, world: &mut World) -> Result<Option<Self::Joined>, AccessError> {
+                if !self.can_join(world)? {
+                    return Ok(None);
+                }
+
+                let mut errors = Vec::new();
+                let ($($A,)*) = self;
+
+                let joined = ($(
+                    match $A.join(req, world) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            errors.push(err);
+                            None
+                        }
+                    },
+                )*);
+
+                let ($(Some($a),)*) = joined else {
+                    return AccessError::from_list(errors).map(|_| None);
+                };
+
+                Ok(Some(($($a,)*)))
+            }
+
+            fn distribute(
+                &self,
+                value: Self::Joined,
+                req: RequestId,
+                world: &mut World,
+            ) -> Result<(), AccessError> {
+                let mut errors = Vec::new();
+                let ($($A,)*) = self;
+                let ($($a,)*) = value;
+
+                $(
+                    if let Err(err) = $A.distribute($a, req, world) {
+                        errors.push(err);
+                    }
+                )*
+
+                AccessError::from_list(errors)
+            }
+
+            type View<'a> = ($($A::View<'a>,)*);
+            fn view<'a>(
+                &self,
+                req: RequestId,
+                world: &'a mut World,
+            ) -> Result<Self::View<'a>, BufferError> {
+                let ($($A,)*) = self;
+                let world_cell = world.as_unsafe_world_cell();
+                Ok(($(
+                    $A.view(req, unsafe {
+                        // SAFETY: We require a &mut World as input to this function,
+                        // so we know that nothing else is interacting with the world
+                        // right now. We only need mutability for the tracing to be
+                        // performed. After that all access is read-only.
+                        world_cell.world_mut()
+                    })?,
+                )*))
+            }
+
+            fn view_untraced<'a>(&self, world: &'a World) -> Result<Self::View<'a>, BufferError> {
+                let ($($A,)*) = self;
+                Ok(($(
+                    $A.view_untraced(world)?,
+                )*))
+            }
+
+            type Access<'w, 's, 'a> = ($($A::Access<'w, 's, 'a>,)*);
+            fn access<U>(
+                &self,
+                req: RequestId,
+                world: &mut World,
+                f: impl FnOnce(Self::Access<'_, '_, '_>) -> U,
+            ) -> Result<U, AccessError> {
+                self.is_disjoint()?;
+
+                let world_cell = world.as_unsafe_world_cell();
+                let ($($a,)*) = self;
+                let ($(mut $b,)*) = ($(
+                    $a.get_state(unsafe {
+                        // SAFETY: We make sure the accessor is disjoint at the start
+                        // of the function. After that there is no overlap in the mutable
+                        // world access needed by the system states. Their commands will
+                        // be flushed serially at the end of this function.
+                        world_cell.world_mut()
+                    }),
+                )*);
+
+                let r = {
+                    let ($(mut $c,)*) = ($(
+                        $A::get_param(&mut $b, unsafe {
+                            // SAFETY: Same rationale as earlier in this function.
+                            world_cell.world_mut()
+                        }),
+                    )*);
+
+                    let mut errors = Vec::new();
+                    let access = ($(
+                        match $A::get_mut($a, req, &mut $c) {
+                            Ok(access) => Some(access),
+                            Err(err) => {
+                                errors.push(err.into());
+                                None
+                            }
+                        },
+                    )*);
+
+                    let ($(Some($d),)*) = access else {
+                        return Err(AccessError::Multiple(errors));
+                    };
+
+                    f(($($d,)*))
+                };
+
+                Ok(r)
+            }
+        }
+    }
+}
+
+// Implements the Accessor trait for all tuples of AccessKeys between size 1 and 12 (inclusive).
+all_tuples!(impl_accessor_for_tuple, 1, 12, A, a, b, c, d);
 
 #[cfg(test)]
 mod tests {
@@ -831,6 +1024,38 @@ mod tests {
         world: &mut World,
     ) {
         world.distribute_to_buffers(value, id, &keys).unwrap();
+    }
+
+    #[test]
+    fn test_access_tuple_join() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let buffers = (
+                builder.create_buffer(Default::default()),
+                builder.create_buffer(Default::default()),
+                builder.create_buffer(Default::default()),
+            );
+
+            builder
+                .chain(scope.start)
+                .with_access(buffers.clone())
+                .then(distribute_to_buffers.into_callback())
+                .with_access(buffers)
+                .then(join_from_buffers.into_callback())
+                .connect(scope.terminate);
+        });
+
+        let values = (
+            2.0,
+            vec![0, 1, 2, 3, 4],
+            String::from("hello"),
+        );
+
+        let resolved_values = context.resolve_request(values.clone(), workflow);
+        assert_eq!(resolved_values.0, values.0);
+        assert_eq!(resolved_values.1, values.1);
+        assert_eq!(resolved_values.2, values.2);
     }
 
     #[cfg(feature = "diagram")]

--- a/src/buffer/accessor.rs
+++ b/src/buffer/accessor.rs
@@ -1046,11 +1046,7 @@ mod tests {
                 .connect(scope.terminate);
         });
 
-        let values = (
-            2.0,
-            vec![0, 1, 2, 3, 4],
-            String::from("hello"),
-        );
+        let values = (2.0, vec![0, 1, 2, 3, 4], String::from("hello"));
 
         let resolved_values = context.resolve_request(values.clone(), workflow);
         assert_eq!(resolved_values.0, values.0);

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -569,8 +569,8 @@ impl<T: BufferMapStruct> Buffering for T {
 /// By default each field of the generated buffers struct will have a type of
 /// [`Buffer<T>`], but you can override this using `#[joined(buffer = ...)]`
 /// to specify a special buffer type. For example if your `Joined` struct
-/// contains an [`AnyMessageBox`] then by default the macro will use `Buffer<AnyMessageBox>`,
-/// but you probably really want it to have an [`AnyBuffer`]:
+/// contains an [`AnyMessageBox`][3] then by default the macro will use
+/// `Buffer<AnyMessageBox>`, but you probably really want it to have an [`AnyBuffer`]:
 ///
 /// ```
 /// # use crossflow::prelude::*;
@@ -588,6 +588,7 @@ impl<T: BufferMapStruct> Buffering for T {
 ///
 /// [1]: crate::Builder::join
 /// [2]: crate::Builder::try_join
+/// [3]: crate::AnyMessageBox
 pub trait Joined: 'static + Send + Sync + Sized {
     /// This associated type must represent a buffer map layout that implements
     /// the [`Joining`] trait. The message type yielded by [`Joining`] for this

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -34,6 +34,8 @@ use crate::{
     RequestId, TypeInfo, add_listener_to_source,
 };
 
+use variadics_please::all_tuples;
+
 #[cfg(feature = "diagram")]
 use crate::MessageRegistry;
 
@@ -846,6 +848,61 @@ impl<B: 'static + Send + Sync + AsAnyBuffer + Clone, const N: usize> BufferMapLa
         Vec::<B>::get_layout_hints()
     }
 }
+
+macro_rules! impl_buffer_map_layout_for_tuple {
+    ($(($B:ident, $b:ident)),*) => {
+        #[allow(non_snake_case)]
+        impl<$($B: 'static + Send + Sync + AsAnyBuffer + Clone),*> BufferMapLayout for ($($B,)*) {
+            fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
+                let mut compatibility = IncompatibleLayout::default();
+                let mut _index = 0;
+                let downcast_buffers = ($(
+                    {
+                        let buffer = match compatibility.require_buffer_for_identifier::<$B>(_index, buffers) {
+                            Ok(downcast) => Some(downcast),
+                            Err(_) => None,
+                        };
+                        _index += 1;
+                        buffer
+                    },
+                )*);
+
+                let ($(Some($b),)*) = downcast_buffers else {
+                    return Err(compatibility);
+                };
+
+                Ok(($($b,)*))
+            }
+
+            fn get_buffer_message_type_hints(
+                identifiers: HashSet<IdentifierRef<'static>>,
+            ) -> Result<MessageTypeHintMap, IncompatibleLayout> {
+                let mut evaluation = MessageTypeHintEvaluation::new(identifiers);
+                $(
+                    if let Some(identifier) = evaluation.next_index_required() {
+                        evaluation.set_hint(identifier, $B::message_type_hint());
+                    }
+                )*
+
+                evaluation.evaluate()
+            }
+
+            fn get_layout_hints() -> BufferMapLayoutHints {
+                let mut hints = MessageTypeHintMap::new();
+                let mut _index = 0;
+                $(
+                    hints.insert(_index.into(), $B::message_type_hint());
+                    _index += 1;
+                )*
+
+                BufferMapLayoutHints::Static(hints)
+            }
+        }
+    }
+}
+
+// Implements the BufferMapLayout trait for all tuples of buffers between size 1 and 12 (inclusive).
+all_tuples!(impl_buffer_map_layout_for_tuple, 1, 12, B, b);
 
 #[cfg(test)]
 mod tests {

--- a/src/buffer/buffer_map.rs
+++ b/src/buffer/buffer_map.rs
@@ -28,10 +28,10 @@ use smallvec::SmallVec;
 use bevy_ecs::prelude::{Entity, World};
 
 use crate::{
-    Accessing, AnyBuffer, AnyBufferKey, AnyMessageBox, AsAnyBuffer, Buffer, BufferKeyBuilder,
-    BufferKeyLifecycle, Bufferable, Buffering, Builder, Chain, CloneFromBuffer, FetchFromBuffer,
-    Gate, GateState, IdentifierRef, Joining, OperationError, OperationResult, OperationRoster,
-    RequestId, TypeInfo, add_listener_to_source,
+    Accessing, AddOperation, AnyBuffer, AsAnyBuffer, Buffer, BufferKeyBuilder, Bufferable,
+    Buffering, Builder, Chain, CloneFromBuffer, FetchFromBuffer, Gate, GateState, Identifiable,
+    IdentifierRef, Join, Joining, OperationError, OperationResult, OperationRoster, Output,
+    RequestId, TypeInfo, UnusedTarget, add_listener_to_source,
 };
 
 use variadics_please::all_tuples;
@@ -592,7 +592,10 @@ pub trait Joined: 'static + Send + Sync + Sized {
     /// This associated type must represent a buffer map layout that implements
     /// the [`Joining`] trait. The message type yielded by [`Joining`] for this
     /// associated type must match the [`Joined`] type.
-    type Buffers: 'static + BufferMapLayout + Joining<Item = Self> + Send + Sync;
+    type Buffers: 'static + BufferMapLayout + Joining + Send + Sync;
+
+    /// This converts from the buffer Joining::Item type into the Joined type
+    fn from_item(item: <Self::Buffers as Joining>::Item) -> Self;
 
     /// Used by [`Builder::try_join`]
     fn try_join_from<'w, 's, 'a, 'b>(
@@ -600,46 +603,26 @@ pub trait Joined: 'static + Send + Sync + Sized {
         builder: &'b mut Builder<'w, 's, 'a>,
     ) -> Result<Chain<'w, 's, 'a, 'b, Self>, IncompatibleLayout> {
         let buffers: Self::Buffers = Self::Buffers::try_from_buffer_map(buffers)?;
-        Ok(buffers.join(builder))
+        let scope = builder.scope();
+        buffers.verify_scope(scope);
+
+        let join = builder.commands.spawn(()).id();
+        let target = builder.commands.spawn(UnusedTarget).id();
+        builder.commands.queue(AddOperation::new(
+            Some(scope),
+            join,
+            Join::<_, Self>::for_joined(buffers, target),
+        ));
+
+        Ok(Output::new(scope, target).chain(builder))
     }
 }
 
-impl BufferMapLayout for BufferMap {
-    fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
-        Ok(buffers.clone())
-    }
-
-    fn get_buffer_message_type_hints(
-        identifiers: HashSet<IdentifierRef<'static>>,
-    ) -> Result<MessageTypeHintMap, IncompatibleLayout> {
-        // We have no information available at compile time about what the right
-        // identifiers are or what the messages types should be. BufferMap can
-        // support anything.
-        let mut evaluation = MessageTypeHintEvaluation::new(identifiers);
-        while let Some(identifier) = evaluation.next_unevaluated() {
-            evaluation.fallback::<AnyMessageBox>(identifier);
-        }
-
-        evaluation.evaluate()
-    }
-
-    fn get_layout_hints() -> BufferMapLayoutHints {
-        BufferMapLayoutHints::Dynamic(DynamicBufferMapLayoutHints {
-            indices: true,
-            names: true,
-            hint: None,
-        })
-    }
-}
-
-impl BufferMapStruct for BufferMap {
-    fn buffer_list(&self) -> SmallVec<[AnyBuffer; 8]> {
-        self.values().cloned().collect()
-    }
-}
-
-impl Joining for BufferMap {
-    type Item = HashMap<IdentifierRef<'static>, AnyMessageBox>;
+impl<K, B: Joining + AsAnyBuffer> Joining for HashMap<K, B>
+where
+    K: 'static + Send + Sync + Clone + Eq + Hash,
+{
+    type Item = HashMap<K, B::Item>;
 
     fn fetch_for_join(
         &self,
@@ -648,29 +631,35 @@ impl Joining for BufferMap {
         world: &mut World,
     ) -> Result<Self::Item, OperationError> {
         let mut value = HashMap::new();
-        for (name, buffer) in self.iter() {
-            value.insert(name.clone(), buffer.fetch_for_join(req, session, world)?);
+        for (key, buffer) in self.iter() {
+            value.insert(key.clone(), buffer.fetch_for_join(req, session, world)?);
         }
 
         Ok(value)
     }
 }
 
-impl Joined for HashMap<IdentifierRef<'static>, AnyMessageBox> {
-    type Buffers = BufferMap;
+impl<K, T> Joined for HashMap<K, T>
+where
+    K: 'static + Send + Sync + Clone + Eq + Hash + Identifiable,
+    T: 'static + Send + Sync,
+{
+    type Buffers = HashMap<K, Buffer<T>>;
+    fn from_item(item: <Self::Buffers as Joining>::Item) -> Self {
+        item
+    }
 }
 
-impl Accessing for BufferMap {
-    type Key = HashMap<IdentifierRef<'static>, AnyBufferKey>;
+impl<K, B: Accessing + AsAnyBuffer> Accessing for HashMap<K, B>
+where
+    K: 'static + Send + Sync + Clone + Eq + Hash,
+{
+    type Key = HashMap<K, B::Key>;
 
     fn create_key(&self, builder: &mut BufferKeyBuilder) -> OperationResult<Self::Key> {
         let mut keys = HashMap::new();
-        for (name, buffer) in self.iter() {
-            let key = AnyBufferKey {
-                body: builder.make_body(buffer.id())?,
-                interface: buffer.interface,
-            };
-            keys.insert(name.clone(), key);
+        for (key, buffer) in self {
+            keys.insert(key.clone(), buffer.create_key(builder)?);
         }
         Ok(keys)
     }
@@ -685,14 +674,14 @@ impl Accessing for BufferMap {
     fn deep_clone_key(key: &Self::Key) -> Self::Key {
         let mut cloned_key = HashMap::new();
         for (name, key) in key.iter() {
-            cloned_key.insert(name.clone(), key.deep_clone());
+            cloned_key.insert(name.clone(), B::deep_clone_key(key));
         }
         cloned_key
     }
 
     fn is_key_in_use(key: &Self::Key) -> bool {
         for k in key.values() {
-            if k.is_in_use() {
+            if B::is_key_in_use(k) {
                 return true;
             }
         }
@@ -701,8 +690,21 @@ impl Accessing for BufferMap {
     }
 }
 
+impl<K, B: AsAnyBuffer> BufferMapStruct for HashMap<K, B>
+where
+    K: 'static + Send + Sync + Clone,
+    B: 'static + Send + Sync + Clone,
+{
+    fn buffer_list(&self) -> SmallVec<[AnyBuffer; 8]> {
+        self.values().map(B::as_any_buffer).collect()
+    }
+}
+
 impl<T: 'static + Send + Sync> Joined for Vec<T> {
     type Buffers = Vec<Buffer<T>>;
+    fn from_item(item: <Self::Buffers as Joining>::Item) -> Self {
+        item
+    }
 }
 
 impl<T: 'static + Send + Sync> BufferMapLayout for Buffer<T> {
@@ -818,8 +820,63 @@ impl<B: 'static + Send + Sync + AsAnyBuffer + Clone> BufferMapLayout for Vec<B> 
     }
 }
 
+impl<K, B> BufferMapLayout for HashMap<K, B>
+where
+    K: 'static + Send + Sync + PartialEq + Eq + Hash + Identifiable + Clone,
+    B: 'static + Send + Sync + AsAnyBuffer + Clone,
+{
+    fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
+        let mut downcast_buffers = HashMap::new();
+        let mut compatibility = IncompatibleLayout::default();
+        for identifier in buffers.keys() {
+            let Some(key) = K::try_from_id(identifier) else {
+                compatibility.forbidden_buffers.push(identifier.clone());
+                continue;
+            };
+
+            if let Ok(downcast) =
+                compatibility.require_buffer_for_identifier::<B>(identifier.clone(), buffers)
+            {
+                downcast_buffers.insert(key, downcast);
+            }
+        }
+
+        compatibility.as_result()?;
+        Ok(downcast_buffers)
+    }
+
+    fn get_buffer_message_type_hints(
+        identifiers: HashSet<IdentifierRef<'static>>,
+    ) -> Result<MessageTypeHintMap, IncompatibleLayout> {
+        let mut compatibility = IncompatibleLayout::default();
+        let mut hints = HashMap::new();
+        for identifier in identifiers.iter() {
+            let Some(_) = K::try_from_id(identifier) else {
+                compatibility.forbidden_buffers.push(identifier.clone());
+                continue;
+            };
+
+            hints.insert(identifier.clone(), B::message_type_hint());
+        }
+
+        compatibility.as_result()?;
+        Ok(hints)
+    }
+
+    fn get_layout_hints() -> BufferMapLayoutHints {
+        BufferMapLayoutHints::Dynamic(DynamicBufferMapLayoutHints {
+            indices: K::indexable(),
+            names: K::nameable(),
+            hint: Some(B::message_type_hint()),
+        })
+    }
+}
+
 impl<T: 'static + Send + Sync, const N: usize> Joined for SmallVec<[T; N]> {
     type Buffers = SmallVec<[Buffer<T>; N]>;
+    fn from_item(item: <Self::Buffers as Joining>::Item) -> Self {
+        item
+    }
 }
 
 impl<B: 'static + Send + Sync + AsAnyBuffer + Clone, const N: usize> BufferMapLayout

--- a/src/buffer/bufferable.rs
+++ b/src/buffer/bufferable.rs
@@ -189,7 +189,7 @@ pub trait IterBufferable {
         builder.commands.queue(AddOperation::new(
             Some(builder.scope()),
             join,
-            Join::new(buffers, target),
+            Join::<_, SmallVec<[<Self::BufferElement as Joining>::Item; N]>>::new(buffers, target),
         ));
 
         Output::new(builder.scope(), target).chain(builder)

--- a/src/buffer/json_buffer.rs
+++ b/src/buffer/json_buffer.rs
@@ -40,12 +40,11 @@ use crate::{
     AnyRange, AsAnyBuffer, BMut, BMutTracer, Buffer, BufferAccessMut, BufferAccessors, BufferEntry,
     BufferError, BufferInstanceId, BufferKey, BufferKeyBody, BufferKeyBuilder, BufferKeyLifecycle,
     BufferKeyTag, BufferLocation, BufferManager, BufferMap, BufferMapLayout, BufferMapLayoutHints,
-    BufferMapStruct, BufferStorage, BufferView, BufferWorldAccess, Bufferable, Buffering, Builder,
-    CloneFromBuffer, DrainBuffer, DynamicBufferMapLayoutHints, FetchBehavior, Gate, GateState,
-    IdentifierRef, IncompatibleLayout, InspectBufferSessions, Joined, Joining,
-    ManageBufferSessions, MessageTypeHint, MessageTypeHintEvaluation, MessageTypeHintMap,
-    NotifyBufferUpdate, OperationError, OperationResult, OrBroken, OverlapError, RequestId, Seq,
-    TypeInfo, add_listener_to_source,
+    BufferStorage, BufferView, BufferWorldAccess, Bufferable, Buffering, Builder, CloneFromBuffer,
+    DrainBuffer, FetchBehavior, Gate, GateState, IdentifierRef, IncompatibleLayout,
+    InspectBufferSessions, Joined, Joining, ManageBufferSessions, MessageTypeHint,
+    MessageTypeHintEvaluation, NotifyBufferUpdate, OperationError, OperationResult, OrBroken,
+    OverlapError, RequestId, Seq, TypeInfo, add_listener_to_source,
 };
 
 #[cfg(feature = "trace")]
@@ -1413,174 +1412,51 @@ impl BufferMapLayout for JsonBuffer {
 
 impl Joined for serde_json::Map<String, JsonMessage> {
     type Buffers = HashMap<String, JsonBuffer>;
-}
-
-impl BufferMapLayout for HashMap<String, JsonBuffer> {
-    fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
-        let mut downcast_buffers = HashMap::new();
-        let mut compatibility = IncompatibleLayout::default();
-        for identifier in buffers.keys() {
-            match identifier {
-                IdentifierRef::Name(name) => {
-                    if let Ok(downcast) =
-                        compatibility.require_buffer_for_borrowed_name::<JsonBuffer>(&name, buffers)
-                    {
-                        downcast_buffers.insert(name.clone().into_owned(), downcast);
-                    }
-                }
-                IdentifierRef::Index(index) => {
-                    compatibility
-                        .forbidden_buffers
-                        .push(IdentifierRef::Index(*index));
-                }
-            }
-        }
-
-        compatibility.as_result()?;
-        Ok(downcast_buffers)
-    }
-
-    fn get_buffer_message_type_hints(
-        identifiers: HashSet<IdentifierRef<'static>>,
-    ) -> Result<MessageTypeHintMap, IncompatibleLayout> {
-        let mut evaluation = MessageTypeHintEvaluation::new(identifiers);
-        while let Some(identifier) = evaluation.next_name_required() {
-            evaluation.fallback::<JsonMessage>(identifier);
-        }
-        evaluation.evaluate()
-    }
-
-    fn get_layout_hints() -> BufferMapLayoutHints {
-        BufferMapLayoutHints::Dynamic(DynamicBufferMapLayoutHints {
-            indices: false,
-            names: true,
-            hint: Some(MessageTypeHint::Fallback(TypeInfo::of::<JsonMessage>())),
-        })
-    }
-}
-
-impl BufferMapStruct for HashMap<String, JsonBuffer> {
-    fn buffer_list(&self) -> SmallVec<[AnyBuffer; 8]> {
-        self.values().map(|b| b.as_any_buffer()).collect()
-    }
-}
-
-impl Joining for HashMap<String, JsonBuffer> {
-    type Item = serde_json::Map<String, JsonMessage>;
-    fn fetch_for_join(
-        &self,
-        req: RequestId,
-        session: Entity,
-        world: &mut World,
-    ) -> Result<Self::Item, OperationError> {
-        self.iter()
-            .map(|(key, value)| {
-                value
-                    .fetch_for_join(req, session, world)
-                    .map(|v| (key.clone(), v))
-            })
-            .collect()
+    fn from_item(mut item: <Self::Buffers as Joining>::Item) -> Self {
+        serde_json::Map::from_iter(item.drain())
     }
 }
 
 impl Joined for JsonMessage {
     type Buffers = HashMap<IdentifierRef<'static>, JsonBuffer>;
-}
-
-impl BufferMapLayout for HashMap<IdentifierRef<'static>, JsonBuffer> {
-    fn try_from_buffer_map(buffers: &BufferMap) -> Result<Self, IncompatibleLayout> {
-        let mut downcast_buffers = HashMap::new();
-        let mut compatibility = IncompatibleLayout::default();
-        for identifier in buffers.keys() {
-            if let Ok(downcast) = compatibility
-                .require_buffer_for_identifier::<JsonBuffer>(identifier.clone(), buffers)
-            {
-                downcast_buffers.insert(identifier.clone(), downcast);
-            }
-        }
-
-        compatibility.as_result()?;
-        Ok(downcast_buffers)
-    }
-
-    fn get_buffer_message_type_hints(
-        identifiers: HashSet<IdentifierRef<'static>>,
-    ) -> Result<MessageTypeHintMap, IncompatibleLayout> {
-        let mut evaluation = MessageTypeHintEvaluation::new(identifiers);
-        while let Some(identifier) = evaluation.next_unevaluated() {
-            evaluation.fallback::<JsonMessage>(identifier);
-        }
-        evaluation.evaluate()
-    }
-
-    fn get_layout_hints() -> BufferMapLayoutHints {
-        BufferMapLayoutHints::Dynamic(DynamicBufferMapLayoutHints {
-            indices: true,
-            names: true,
-            hint: Some(MessageTypeHint::Fallback(TypeInfo::of::<JsonMessage>())),
-        })
-    }
-}
-
-impl BufferMapStruct for HashMap<IdentifierRef<'static>, JsonBuffer> {
-    fn buffer_list(&self) -> SmallVec<[AnyBuffer; 8]> {
-        self.values().map(|b| b.as_any_buffer()).collect()
-    }
-}
-
-impl Joining for HashMap<IdentifierRef<'static>, JsonBuffer> {
-    type Item = JsonMessage;
-    fn fetch_for_join(
-        &self,
-        req: RequestId,
-        session: Entity,
-        world: &mut World,
-    ) -> Result<Self::Item, OperationError> {
+    fn from_item(item: <Self::Buffers as Joining>::Item) -> Self {
         let mut object = serde_json::Map::<String, JsonMessage>::new();
         let mut array = Vec::<JsonMessage>::new();
-
-        for (identifier, buffer) in self.iter() {
+        for (identifier, element) in item {
             match identifier {
                 IdentifierRef::Index(index) => {
-                    if *index >= array.len() {
+                    if index >= array.len() {
                         // Ensure we have enough items in the array to reach the
                         // specified index.
-                        array.resize(*index + 1, JsonMessage::Null);
+                        array.resize(index + 1, JsonMessage::Null);
                     }
 
-                    array[*index] = buffer.fetch_for_join(req, session, world)?;
+                    array[index] = element;
                 }
                 IdentifierRef::Name(name) => {
-                    object.insert(
-                        name.as_ref().to_owned(),
-                        buffer.fetch_for_join(req, session, world)?,
-                    );
+                    object.insert(name.as_ref().to_owned(), element);
                 }
             }
         }
 
-        let value = if !object.is_empty() && !array.is_empty() {
-            // There are keyed buffers as well as arrayed buffers, so we need to
+        if !object.is_empty() && !array.is_empty() {
+            // There are named items as well as indexed items, so we need to
             // organize them into two different fields in a json object.
             JsonMessage::Object(serde_json::Map::from_iter([
                 ("array".to_owned(), JsonMessage::Array(array)),
                 ("object".to_owned(), JsonMessage::Object(object)),
             ]))
         } else if !object.is_empty() {
-            // There are only object entries, so we will join them into a
-            // top-level object.
+            // There are only named items, so we will join them into an object
             JsonMessage::Object(object)
         } else if !array.is_empty() {
-            // There are only array entries, so we will join them into a
-            // top-level array.
+            // There are only indexed items, so we will join them into an array
             JsonMessage::Array(array)
         } else {
-            // There are no entries at all. This shouldn't happen, but we will
+            // There are no items at all. This shouldn't happen, but we will
             // handle it by returning a null value.
             JsonMessage::Null
-        };
-
-        Ok(value)
+        }
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -443,7 +443,10 @@ fn wait_for<A: Accessor, U: 'static + Send>(
 mod tests {
     use crate::{prelude::*, testing::*};
     use bevy_ecs::system::EntityCommands;
-    use std::time::Duration;
+    use std::{
+        collections::HashMap,
+        time::Duration
+    };
 
     #[test]
     fn test_channel_request() {
@@ -698,6 +701,93 @@ mod tests {
         assert_eq!(result.0, 0);
         assert_eq!(result.1, vec![0, 1, 2, 3, 4, 5]);
         assert_eq!(result.2, values.2);
+    }
+
+    #[test]
+    fn test_hashmap_wait_for_access() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let mut buffers = HashMap::new();
+            buffers.insert(
+                String::from("alice"),
+                builder.create_buffer(Default::default()),
+            );
+            buffers.insert(
+                String::from("bob"),
+                builder.create_buffer(Default::default()),
+            );
+            buffers.insert(
+                String::from("chris"),
+                builder.create_buffer(Default::default()),
+            );
+
+            let (values, trigger) = builder
+                .chain(scope.start)
+                .map_block(|value| (value, ()))
+                .unzip();
+
+            builder
+                .chain(trigger)
+                .with_access(buffers.clone())
+                .map(|Async { request: (_, keys), channel, id, .. }: Async<((), HashMap<String, BufferKey<i32>>)>| {
+                        async move {
+                            channel
+                                .wait_for(keys.clone(), move |world| {
+                                    world
+                                        .buffers_mut(id, &keys, |mut buffers| {
+                                            let [alice, bob, chris] = buffers.get_disjoint_mut(["alice", "bob", "chris"]);
+                                            let mut alice = alice?.oldest_mut()?;
+                                            let mut bob = bob?.oldest_mut()?;
+                                            let chris = chris?.oldest_mut()?;
+                                            *alice = *alice - *bob;
+                                            *bob = *bob - *chris;
+
+                                            Some(())
+                                        })
+                                        .unwrap()
+                                })
+                                .await;
+                        }
+                    },
+                )
+                .with_access(buffers.clone())
+                .then(async_join_values.into_callback())
+                .connect(scope.terminate);
+
+            builder
+                .chain(values)
+                .with_access(buffers)
+                .then(async_distribute_values.into_callback())
+                .unused();
+        });
+
+        let mut values = HashMap::new();
+        values.insert(
+            String::from("alice"),
+            42,
+        );
+        values.insert(
+            String::from("bob"),
+            67,
+        );
+        values.insert(
+            String::from("chris"),
+            88,
+        );
+
+        let resolved = context.resolve_request(values.clone(), workflow);
+
+        // Manipulate the values in the same way they should have been manipulated by the accessor
+        let [alice, bob, chris] = values.get_disjoint_mut(["alice", "bob", "chris"]);
+        let alice = alice.unwrap();
+        let bob = bob.unwrap();
+        let chris = chris.unwrap();
+        *alice = *alice - *bob;
+        *bob = *bob - *chris;
+
+        // Now check that the resolved values are what they are supposed to be
+        assert_eq!(resolved, values);
     }
 
     async fn async_distribute_values<A: Accessor>(

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -443,10 +443,7 @@ fn wait_for<A: Accessor, U: 'static + Send>(
 mod tests {
     use crate::{prelude::*, testing::*};
     use bevy_ecs::system::EntityCommands;
-    use std::{
-        collections::HashMap,
-        time::Duration
-    };
+    use std::{collections::HashMap, time::Duration};
 
     #[test]
     fn test_channel_request() {
@@ -730,13 +727,20 @@ mod tests {
             builder
                 .chain(trigger)
                 .with_access(buffers.clone())
-                .map(|Async { request: (_, keys), channel, id, .. }: Async<((), HashMap<String, BufferKey<i32>>)>| {
+                .map(
+                    |Async {
+                         request: (_, keys),
+                         channel,
+                         id,
+                         ..
+                     }: Async<((), HashMap<String, BufferKey<i32>>)>| {
                         async move {
                             channel
                                 .wait_for(keys.clone(), move |world| {
                                     world
                                         .buffers_mut(id, &keys, |mut buffers| {
-                                            let [alice, bob, chris] = buffers.get_disjoint_mut(["alice", "bob", "chris"]);
+                                            let [alice, bob, chris] =
+                                                buffers.get_disjoint_mut(["alice", "bob", "chris"]);
                                             let mut alice = alice?.oldest_mut()?;
                                             let mut bob = bob?.oldest_mut()?;
                                             let chris = chris?.oldest_mut()?;
@@ -763,18 +767,9 @@ mod tests {
         });
 
         let mut values = HashMap::new();
-        values.insert(
-            String::from("alice"),
-            42,
-        );
-        values.insert(
-            String::from("bob"),
-            67,
-        );
-        values.insert(
-            String::from("chris"),
-            88,
-        );
+        values.insert(String::from("alice"), 42);
+        values.insert(String::from("bob"), 67);
+        values.insert(String::from("chris"), 88);
 
         let resolved = context.resolve_request(values.clone(), workflow);
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -638,11 +638,7 @@ mod tests {
                 builder.create_buffer(Default::default()),
                 builder.create_buffer(Default::default()),
             );
-            type Keys = (
-                BufferKey<i32>,
-                BufferKey<Vec<i32>>,
-                BufferKey<String>,
-            );
+            type Keys = (BufferKey<i32>, BufferKey<Vec<i32>>, BufferKey<String>);
 
             let (values, trigger) = builder
                 .chain(scope.start)
@@ -652,32 +648,39 @@ mod tests {
             builder
                 .chain(trigger)
                 .with_access(buffers)
-                .map(|Async { request: (_, keys), channel, id, .. }: Async<((), Keys)>| {
-                    async move {
-                        channel.wait_for(
-                            keys.clone(),
-                            move |world| {
-                                world.buffers_mut(id, &keys, |mut buffers| {
-                                    let value = buffers.0.pull()?;
-                                    // Note: Using the ? above means that this function will
-                                    // return None until it manages to pull a value from the
-                                    // first buffer.
+                .map(
+                    |Async {
+                         request: (_, keys),
+                         channel,
+                         id,
+                         ..
+                     }: Async<((), Keys)>| {
+                        async move {
+                            channel
+                                .wait_for(keys.clone(), move |world| {
+                                    world
+                                        .buffers_mut(id, &keys, |mut buffers| {
+                                            let value = buffers.0.pull()?;
+                                            // Note: Using the ? above means that this function will
+                                            // return None until it manages to pull a value from the
+                                            // first buffer.
 
-                                    let mut values = buffers.1.oldest_mut().unwrap();
-                                    values.push(value);
+                                            let mut values = buffers.1.oldest_mut().unwrap();
+                                            values.push(value);
 
-                                    // Put a value back into the first buffer so we
-                                    // can join all the buffers again later.
-                                    buffers.0.push(*values.first().unwrap());
+                                            // Put a value back into the first buffer so we
+                                            // can join all the buffers again later.
+                                            buffers.0.push(*values.first().unwrap());
 
-                                    // Return Some to end this wait_for
-                                    Some(())
-                                }).unwrap()
-                            },
-                        )
-                        .await;
-                    }
-                })
+                                            // Return Some to end this wait_for
+                                            Some(())
+                                        })
+                                        .unwrap()
+                                })
+                                .await;
+                        }
+                    },
+                )
                 .with_access(buffers)
                 .then(async_join_values.into_callback())
                 .connect(scope.terminate);
@@ -689,11 +692,7 @@ mod tests {
                 .unused();
         });
 
-        let values = (
-            5,
-            vec![0, 1, 2, 3, 4],
-            String::from("hello"),
-        );
+        let values = (5, vec![0, 1, 2, 3, 4], String::from("hello"));
 
         let result = context.resolve_request(values.clone(), workflow);
         assert_eq!(result.0, 0);

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -561,7 +561,7 @@ mod tests {
     }
 
     #[test]
-    fn test_wait_for_access() {
+    fn test_struct_wait_for_access() {
         let mut context = TestingContext::minimal_plugins();
 
         let workflow = context.spawn_io_workflow(|scope, builder| {
@@ -628,29 +628,102 @@ mod tests {
         assert!(result > 4);
     }
 
-    async fn async_distribute_values(
+    #[test]
+    fn test_tuple_wait_for_access() {
+        let mut context = TestingContext::minimal_plugins();
+
+        let workflow = context.spawn_io_workflow(|scope, builder| {
+            let buffers: (Buffer<i32>, Buffer<Vec<i32>>, Buffer<String>) = (
+                builder.create_buffer(Default::default()),
+                builder.create_buffer(Default::default()),
+                builder.create_buffer(Default::default()),
+            );
+            type Keys = (
+                BufferKey<i32>,
+                BufferKey<Vec<i32>>,
+                BufferKey<String>,
+            );
+
+            let (values, trigger) = builder
+                .chain(scope.start)
+                .map_block(|value| (value, ()))
+                .unzip();
+
+            builder
+                .chain(trigger)
+                .with_access(buffers)
+                .map(|Async { request: (_, keys), channel, id, .. }: Async<((), Keys)>| {
+                    async move {
+                        channel.wait_for(
+                            keys.clone(),
+                            move |world| {
+                                world.buffers_mut(id, &keys, |mut buffers| {
+                                    let value = buffers.0.pull()?;
+                                    // Note: Using the ? above means that this function will
+                                    // return None until it manages to pull a value from the
+                                    // first buffer.
+
+                                    let mut values = buffers.1.oldest_mut().unwrap();
+                                    values.push(value);
+
+                                    // Put a value back into the first buffer so we
+                                    // can join all the buffers again later.
+                                    buffers.0.push(*values.first().unwrap());
+
+                                    // Return Some to end this wait_for
+                                    Some(())
+                                }).unwrap()
+                            },
+                        )
+                        .await;
+                    }
+                })
+                .with_access(buffers)
+                .then(async_join_values.into_callback())
+                .connect(scope.terminate);
+
+            builder
+                .chain(values)
+                .with_access(buffers)
+                .then(async_distribute_values.into_callback())
+                .unused();
+        });
+
+        let values = (
+            5,
+            vec![0, 1, 2, 3, 4],
+            String::from("hello"),
+        );
+
+        let result = context.resolve_request(values.clone(), workflow);
+        assert_eq!(result.0, 0);
+        assert_eq!(result.1, vec![0, 1, 2, 3, 4, 5]);
+        assert_eq!(result.2, values.2);
+    }
+
+    async fn async_distribute_values<A: Accessor>(
         Async {
             request, channel, ..
-        }: Async<(TestJoined, TestKeys)>,
+        }: Async<(A::Joined, A)>,
     ) {
         let (values, keys) = request;
         channel.distribute(keys, values).await.unwrap();
     }
 
-    async fn async_join_values(
+    async fn async_join_values<A: Accessor>(
         Async {
             request, channel, ..
-        }: Async<((), TestKeys)>,
-    ) -> TestJoined {
+        }: Async<((), A)>,
+    ) -> A::Joined {
         let (_, keys) = request;
         channel.try_join(keys).await.unwrap().unwrap()
     }
 
-    async fn async_wait_for_join_values(
+    async fn async_wait_for_join_values<A: Accessor>(
         Async {
             request, channel, ..
-        }: Async<((), TestKeys)>,
-    ) -> TestJoined {
+        }: Async<((), A)>,
+    ) -> A::Joined {
         let (_, keys) = request;
         channel.wait_for_join(keys).await.unwrap()
     }

--- a/src/identifier.rs
+++ b/src/identifier.rs
@@ -179,6 +179,20 @@ impl<'a> IdentifierRef<'a> {
         matches!(self, Self::Index(_))
     }
 
+    pub fn index(&self) -> Option<usize> {
+        match self {
+            Self::Index(index) => Some(*index),
+            _ => None,
+        }
+    }
+
+    pub fn name(&self) -> Option<&'_ str> {
+        match self {
+            Self::Name(name) => Some(name.as_ref()),
+            _ => None,
+        }
+    }
+
     pub fn to_owned(&self) -> IdentifierRef<'static> {
         match self {
             Self::Index(index) => IdentifierRef::Index(*index),
@@ -211,7 +225,7 @@ impl IdentifierRef<'static> {
     }
 
     /// Use an index as an identifier.
-    pub fn index(index: usize) -> Self {
+    pub fn from_index(index: usize) -> Self {
         IdentifierRef::Index(index)
     }
 }
@@ -274,6 +288,73 @@ impl<'a> PartialEq<Identifier> for IdentifierRef<'a> {
 }
 
 pub type OutputPort<'a> = &'a [IdentifierRef<'a>];
+
+pub trait Identifiable {
+    fn try_from_id(id: &IdentifierRef<'static>) -> Option<Self>
+    where
+        Self: Sized;
+    fn indexable() -> bool;
+    fn nameable() -> bool;
+}
+
+impl<'a> Identifiable for IdentifierRef<'a> {
+    fn try_from_id(id: &IdentifierRef<'static>) -> Option<Self> {
+        Some(id.clone())
+    }
+
+    fn indexable() -> bool {
+        true
+    }
+
+    fn nameable() -> bool {
+        true
+    }
+}
+
+impl Identifiable for Identifier {
+    fn try_from_id(id: &IdentifierRef<'static>) -> Option<Self> {
+        Some(id.clone().into())
+    }
+
+    fn indexable() -> bool {
+        true
+    }
+
+    fn nameable() -> bool {
+        true
+    }
+}
+
+impl Identifiable for usize {
+    fn try_from_id(id: &IdentifierRef<'static>) -> Option<Self> {
+        id.index()
+    }
+
+    fn indexable() -> bool {
+        true
+    }
+
+    fn nameable() -> bool {
+        false
+    }
+}
+
+impl Identifiable for String {
+    fn try_from_id(id: &IdentifierRef<'static>) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        id.name().map(ToString::to_string)
+    }
+
+    fn indexable() -> bool {
+        false
+    }
+
+    fn nameable() -> bool {
+        true
+    }
+}
 
 /// The output_port module provides utility functions for easily creating
 /// [`OutputPort`] instances that avoid any memory allocations.

--- a/src/operation/join.rs
+++ b/src/operation/join.rs
@@ -18,28 +18,59 @@
 use bevy_ecs::prelude::{Component, Entity};
 
 use crate::{
-    FunnelInputStorage, Input, InputBundle, Joining, ManageInput, Operation, OperationCleanup,
-    OperationReachability, OperationRequest, OperationResult, OperationSetup, OrBroken,
-    ReachabilityResult, RequestId, SingleInputStorage, SingleTargetStorage, output_port,
+    FunnelInputStorage, Input, InputBundle, Joined, Joining, ManageInput, Operation,
+    OperationCleanup, OperationReachability, OperationRequest, OperationResult, OperationSetup,
+    OrBroken, ReachabilityResult, RequestId, SingleInputStorage, SingleTargetStorage, output_port,
 };
 
-pub(crate) struct Join<Buffers> {
+pub(crate) struct Join<Buffers: Joining, Target = <Buffers as Joining>::Item> {
     buffers: Buffers,
     target: Entity,
+    from_item: fn(Buffers::Item) -> Target,
 }
 
-impl<Buffers> Join<Buffers> {
+impl<Buffers: Joining> Join<Buffers> {
     pub(crate) fn new(buffers: Buffers, target: Entity) -> Self {
-        Self { buffers, target }
+        Self {
+            buffers,
+            target,
+            from_item: |x| x,
+        }
+    }
+}
+
+impl<Buffers: Joining, Target> Join<Buffers, Target> {
+    pub(crate) fn for_joined(buffers: Buffers, target: Entity) -> Self
+    where
+        Target: Joined<Buffers = Buffers>,
+    {
+        Self {
+            buffers,
+            target,
+            from_item: Target::from_item,
+        }
     }
 }
 
 #[derive(Component)]
-struct BufferStorage<Buffers>(Buffers);
+struct JoinStorage<Buffers: Joining, Target> {
+    buffers: Buffers,
+    from_item: fn(Buffers::Item) -> Target,
+}
 
-impl<Buffers: Joining + 'static + Send + Sync> Operation for Join<Buffers>
+impl<Buffers: Joining, Target> Clone for JoinStorage<Buffers, Target> {
+    fn clone(&self) -> Self {
+        Self {
+            buffers: self.buffers.clone(),
+            from_item: self.from_item,
+        }
+    }
+}
+
+impl<Buffers: Joining + 'static + Send + Sync, Target> Operation for Join<Buffers, Target>
 where
     Buffers::Item: 'static + Send + Sync,
+    Target: 'static + Send + Sync,
 {
     fn setup(self, OperationSetup { source, world }: OperationSetup) -> OperationResult {
         world
@@ -51,7 +82,10 @@ where
 
         world.entity_mut(source).insert((
             FunnelInputStorage::from(self.buffers.as_input()),
-            BufferStorage(self.buffers),
+            JoinStorage {
+                buffers: self.buffers,
+                from_item: self.from_item,
+            },
             InputBundle::<()>::new(),
             SingleTargetStorage::new(self.target),
         ));
@@ -68,10 +102,9 @@ where
         let Input { session, seq, .. } = world.take_input::<()>(source)?;
         let source_ref = world.get_entity(source).or_broken()?;
         let target = source_ref.get::<SingleTargetStorage>().or_broken()?.get();
-        let buffers = source_ref
-            .get::<BufferStorage<Buffers>>()
+        let JoinStorage { buffers, from_item } = source_ref
+            .get::<JoinStorage<Buffers, Target>>()
             .or_broken()?
-            .0
             .clone();
 
         let req = RequestId {
@@ -85,7 +118,9 @@ where
                 return Ok(());
             }
 
-            let output = buffers.fetch_for_join(req, session, world)?;
+            let item = buffers.fetch_for_join(req, session, world)?;
+            let output = from_item(item);
+
             let route = req.to_message_route(&port, target);
             world.give_input(route, output, roster)?;
         }
@@ -97,10 +132,11 @@ where
     }
 
     fn is_reachable(mut r: OperationReachability) -> ReachabilityResult {
-        let buffers = r
+        let buffers = &r
             .world
-            .get::<BufferStorage<Buffers>>(r.source)
-            .or_broken()?;
+            .get::<JoinStorage<Buffers, Target>>(r.source)
+            .or_broken()?
+            .buffers;
 
         let inputs = r
             .world
@@ -112,7 +148,7 @@ where
             if !r.check_upstream(*input)? {
                 // This input buffer is no longer reachable, so if it is also
                 // empty then there will be no way to ever perform a join.
-                if buffers.0.buffered_count_for(*input, r.session, r.world)? == 0 {
+                if buffers.buffered_count_for(*input, r.session, r.world)? == 0 {
                     return Ok(false);
                 }
             }


### PR DESCRIPTION
This expands on #187 to now allow tuples and hash maps of buffer keys to be used as "Accessors", allowing even more flexible ways for buffers be accessed, both in sync and async contexts.

This PR also generalizes the `Joined` trait and makes it more flexible than it was previously.